### PR TITLE
fix(mcp): redirect warnings to stderr to preserve MCP JSON integrity

### DIFF
--- a/src/mcp/internal/fpf/tools.go
+++ b/src/mcp/internal/fpf/tools.go
@@ -124,7 +124,7 @@ func (t *Tools) InitProject() error {
 		dbPath := filepath.Join(t.GetFPFDir(), "quint.db")
 		database, err := db.NewStore(dbPath)
 		if err != nil {
-			fmt.Printf("Warning: Failed to init DB: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to init DB: %v\n", err)
 		} else {
 			t.DB = database
 		}
@@ -605,7 +605,7 @@ func (t *Tools) FinalizeDecision(title, winnerID string, rejectedIDs []string, d
 	if winnerID != "" {
 		_, err := t.MoveHypothesis(winnerID, "L1", "L2")
 		if err != nil {
-			fmt.Printf("WARNING: Failed to move winner hypothesis %s to L2: %v\n", winnerID, err)
+			fmt.Fprintf(os.Stderr, "WARNING: Failed to move winner hypothesis %s to L2: %v\n", winnerID, err)
 		}
 	}
 
@@ -631,13 +631,13 @@ func (t *Tools) RunDecay() error {
 	for _, id := range ids {
 		_, err := calc.CalculateReliability(ctx, id)
 		if err != nil {
-			fmt.Printf("Error calculating R for %s: %v\n", id, err)
+			fmt.Fprintf(os.Stderr, "Error calculating R for %s: %v\n", id, err)
 			continue
 		}
 		updatedCount++
 	}
 
-	fmt.Printf("Decay update complete. Processed %d holons.\n", updatedCount)
+	fmt.Fprintf(os.Stderr, "Decay update complete. Processed %d holons.\n", updatedCount)
 	return nil
 }
 


### PR DESCRIPTION
### Summary
Redirects MCP tool warnings from stdout to stderr to prevent JSON-RPC stream corruption.

### Background
During `quint_decide` and other MCP tool calls, warnings written with `fmt.Printf()` were being sent to stdout, mixing with JSON-RPC output and causing `"Transport closed"` or `"connection closed: initialize response"` errors in Codex and other stdio MCP clients.

### Changes
- Replaced all `fmt.Printf()` calls with `fmt.Fprintf(os.Stderr, ...)` in `src/mcp/internal/fpf/tools.go`
- Verified with:
  - Codex MCP v0.77.0
  - Quint-Code v4.1.0 (Go 1.24)
  - Successful end-to-end `quint_decide` execution, no transport errors.

### Impact
- Fixes transport corruption on stdio MCP integrations.
- No functional change in logic; only log redirection.

### Status
✅ Verified  
✅ Builds on Go 1.24  
✅ No regression in DRR output
