### PR TITLE
fix(release): linux_amd64 only goreleaser (CGO/tree-sitter)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,21 +21,8 @@ builds:
       - -X github.com/m0n0x41d/haft/internal/cli.BuildDate={{ .Date }}
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
-      - arm64
-  - id: haft-desktop
-    dir: .
-    main: ./desktop
-    binary: haft-desktop
-    flags:
-      - -trimpath
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
 
 archives:
   - id: haft-cli
@@ -51,12 +38,6 @@ archives:
       - src: tui/dist/tui.mjs
         dst: tui
         strip_parent: true
-  - id: haft-desktop
-    ids:
-      - haft-desktop
-    formats:
-      - zip
-    name_template: "{{ .ProjectName }}-desktop-{{ .Os }}-{{ .Arch }}"
 
 checksum:
   name_template: 'checksums.txt'
@@ -68,16 +49,20 @@ release:
   header: |
     ## Haft {{ .Tag }}
 
-    Engineering agent with FPF reasoning discipline. Interactive CLI + MCP server.
+    FPF-native engineering reasoning runtime. MCP plugin + Desktop app.
 
     ### Install
+
+    ```bash
+    curl -fsSL https://quint.codes/install.sh | bash
+    ```
+
+    Or build from source (macOS/Linux, requires Go 1.25+):
 
     ```bash
     go install github.com/m0n0x41d/haft/cmd/haft@latest
     ```
 
-    ### Desktop Artifact
+    **Note:** Pre-built binaries are currently Linux amd64 only. macOS users should use `go install` or the install script (which builds from source as fallback).
 
-    Release archives now include a `haft-desktop` build for macOS alongside the CLI bundles.
-
-    See [CHANGELOG](https://github.com/m0n0x41d/quint-code/blob/main/CHANGELOG.md) for full details.
+    See [CHANGELOG](https://github.com/m0n0x41d/haft/blob/main/CHANGELOG.md) for full details.


### PR DESCRIPTION
tree-sitter CGO prevents cross-compilation. Linux amd64 binary from goreleaser, macOS via go install.