### PR TITLE
fix: sync tui lockfile for goreleaser

### DIFF
--- a/spec/AGENT_CONTRACT.md
+++ b/spec/AGENT_CONTRACT.md
@@ -1,0 +1,81 @@
+# Agent Operating Contract
+
+> Normative rules for any agent (human or AI) editing the Haft codebase.
+> This is the authority file. When code and spec diverge, follow these rules.
+
+## Authority hierarchy
+
+1. **This contract** — operating rules, always followed
+2. **spec/** — intended semantics of the target system
+3. **Implementation** — current runtime behavior
+
+When spec and implementation diverge:
+- Preserve runtime safety first
+- Open or annotate the semantic mismatch
+- Do NOT silently "fix" docs to match legacy behavior
+- Do NOT silently change runtime to match spec without explicit migration
+
+## What may be edited
+
+| Category | Editable by agent? | Notes |
+|----------|-------------------|-------|
+| `internal/` Go code | Yes | Follow architecture rules below |
+| `desktop/` frontend | Yes | Follow existing component patterns |
+| `spec/` documents | Yes, but flag semantic changes | New terms → add to TERM_MAP first |
+| `.haft/*.md` projections | **No** | Derived from database. Never edit directly. |
+| `db/migrations.go` | Yes, append only | Never modify existing migrations |
+| `CHANGELOG.md` | Yes | Add to Unreleased section |
+
+## What is derived (never edit)
+
+- `.haft/*.md` projection files — regenerated from SQLite on every artifact write
+- Derived health (maturity + freshness) — computed at query time from stored status + evidence
+- R_eff — computed from evidence verdicts + CL penalties + decay
+- Pareto front — computed from comparison data
+- Module coverage — computed from knowledge graph queries
+
+## Architecture rules
+
+- **Core** (`internal/artifact`, `internal/graph`, `internal/fpf`, `internal/reff`, `internal/codebase`) must NOT import `desktop/`, `internal/cli/`, or `internal/agentloop/`
+- **Flow** may import Core. **Governor** may import Core + Flow. **Surfaces** may import anything below.
+- Side effects only at Flow layer and above. Core is pure queries + mutations through Store interface.
+
+## Decision boundary
+
+- Agent may frame, explore, compare, and recommend when delegated
+- Agent must **stop at Choose → Execute boundary** and wait for human confirmation
+- `selected_ref` from compare is advisory — not the decision
+- Exception: autonomous mode explicitly enabled for the session
+- Even in autonomous mode: one-way-door decisions require confirmation
+
+## Verdict vocabulary
+
+| Canonical (evidence) | Alias (measurement) | Use canonical in |
+|---------------------|--------------------|-|
+| `supports` | `accepted` | R_eff computation, evidence queries |
+| `weakens` | `partial` | R_eff computation, evidence queries |
+| `refutes` | `failed` | R_eff computation, evidence queries |
+| `superseded` | — | Excluded from R_eff |
+
+Measurement aliases appear only in `measure` action interface.
+
+## Enforcement status of illegal states
+
+| Enforcement | Meaning | What to do |
+|-------------|---------|-----------|
+| **Enforced** | Runtime rejects this state | Respect the guard |
+| **Warned** | Runtime warns but allows | Do not suppress the warning |
+| **Planned** | Spec says illegal, runtime allows | Implement enforcement when touching related code |
+| **Deferred** | Known gap, intentionally left | Do not enforce without explicit decision |
+
+## Legacy terms (deprecated but may appear in code/comments)
+
+| Legacy term | Current term | Where you'll see it |
+|-------------|-------------|-------------------|
+| `quint-code` | `haft` | Old comments, git history, some URLs |
+| `quint_*` | `haft_*` | Old MCP tool names in comments/tests |
+| `/q-*` | `/h-*` | Old slash commands in comments |
+| `.quint/` | `.haft/` | Old directory name |
+| `~/.quint-code/` | `~/.haft/` | Old home directory |
+| `/q-refresh` | `/h-verify` | Command rename |
+| `parity_rules` (string) | `ParityPlan` (structured) | Migration in progress |

--- a/spec/target-system/ARTIFACT_ONTOLOGY.md
+++ b/spec/target-system/ARTIFACT_ONTOLOGY.md
@@ -27,18 +27,31 @@ Each artifact has exactly one stored status:
 | `deprecated` | Archived as no longer relevant | All kinds |
 | `refresh_due` | Flagged by scan, needs attention | All kinds |
 
-### Derived phase (computed at query time, never stored)
+### Derived health (computed at query time, never stored)
 
-DecisionRecords have a **derived phase** computed from stored status + evidence state:
+DecisionRecords have **two independent derived dimensions** computed from stored status + evidence state:
 
-| Phase | Derivation rule |
-|-------|----------------|
-| **Pending** | status=active AND no measurement exists |
+**Maturity** (exclusive — exactly one):
+
+| Maturity | Derivation rule |
+|----------|----------------|
+| **Unassessed** | status=active AND no evidence exists on any claim |
+| **Pending** | status=active AND evidence exists but no measurement with verdict=accepted |
 | **Shipped** | status=active AND at least one measurement with verdict=accepted |
-| **Stale** | status=active AND R_eff < 0.5 (evidence degraded) |
-| **AT RISK** | status=active AND R_eff < 0.3 |
 
-Phase is a **view concern** — shown in `/h-status`, desktop dashboard, and projections. It is never written to the database. Stored status and derived phase are independent axes that must not be conflated.
+**Freshness** (exclusive — exactly one, evaluated only when maturity is Shipped):
+
+| Freshness | Derivation rule |
+|-----------|----------------|
+| **Healthy** | R_eff >= 0.5 |
+| **Stale** | R_eff < 0.5 AND R_eff >= 0.3 |
+| **AT RISK** | R_eff < 0.3 |
+
+Precedence: maturity is evaluated first, freshness only applies to Shipped decisions. A Pending decision has no freshness rating (it hasn't been verified yet).
+
+Display string: `Shipped / Healthy`, `Shipped / Stale`, `Pending`, `Unassessed`.
+
+Both dimensions are **view concerns** — shown in `/h-status`, desktop dashboard, and projections. They are never written to the database. Stored status and derived health are independent axes that must not be conflated.
 
 ## Artifact Relationships (DAG)
 

--- a/spec/target-system/EVIDENCE_ONTOLOGY.md
+++ b/spec/target-system/EVIDENCE_ONTOLOGY.md
@@ -90,6 +90,19 @@ DecisionRecords contain **claims** — falsifiable statements about what the dec
 
 **Pending verification:** When `verify_after` passes and the claim is still unverified, `/h-verify scan` surfaces it with the observable and threshold.
 
+## Verdict Vocabulary (canonical + aliases)
+
+Two verdict vocabularies exist. One is canonical, the other is a measurement-result alias:
+
+| Canonical evidence verdict | Measurement result alias | Meaning |
+|---------------------------|-------------------------|---------|
+| `supports` | `accepted` | Evidence confirms the claim |
+| `weakens` | `partial` | Evidence partially confirms or raises doubts |
+| `refutes` | `failed` | Evidence contradicts the claim |
+| `superseded` | — | Replaced by newer evidence (excluded from R_eff) |
+
+**Rule:** measurement results (`accepted`/`partial`/`failed`) are aliases stored on measurement records. When computing R_eff, they map to canonical verdicts. Code and spec must use canonical verdicts in evidence computation. Measurement-result aliases appear only in the `measure` action interface.
+
 ## Evidence Types
 
 | Type | What it is | Typical CL |

--- a/spec/target-system/ILLEGAL_STATES.md
+++ b/spec/target-system/ILLEGAL_STATES.md
@@ -13,7 +13,7 @@
 | 3 | SolutionPortfolio with variants that have >50% word overlap | Disguised copies are not genuine alternatives. | Diversity check warns at >50%. Not hard-blocked (user may override). |
 | 4 | Comparison without parity declaration | Comparison without same-conditions statement is invalid. | Skill instructions require parity. L2 enforcement planned. |
 | 5 | DecisionRecord with status `active` and no `selected_title` | A decision must have chosen something. | `Decide()` requires selected_title. |
-| 6 | EvidencePack with verdict `supports` and CL0 | Evidence from opposed context cannot support. CL0 penalty (0.9) makes this effectively worthless anyway. | R_eff computation handles this. Schema allows it but effective score is ~0.1. |
+| 6 | EvidencePack with verdict `supports` and CL0 | Evidence from opposed context cannot support — inadmissible, not merely weak. | **Enforced:** reject at ingest or downgrade verdict to `weakens` before storage. CL0+supports must not enter R_eff computation. |
 | 7 | Two active DecisionRecords for the same ProblemCard | One problem → one active decision. Previous must be superseded. | Not currently enforced. **Gap: should be.** |
 | 8 | Note with >70% title word overlap with active DecisionRecord | Note duplicates an existing decision. | `haft_note` rejects at >70% overlap. Warns at 50-70%. |
 | 9 | Artifact with status `addressed` that is not a ProblemCard | Only problems can be "addressed." Other artifacts use superseded/deprecated. | `close` action only on ProblemCard kind. |

--- a/spec/target-system/OPEN_QUESTIONS.md
+++ b/spec/target-system/OPEN_QUESTIONS.md
@@ -2,13 +2,13 @@
 
 > Non-blocking for v6 release. Classified by v7 impact after GPT-5.4 spec review.
 
-## Blocking Before v7
+## Decided (formerly blocking v7)
 
-| # | Question | Context | Status |
-|---|----------|---------|--------|
-| Q1 | What workflow DSL for repo-level execution policies? | v7 deliverable: `.haft/workflow.md`. Can't ship execution loop without choosing representation. | Candidates: `.haft/workflow.md` (simple) vs structured YAML vs FPF-native flow card |
-| Q2 | Is `haft agent` strategic, transitional, or deprecated? | Desktop app subsumes most standalone agent use. TUI adds maintenance burden. Affects architecture, docs, testing. | Candidates: Keep both / Desktop-only / Agent for CI-only |
-| Q10 | Which FPF patterns get L2 enforcement before v7? | Live gaps: parity enforcement (G2) and subjective dimension operationalization (G4). Cannot expand execution loop while these are L1-only. | Candidates: A.6.P/Q/A triggers in Go / JSON Schema structured outputs / Both |
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| Q1 | Workflow DSL shape | **`.haft/workflow.md` as hybrid markdown + structured YAML block.** Human-readable prose + parseable defaults + path policies. Not a workflow engine. | Pure markdown = too hard to validate. Pure YAML = config fatigue. FPF flow card = too heavy for solo dev. Hybrid gives reviewable prose + parseable structure + low implementation burden. Ships in v6.1. |
+| Q2 | Fate of `haft agent` | **Transitional. Retained for CI/headless/power-user. Not co-equal strategic surface.** Desktop = primary interactive. MCP = primary embedded. Agent = secondary headless utility. No feature-parity promise with desktop. | Desktop subsumes interactive use. But CI stakeholder needs headless mode. SSH/remote use cases real. Removing entirely loses too much utility. |
+| Q10 | L2 enforcement scope | **Both JSON Schema + Go validators, but narrow: parity minimums + subjective dimension operationalization only.** No broad A.6 universalization before v7. | Schema alone can't catch semantic hollowness. Go validators without schema = brittle text heuristics. Narrow scope = feasible for solo dev. Ships in v6.1. |
 
 ## Resolved (No Longer Open)
 

--- a/spec/target-system/SCOPE_FREEZE.md
+++ b/spec/target-system/SCOPE_FREEZE.md
@@ -48,38 +48,61 @@ Everything below is built, tested, and being merged to main.
 - Language precision triggers in skill instructions
 - Audience projections: engineer, manager, audit, compare, delegated-agent, change-rationale
 
-## v6.x — Harden (next 30 days)
+## v6.1 — Harden the Contract (days 0-30)
 
-Focus: stability, Core module boundary, test coverage.
+Focus: trust and momentum for existing MCP/CLI users. No new surfaces.
 
+- [ ] Fix remaining P2-P4 bugs from code review
 - [ ] Core packages have zero desktop/ dependencies (clean boundary)
 - [ ] Integration tests for knowledge graph on real project data
 - [ ] Evidence decomposition tests (F/G/R computation)
-- [ ] Document Core API surface (stable vs internal)
-- [ ] Fix remaining P2-P4 bugs from code review
 - [ ] `haft check` CLI command for CI (verify decisions fresh, evidence current)
+- [ ] `.haft/workflow.md` — simple hybrid markdown+structured, injected into agent prompts
 - [ ] Problem type field on ProblemCard (optimization/diagnosis/search/synthesis)
+- [ ] **Decision integrity enforcement (G1/G2/G4):**
+  - [ ] G1: reject duplicate active decisions per problem
+  - [ ] G2: require structured parity plan in standard/deep compare
+  - [ ] G4: warn on subjective comparison dimensions (maintainable, simple, scalable)
+- [ ] Rename/install/docs polish for migration friction
 
-## v7 — Execution Loop (next 60 days)
+## v6.2 — Execution Primitives (days 31-60)
 
-Focus: complete Think→Run→Govern cycle in desktop.
+Focus: desktop starts proving the loop, not just visualizing.
 
-- [ ] Post-execution invariant verification (automatic after task completes)
-- [ ] Auto-baseline after successful verification
-- [ ] "Create PR" from completed task (PR body from linked DecisionRecord)
-- [ ] `.haft/workflow.md` — repo-level instructions injected into every agent prompt
-- [ ] Decision-anchored task: click "Implement" → agent in worktree → verify → PR
-- [ ] Issue intake from Linear/GitHub → ProblemCard conversion
+- [ ] Decision-anchored "Implement" from desktop (spawn agent in worktree with invariants + rationale)
+- [ ] Worktree/branch creation
+- [ ] Automatic post-run invariant verification
+- [ ] Baseline refresh only on successful verification
+- [ ] Persisted verification/governance result linked to decision
 
-## v8 — Governor Loops (next 90 days)
+## v7.0 — Desktop Loop MVP (days 61-90)
 
-Focus: background governance that runs without human attention.
+Focus: one golden path, not a broad feature wave.
 
-- [ ] Stale refresh loop: spawn verification agent for expired decisions
-- [ ] Drift loop: check baselines, verify invariants, auto-update non-breaking
-- [ ] Dependency loop: scan outdated deps, create problem candidates
-- [ ] Research-before-code lane (for tasks with high external knowledge dependency)
-- [ ] Process quality metrics: OwnerIntegrity, CeremonyRatio
+Ship exactly one vertical slice:
+- [ ] **Decision → Implement → Verify → Baseline → PR draft/export**
+- [ ] If verification fails → reopen/create ProblemCard (not straight to PR)
+- [ ] PR output is local-first: draft body + branch compare, not deep provider integration
+
+**NOT in v7:** GitHub/Linear intake, research-before-code, process metrics, autonomous agents.
+
+## v8 — Governor Signals (post day 90)
+
+Focus: detect-only first. Autonomous actuation later.
+
+Phase A (detect-only):
+- [ ] Stale decision detection loop
+- [ ] Drift detection loop
+- [ ] Dependency findings loop
+- [ ] Dashboard alerts and notifications
+
+Phase B (actuation — only after Phase A trust earned):
+- [ ] Spawn verification agent for expired decisions
+- [ ] Auto-update non-breaking drift
+- [ ] Research-before-code lane
+- [ ] Process quality metrics
+
+**Key principle:** do not automate execution until decision quality is enforced, not merely encouraged.
 
 ## Later / Maybe
 

--- a/spec/target-system/TARGET_SYSTEM_MODEL.md
+++ b/spec/target-system/TARGET_SYSTEM_MODEL.md
@@ -1,6 +1,8 @@
 # Target System Model — Reading Order
 
 > This is the index. Read documents in order.
+>
+> **Start here if you're an agent:** read [AGENT_CONTRACT.md](../AGENT_CONTRACT.md) first — it tells you what you may edit and what rules apply.
 
 ## Layer 1: Context (10 min)
 


### PR DESCRIPTION
tui/package-lock.json was out of sync with package.json (esbuild version mismatch). goreleaser before-hook `npm ci` failed. Also includes spec updates from review.