### PR TITLE
fix(artifact): enforce one live decision per problem

### DIFF
--- a/internal/artifact/decision.go
+++ b/internal/artifact/decision.go
@@ -512,6 +512,154 @@ func MergeProblemRefs(single string, multiple []string) []string {
 	return refs
 }
 
+func decisionBlocksReplacement(status Status) bool {
+	return status == StatusActive || status == StatusRefreshDue
+}
+
+func resolvePortfolioProblemRefs(portfolio *Artifact) []string {
+	if portfolio == nil {
+		return nil
+	}
+
+	resolvedRefs := []string{}
+	fields := portfolio.UnmarshalPortfolioFields()
+
+	if fields.ProblemRef != "" {
+		resolvedRefs = appendUniqueString(resolvedRefs, fields.ProblemRef)
+	}
+
+	for _, link := range portfolio.Meta.Links {
+		if link.Type != "based_on" {
+			continue
+		}
+		if !strings.HasPrefix(link.Ref, KindProblemCard.IDPrefix()+"-") {
+			continue
+		}
+
+		resolvedRefs = appendUniqueString(resolvedRefs, link.Ref)
+	}
+
+	sort.Strings(resolvedRefs)
+	return resolvedRefs
+}
+
+func resolveDecisionProblemRefs(ctx context.Context, store ArtifactStore, decision *Artifact) []string {
+	if decision == nil {
+		return nil
+	}
+
+	resolvedRefs := cloneStringSlice(decision.UnmarshalDecisionFields().ProblemRefs)
+
+	for _, link := range decision.Meta.Links {
+		if link.Type != "based_on" {
+			continue
+		}
+
+		if strings.HasPrefix(link.Ref, KindProblemCard.IDPrefix()+"-") {
+			resolvedRefs = appendUniqueString(resolvedRefs, link.Ref)
+			continue
+		}
+
+		linkedArtifact, err := store.Get(ctx, link.Ref)
+		if err != nil {
+			continue
+		}
+		if linkedArtifact.Meta.Kind != KindSolutionPortfolio {
+			continue
+		}
+
+		for _, problemRef := range resolvePortfolioProblemRefs(linkedArtifact) {
+			resolvedRefs = appendUniqueString(resolvedRefs, problemRef)
+		}
+	}
+
+	sort.Strings(resolvedRefs)
+	return resolvedRefs
+}
+
+func resolveIncomingDecisionProblemRefs(
+	ctx context.Context,
+	store ArtifactStore,
+	problemRefs []string,
+	portfolioRef string,
+) []string {
+	resolvedRefs := cloneStringSlice(problemRefs)
+
+	if portfolioRef == "" {
+		sort.Strings(resolvedRefs)
+		return resolvedRefs
+	}
+
+	portfolio, err := store.Get(ctx, portfolioRef)
+	if err != nil || portfolio.Meta.Kind != KindSolutionPortfolio {
+		sort.Strings(resolvedRefs)
+		return resolvedRefs
+	}
+
+	for _, problemRef := range resolvePortfolioProblemRefs(portfolio) {
+		resolvedRefs = appendUniqueString(resolvedRefs, problemRef)
+	}
+
+	sort.Strings(resolvedRefs)
+	return resolvedRefs
+}
+
+func validateNoActiveDecisionConflict(
+	ctx context.Context,
+	store ArtifactStore,
+	problemRefs []string,
+	portfolioRef string,
+) error {
+	resolvedIncomingRefs := resolveIncomingDecisionProblemRefs(ctx, store, problemRefs, portfolioRef)
+
+	if len(resolvedIncomingRefs) == 0 {
+		return nil
+	}
+
+	decisions, err := store.ListByKind(ctx, KindDecisionRecord, 0)
+	if err != nil {
+		return fmt.Errorf("list decision records: %w", err)
+	}
+
+	for _, decision := range decisions {
+		if !decisionBlocksReplacement(decision.Meta.Status) {
+			continue
+		}
+
+		fullDecision, err := store.Get(ctx, decision.Meta.ID)
+		if err != nil {
+			continue
+		}
+
+		for _, existingProblemRef := range resolveDecisionProblemRefs(ctx, store, fullDecision) {
+			if !slicesContains(resolvedIncomingRefs, existingProblemRef) {
+				continue
+			}
+
+			return fmt.Errorf(
+				"problem_ref %s already has live DecisionRecord %s (%s) — supersede the previous decision or close the problem first",
+				existingProblemRef,
+				fullDecision.Meta.ID,
+				fullDecision.Meta.Title,
+			)
+		}
+	}
+
+	return nil
+}
+
+func slicesContains(values []string, target string) bool {
+	for _, value := range values {
+		if value != target {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
 // BuildLinks constructs artifact links from problem refs and portfolio ref. Pure.
 func BuildLinks(problemRefs []string, portfolioRef string) []Link {
 	var links []Link
@@ -528,6 +676,11 @@ func BuildLinks(problemRefs []string, portfolioRef string) []Link {
 func Decide(ctx context.Context, store ArtifactStore, haftDir string, input DecideInput) (*Artifact, string, error) {
 	input = normalizeDecisionInput(input)
 
+	problemRefs := MergeProblemRefs(input.ProblemRef, input.ProblemRefs)
+	if err := validateNoActiveDecisionConflict(ctx, store, problemRefs, input.PortfolioRef); err != nil {
+		return nil, "", err
+	}
+
 	seq, err := store.NextSequence(ctx, KindDecisionRecord)
 	if err != nil {
 		return nil, "", fmt.Errorf("generate ID: %w", err)
@@ -537,7 +690,6 @@ func Decide(ctx context.Context, store ArtifactStore, haftDir string, input Deci
 	now := time.Now().UTC()
 
 	// Pure: merge refs
-	problemRefs := MergeProblemRefs(input.ProblemRef, input.ProblemRefs)
 	links := BuildLinks(problemRefs, input.PortfolioRef)
 
 	// Effects: compute mode from chain

--- a/internal/artifact/decision_test.go
+++ b/internal/artifact/decision_test.go
@@ -352,6 +352,196 @@ func TestDecide_RejectsSelectedVariantAsRejectedAlternative(t *testing.T) {
 	}
 }
 
+func TestDecide_RejectsDuplicateLiveDecisionForProblem(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title:  "Event pipeline redesign",
+		Signal: "Current broker drops messages during failover.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("NATS", "cluster tuning", "Lean broker with smaller operational surface."),
+			testVariant("Kafka", "ops overhead", "Mature streaming platform with heavier operations."),
+		},
+		NoSteppingStoneRationale: "Both variants are direct production paths.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  firstPortfolio.Meta.ID,
+		SelectedTitle: "NATS",
+		WhySelected:   "Smaller operational surface wins at the current scale.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("RabbitMQ quorum", "migration risk", "Reuse existing AMQP tooling with a more resilient queue mode."),
+			testVariant("Kafka", "ops overhead", "Mature streaming platform with heavier operations."),
+		},
+		NoSteppingStoneRationale: "Both variants still target the same production decision.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  secondPortfolio.Meta.ID,
+		SelectedTitle: "RabbitMQ quorum",
+		WhySelected:   "It would reduce migration effort.",
+	}))
+	if err == nil {
+		t.Fatal("expected duplicate live decision error")
+	}
+	if !strings.Contains(err.Error(), problem.Meta.ID) {
+		t.Fatalf("expected problem_ref in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), firstDecision.Meta.ID) {
+		t.Fatalf("expected existing decision ref in error, got %v", err)
+	}
+}
+
+func TestDecide_RejectsPortfolioOnlyDecisionWhenProblemAlreadyHasLiveDecision(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title:  "Auth token rotation",
+		Signal: "Refresh tokens stay valid after key rotation.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Rotate signing key in place", "cache invalidation", "Smaller code change, but clients may cache the old verifier."),
+			testVariant("Dual-key grace period", "operational complexity", "Accept both keys during the migration window."),
+		},
+		NoSteppingStoneRationale: "Both variants are immediate production candidates.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  firstPortfolio.Meta.ID,
+		SelectedTitle: "Dual-key grace period",
+		WhySelected:   "It avoids breaking active sessions during rotation.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Opaque sessions", "storage growth", "Move token validity to server-side session lookup."),
+			testVariant("Dual-key grace period", "operational complexity", "Keep the current token model with safer rotation."),
+		},
+		NoSteppingStoneRationale: "Both variants remain valid responses to the same problem.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		PortfolioRef:  secondPortfolio.Meta.ID,
+		SelectedTitle: "Opaque sessions",
+		WhySelected:   "It centralizes revocation control.",
+	}))
+	if err == nil {
+		t.Fatal("expected duplicate live decision error for portfolio-only lineage")
+	}
+	if !strings.Contains(err.Error(), problem.Meta.ID) {
+		t.Fatalf("expected derived problem_ref in error, got %v", err)
+	}
+}
+
+func TestDecide_AllowsReplacementAfterSupersede(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title:  "Background job queue",
+		Signal: "Queue latency is rising faster than expected.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Single Redis queue", "head-of-line blocking", "Keep the architecture simple and local."),
+			testVariant("Sharded Redis queues", "routing complexity", "Split heavy and light jobs into separate lanes."),
+		},
+		NoSteppingStoneRationale: "Both variants are direct implementation paths.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  firstPortfolio.Meta.ID,
+		SelectedTitle: "Single Redis queue",
+		WhySelected:   "It is enough until job volume proves otherwise.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = SupersedeArtifact(ctx, store, haftDir, firstDecision.Meta.ID, "", "A broader queue redesign replaced the first choice.")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Sharded Redis queues", "routing complexity", "Split heavy and light jobs into separate lanes."),
+			testVariant("Postgres-backed queue", "db load", "Reuse existing operational tooling for jobs."),
+		},
+		NoSteppingStoneRationale: "Both variants remain immediate candidates after the supersession.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacementDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  secondPortfolio.Meta.ID,
+		SelectedTitle: "Sharded Redis queues",
+		WhySelected:   "Volume now justifies splitting hot and cold workloads.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacementDecision.Meta.ID == "" {
+		t.Fatal("expected replacement decision to be created")
+	}
+}
+
 func TestApply_ReturnsBody(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/artifact/query_test.go
+++ b/internal/artifact/query_test.go
@@ -303,7 +303,7 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		t.Fatal(err)
 	}
 
