### PR TITLE
Fix: Standardize Go module import paths

### DIFF
--- a/src/mcp/cmd/init.go
+++ b/src/mcp/cmd/init.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"quint-mcp/db"
+	"github.com/m0n0x41d/quint-code/db"
 
 	"github.com/spf13/cobra"
 )

--- a/src/mcp/cmd/serve.go
+++ b/src/mcp/cmd/serve.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"quint-mcp/db"
-	"quint-mcp/internal/fpf"
+	"github.com/m0n0x41d/quint-code/db"
+	"github.com/m0n0x41d/quint-code/internal/fpf"
 
 	"github.com/spf13/cobra"
 )

--- a/src/mcp/go.mod
+++ b/src/mcp/go.mod
@@ -1,4 +1,4 @@
-module quint-mcp
+module github.com/m0n0x41d/quint-code
 
 go 1.24.0
 

--- a/src/mcp/internal/fpf/actualize_test.go
+++ b/src/mcp/internal/fpf/actualize_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"quint-mcp/db"
-	"quint-mcp/internal/fpf"
+	"github.com/m0n0x41d/quint-code/db"
+	"github.com/m0n0x41d/quint-code/internal/fpf"
 )
 
 func TestActualize_GitReconciliation(t *testing.T) {

--- a/src/mcp/internal/fpf/assurance_integration_test.go
+++ b/src/mcp/internal/fpf/assurance_integration_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"quint-mcp/assurance"
-	"quint-mcp/db"
-	"quint-mcp/internal/fpf"
+	"github.com/m0n0x41d/quint-code/assurance"
+	"github.com/m0n0x41d/quint-code/db"
+	"github.com/m0n0x41d/quint-code/internal/fpf"
 )
 
 func setupAssuranceTestEnv(t *testing.T) (*fpf.FSM, *db.Store, string) {

--- a/src/mcp/internal/fpf/fsm.go
+++ b/src/mcp/internal/fpf/fsm.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"quint-mcp/assurance"
+	"github.com/m0n0x41d/quint-code/assurance"
 )
 
 // Phase definitions

--- a/src/mcp/internal/fpf/integration_test.go
+++ b/src/mcp/internal/fpf/integration_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"quint-mcp/db"
-	"quint-mcp/internal/fpf"
+	"github.com/m0n0x41d/quint-code/db"
+	"github.com/m0n0x41d/quint-code/internal/fpf"
 )
 
 // Helper to get FPF knowledge path for a level

--- a/src/mcp/internal/fpf/preconditions_test.go
+++ b/src/mcp/internal/fpf/preconditions_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"quint-mcp/db"
+	"github.com/m0n0x41d/quint-code/db"
 )
 
 func TestCheckPreconditions_Propose(t *testing.T) {

--- a/src/mcp/internal/fpf/projection.go
+++ b/src/mcp/internal/fpf/projection.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"quint-mcp/db"
+	"github.com/m0n0x41d/quint-code/db"
 )
 
 type TamperingEvent struct {

--- a/src/mcp/internal/fpf/projection_test.go
+++ b/src/mcp/internal/fpf/projection_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"quint-mcp/db"
+	"github.com/m0n0x41d/quint-code/db"
 )
 
 var ctx = context.Background()

--- a/src/mcp/internal/fpf/tools.go
+++ b/src/mcp/internal/fpf/tools.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"quint-mcp/assurance"
-	"quint-mcp/db"
+	"github.com/m0n0x41d/quint-code/assurance"
+	"github.com/m0n0x41d/quint-code/db"
 
 	"github.com/google/uuid"
 )

--- a/src/mcp/internal/fpf/tools_test.go
+++ b/src/mcp/internal/fpf/tools_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"quint-mcp/db"
+	"github.com/m0n0x41d/quint-code/db"
 )
 
 // Helper to create a dummy Tools instance for testing
@@ -611,9 +611,9 @@ func TestPropose_WithDependsOn(t *testing.T) {
 		"external traffic",
 		"system",
 		`{"anomaly": "need unified entry point"}`,
-		"",                                       // no decision_context
+		"",                                      // no decision_context
 		[]string{"auth-module", "rate-limiter"}, // depends_on
-		3,                                        // CL3
+		3,                                       // CL3
 	)
 	if err != nil {
 		t.Fatalf("ProposeHypothesis failed: %v", err)

--- a/src/mcp/main.go
+++ b/src/mcp/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "quint-mcp/cmd"
+import "github.com/m0n0x41d/quint-code/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This PR updates all import paths throughout the codebase to use the correct, fully-qualified module name github.com/m0n0x41d/quint-code instead of the local quint-mcp reference.

Changes:
- Updated go.mod module declaration from quint-mcp to github.com/m0n0x41d/quint-code
- Fixed all internal imports across 12 files to use the canonical module path