### PR TITLE
fix(release): platform-safe npm install in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,8 @@ project_name: haft
 
 before:
   hooks:
-    - sh -c "cd desktop/frontend && npm install --no-audit --no-fund && npm run build"
-    - sh -c "cd tui && npm install --no-audit --no-fund && npm run build"
+    - sh -c "cd desktop/frontend && rm -f package-lock.json && npm install --no-audit --no-fund && npm run build"
+    - sh -c "cd tui && rm -f package-lock.json && npm install --no-audit --no-fund && npm run build"
 
 builds:
   - id: haft


### PR DESCRIPTION
Delete lockfiles before npm install so esbuild resolves correct platform binary.