### PR TITLE
fix(ci): clean lockfiles in release npm steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '24'
       - name: Build TUI bundle
-        run: cd tui && npm install --no-audit --no-fund && npm run build
+        run: cd tui && rm -rf node_modules package-lock.json && npm install --no-audit --no-fund && npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: tui-bundle
@@ -68,6 +68,7 @@ jobs:
       - name: Prepare desktop embed
         run: |
           cd desktop/frontend
+          rm -rf node_modules package-lock.json
           npm install --no-audit --no-fund
           npm run build
 


### PR DESCRIPTION
Lockfiles pin darwin esbuild. Must delete before npm install on linux.