### PR TITLE
fix(install): tui.mjs path + README URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Both share the same kernel. Desktop is where humans think. MCP is where agents t
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/m0n0x41d/quint-code/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/m0n0x41d/haft/main/install.sh | bash
 ```
 
 The install URL still points at the historical `quint-code` repository path. The installed binary is `haft`.

--- a/install.sh
+++ b/install.sh
@@ -92,6 +92,7 @@ find_archive_binary() {
 find_archive_tui_bundle() {
     local archive_root="$1"
     local candidates=(
+        "$archive_root/tui.mjs"
         "$archive_root/tui/bundle.mjs"
         "$archive_root/tui/tui.mjs"
         "$archive_root/bundle.mjs"


### PR DESCRIPTION
Archive has tui.mjs at root, script didn't search there. README pointed to old repo URL.