### PR TITLE
fix(release): disable npm cache causing cross-platform esbuild failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: |
-            desktop/frontend/package-lock.json
-            tui/package-lock.json
 
       - uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
npm cache from actions/setup-node persists darwin esbuild binary → Exec format error on Linux goreleaser.