-	otherPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+	_, _, err = ExploreSolutions(ctx, store, haftDir, ExploreInput{
 		ProblemRef: problem.Meta.ID,
 		Variants: []Variant{
 			testVariant("WebSocket", "connection lifecycle complexity", "Keep duplex sessions alive"),
@@ -311,16 +311,6 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		},
 		NoSteppingStoneRationale: "Both transports are direct target architectures.",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	otherDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
-		ProblemRef:    problem.Meta.ID,
-		PortfolioRef:  otherPortfolio.Meta.ID,
-		SelectedTitle: "WebSocket",
-		WhySelected:   "A newer alternative path should not hijack adoption refs for the compared portfolio.",
-	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,18 +327,6 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		t.Fatal(err)
 	}
 
-	_, err = store.DB().ExecContext(ctx, `
-		UPDATE artifacts
-		SET created_at = ?, updated_at = ?
-		WHERE id = ?`,
-		"2026-01-03T00:00:00Z",
-		"2026-01-03T00:00:00Z",
-		otherDecision.Meta.ID,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	refs := ResolveProblemAdoptionRefs(ctx, store, problem.Meta.ID)
 	if refs.PortfolioRef != comparedPortfolio.Meta.ID {
 		t.Fatalf("PortfolioRef = %q, want %q", refs.PortfolioRef, comparedPortfolio.Meta.ID)
@@ -357,6 +335,6 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		t.Fatalf("ComparedPortfolioRef = %q, want %q", refs.ComparedPortfolioRef, comparedPortfolio.Meta.ID)
 	}
 	if refs.DecisionRef != comparedDecision.Meta.ID {
-		t.Fatalf("DecisionRef = %q, want %q (not newer %q)", refs.DecisionRef, comparedDecision.Meta.ID, otherDecision.Meta.ID)
+		t.Fatalf("DecisionRef = %q, want %q", refs.DecisionRef, comparedDecision.Meta.ID)
 	}
 }

--- a/internal/tools/haft_test.go
+++ b/internal/tools/haft_test.go
@@ -1382,9 +1382,40 @@ func TestHaftDecisionTool_MeasureRejectsForeignDecisionRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	foreignProblem, _, err := artifact.FrameProblem(fixture.ctx, fixture.store, fixture.haftDir, artifact.ProblemFrameInput{
+		Title:      "Streaming fallback transport",
+		Signal:     "Current transport cannot survive mobile reconnect churn.",
+		Acceptance: "Select a transport that keeps reconnect latency predictable.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foreignPortfolio, _, err := artifact.ExploreSolutions(fixture.ctx, fixture.store, fixture.haftDir, artifact.ExploreInput{
+		ProblemRef: foreignProblem.Meta.ID,
+		Variants: []artifact.Variant{
+			{
+				ID:            "Y1",
+				Title:         "WebSocket",
+				WeakestLink:   "connection lifecycle complexity",
+				NoveltyMarker: "Keep long-lived duplex sessions",
+			},
+			{
+				ID:            "Y2",
+				Title:         "SSE",
+				WeakestLink:   "server-to-client only",
+				NoveltyMarker: "Use unidirectional event streams",
+			},
+		},
+		NoSteppingStoneRationale: "Both variants are valid responses to the separate reconnect problem.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	foreignDecision, _, err := artifact.Decide(fixture.ctx, fixture.store, fixture.haftDir, artifact.DecideInput{
-		ProblemRef:      fixture.problem.Meta.ID,
-		PortfolioRef:    fixture.otherPortfolio.Meta.ID,
+		ProblemRef:      foreignProblem.Meta.ID,
+		PortfolioRef:    foreignPortfolio.Meta.ID,
 		SelectedTitle:   "WebSocket",
 		WhySelected:     "The foreign portfolio keeps duplex connections available.",
 		SelectionPolicy: "Prioritize persistent duplex transport.",

--- a/spec/target-system/ILLEGAL_STATES.md
+++ b/spec/target-system/ILLEGAL_STATES.md
@@ -14,7 +14,7 @@
 | 4 | Comparison without parity declaration | Comparison without same-conditions statement is invalid. | Skill instructions require parity. L2 enforcement planned. |
 | 5 | DecisionRecord with status `active` and no `selected_title` | A decision must have chosen something. | `Decide()` requires selected_title. |
 | 6 | EvidencePack with verdict `supports` and CL0 | Evidence from opposed context cannot support — inadmissible, not merely weak. | **Enforced:** reject at ingest or downgrade verdict to `weakens` before storage. CL0+supports must not enter R_eff computation. |
-| 7 | Two active DecisionRecords for the same ProblemCard | One problem → one active decision. Previous must be superseded. | Not currently enforced. **Gap: should be.** |
+| 7 | Two active DecisionRecords for the same ProblemCard | One problem → one active decision. Previous must be superseded. | **Enforced:** `Decide()` rejects a new live DecisionRecord when another live decision already governs the same problem. |
 | 8 | Note with >70% title word overlap with active DecisionRecord | Note duplicates an existing decision. | `haft_note` rejects at >70% overlap. Warns at 50-70%. |
 | 9 | Artifact with status `addressed` that is not a ProblemCard | Only problems can be "addressed." Other artifacts use superseded/deprecated. | `close` action only on ProblemCard kind. |
 
@@ -64,7 +64,6 @@
 
 | # | Gap | Impact | Priority |
 |---|-----|--------|----------|
-| G1 | #7: Multiple active decisions per problem | Poisons invariant injection, file-to-decision lookup, governance scans, and "what governs this file?" | **High** — must enforce before v7 execution loop |
 | G2 | #4: Parity declaration enforcement | Unfair comparisons pass without warning | **High** — planned for v6.x |
 | G3 | #10: Measurement fabrication detection | Trust inflation | Low — fundamentally LLM discipline issue |
 | G4 | #19: Subjective dimension enforcement | Entire Choose mode can look rigorous while being semantically hollow. Core value proposition corrupted. | **High** — L2 enforcement needed before v7 |


### PR DESCRIPTION
Reject replacement DecisionRecords when the same ProblemCard already has a live decision, including lineage resolved through linked portfolios. Update tests and illegal-state documentation to reflect the new B1 enforcement boundary.