### PR TITLE
v6.1.0 — Harden the Contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
             exit 1
           fi
 
+      - name: Sync tracked governance artifacts
+        run: ./haft sync
+
+      - name: Check governance debt
+        run: ./haft check
+
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '24'
       - name: Build TUI bundle
-        run: cd tui && npm install --no-audit --no-fund && npm run build
+        run: cd tui && rm -rf node_modules package-lock.json && npm install --no-audit --no-fund && npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: tui-bundle
@@ -68,6 +68,7 @@ jobs:
       - name: Prepare desktop embed
         run: |
           cd desktop/frontend
+          rm -rf node_modules package-lock.json
           npm install --no-audit --no-fund
           npm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           - { runner: ubuntu-latest,    goos: linux,  goarch: amd64 }
           - { runner: ubuntu-24.04-arm, goos: linux,  goarch: arm64 }
           - { runner: macos-latest,     goos: darwin, goarch: arm64 }
-          - { runner: macos-13,         goos: darwin, goarch: amd64 }
+          - { runner: macos-latest,      goos: darwin, goarch: amd64 }
     steps:
       - uses: actions/checkout@v6
         with:
@@ -82,6 +82,10 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '1'
         run: |
           go build -trimpath \
             -ldflags "-s -w \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: |
-            desktop/frontend/package-lock.json
-            tui/package-lock.json
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,27 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*']
 
 permissions:
   contents: write
 
 jobs:
+  tui-bundle:
+    name: Build TUI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - name: Build TUI bundle
+        run: cd tui && npm install --no-audit --no-fund && npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tui-bundle
+          path: tui/dist/tui.mjs
+
   test:
     name: Pre-release tests
     runs-on: ubuntu-latest
@@ -17,51 +31,96 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache-dependency-path: go.sum
-
       - name: Prepare desktop embed placeholder
         run: |
           mkdir -p desktop/frontend/dist
           printf 'ci placeholder\n' > desktop/frontend/dist/.ci-placeholder
-
       - name: Run tests
-        run: |
-          packages=$(go list ./... | grep -v /desktop)
+        run: go test -race $(go list ./... | grep -v /desktop)
 
-          while IFS= read -r pkg; do
-            echo "::group::go test -race $pkg"
-            go test -v -race "$pkg"
-            echo "::endgroup::"
-          done <<EOF
-          $packages
-          EOF
-
-  release:
-    name: Release
-    needs: test
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    needs: [test, tui-bundle]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    goos: linux,  goarch: amd64 }
+          - { runner: ubuntu-24.04-arm, goos: linux,  goarch: arm64 }
+          - { runner: macos-latest,     goos: darwin, goarch: arm64 }
+          - { runner: macos-13,         goos: darwin, goarch: amd64 }
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          fetch-depth: 0
-
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache-dependency-path: go.sum
-
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Prepare desktop embed
+        run: |
+          cd desktop/frontend
+          npm install --no-audit --no-fund
+          npm run build
+
+      - uses: actions/download-artifact@v4
         with:
-          version: '~> v2'
-          args: release --clean
+          name: tui-bundle
+          path: tui/dist
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build binary
+        run: |
+          go build -trimpath \
+            -ldflags "-s -w \
+              -X github.com/m0n0x41d/haft/internal/cli.Version=${{ steps.version.outputs.version }} \
+              -X github.com/m0n0x41d/haft/internal/cli.Commit=$(git rev-parse --short HEAD) \
+              -X github.com/m0n0x41d/haft/internal/cli.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o haft ./cmd/haft/
+
+      - name: Package
+        run: |
+          mkdir -p _dist
+          cp tui/dist/tui.mjs .
+          tar czf _dist/haft-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+            haft tui.mjs README.md LICENSE CHANGELOG.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: haft-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: _dist/*.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: _artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: cd _artifacts && sha256sum *.tar.gz > checksums.txt
+
+      - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "Haft ${{ github.ref_name }}" \
+            --generate-notes \
+            _artifacts/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,8 @@ project_name: haft
 
 before:
   hooks:
-    - sh -c "cd desktop/frontend && npm install --no-audit --no-fund && npm run build"
-    - sh -c "cd tui && npm install --no-audit --no-fund && npm run build"
+    - sh -c "cd desktop/frontend && rm -f package-lock.json && npm install --no-audit --no-fund && npm run build"
+    - sh -c "cd tui && rm -f package-lock.json && npm install --no-audit --no-fund && npm run build"
 
 builds:
   - id: haft

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,8 @@ project_name: haft
 
 before:
   hooks:
-    - sh -c "cd desktop/frontend && rm -f package-lock.json && npm install --no-audit --no-fund && npm run build"
-    - sh -c "cd tui && rm -f package-lock.json && npm install --no-audit --no-fund && npm run build"
+    - sh -c "cd desktop/frontend && rm -rf node_modules package-lock.json && npm install --no-audit --no-fund && npm run build"
+    - sh -c "cd tui && rm -rf node_modules package-lock.json && npm install --no-audit --no-fund && npm run build"
 
 builds:
   - id: haft

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,21 +21,8 @@ builds:
       - -X github.com/m0n0x41d/haft/internal/cli.BuildDate={{ .Date }}
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
-      - arm64
-  - id: haft-desktop
-    dir: .
-    main: ./desktop
-    binary: haft-desktop
-    flags:
-      - -trimpath
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
 
 archives:
   - id: haft-cli
@@ -51,12 +38,6 @@ archives:
       - src: tui/dist/tui.mjs
         dst: tui
         strip_parent: true
-  - id: haft-desktop
-    ids:
-      - haft-desktop
-    formats:
-      - zip
-    name_template: "{{ .ProjectName }}-desktop-{{ .Os }}-{{ .Arch }}"
 
 checksum:
   name_template: 'checksums.txt'
@@ -68,16 +49,20 @@ release:
   header: |
     ## Haft {{ .Tag }}
 
-    Engineering agent with FPF reasoning discipline. Interactive CLI + MCP server.
+    FPF-native engineering reasoning runtime. MCP plugin + Desktop app.
 
     ### Install
+
+    ```bash
+    curl -fsSL https://quint.codes/install.sh | bash
+    ```
+
+    Or build from source (macOS/Linux, requires Go 1.25+):
 
     ```bash
     go install github.com/m0n0x41d/haft/cmd/haft@latest
     ```
 
-    ### Desktop Artifact
+    **Note:** Pre-built binaries are currently Linux amd64 only. macOS users should use `go install` or the install script (which builds from source as fallback).
 
-    Release archives now include a `haft-desktop` build for macOS alongside the CLI bundles.
-
-    See [CHANGELOG](https://github.com/m0n0x41d/quint-code/blob/main/CHANGELOG.md) for full details.
+    See [CHANGELOG](https://github.com/m0n0x41d/haft/blob/main/CHANGELOG.md) for full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [6.1.0] — 2026-04-14
+
+### Added
+
+- **`haft check` CLI command** — CI-friendly governance verification. Runs stale scan, drift scan, unassessed decisions, coverage gaps. Exit 0 = clean, exit 1 = findings. `--json` flag for structured output.
+- **Full governance state in `/h-verify`** — scan now surfaces pending problems (backlog/in-progress count), addressed problems without linked decisions, and invariant violations from knowledge graph. Single entry point for "what needs attention."
+- **`.haft/workflow.md` support** — hybrid markdown+YAML project policy file. Parsed at serve/agent startup. Intent + Defaults injected into agent prompts. `haft init` creates commented example.
+- **Problem typing on ProblemCard** — `problem_type` field: optimization, diagnosis, search, synthesis. Accepted on frame, stored in DB, shown in `/h-status` and `/h-problems`.
+- **Derived decision health model** — replaces single "phase" with two independent axes: Maturity (Unassessed / Pending / Shipped) and Freshness (Healthy / Stale / AT RISK). Freshness evaluated only for Shipped decisions. Never stored — computed at query time.
+- **Claim-scoped evidence supersession** — new measurement supersedes only previous measurements for the same `(claim_ref, observable)`, not all measurements on the decision. Prevents unrelated evidence from being retired.
+- **Claim-scoped R_eff** — `R_eff(decision) = min(R_eff(claim_i))` where each claim's R_eff is computed from its own evidence. More precise than decision-level aggregation.
+- **F_eff / G_eff decomposition** — Formality (F0–F3) and Groundedness (CL-derived) exposed as view concerns alongside R_eff for evidence diagnosis.
+- **Deep onboard for legacy projects** — `/h-onboard` now runs module coverage analysis and deep scans blind modules: reads code, identifies responsibilities, invariants, implicit decisions, risks. Supports parallel subagent execution when available.
+
+### Changed
+
+- **"No evidence = Unassessed"** — decisions without evidence are shown separately from healthy decisions, not treated as fresh. UI surfaces coverage gaps.
+- **Verdict vocabulary normalized** — measurement result aliases (`accepted`/`partial`/`failed`) mapped to canonical evidence verdicts (`supports`/`weakens`/`refutes`) at storage boundary.
+- **CL0 + supports = inadmissible** — evidence from opposed context with verdict `supports` is rejected at ingest, not merely penalized.
+- **G1 enforced: one active decision per problem** — `Decide()` rejects if another active DecisionRecord exists for the same problem_ref.
+- **G2: parity plan warnings** — `haft_solution(action="compare")` in standard/deep mode warns if parity plan is empty or unstructured.
+- **G4: subjective dimension warnings** — compare warns on dimensions like "maintainable", "simple", "scalable" — asks to decompose into measurables or tag as observation-only.
+- **Core boundary enforced** — integration tests verify Core packages (`internal/artifact`, `graph`, `fpf`, `reff`, `codebase`) have zero `desktop/` imports.
+
+### Fixed
+
+- **Desktop: oversized task output tails bounded** — prevents UI freeze on large agent outputs.
+- **Knowledge graph integration tests** — FindDecisionsForFile, FindInvariantsForFile, ComputeImpactSet tested on seeded DB with real project data.
 
 ## [6.0.0] — 2026-04-13
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Both share the same kernel. Desktop is where humans think. MCP is where agents t
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/m0n0x41d/quint-code/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/m0n0x41d/haft/main/install.sh | bash
 ```
 
 The install URL still points at the historical `quint-code` repository path. The installed binary is `haft`.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 *formerly [quint-code](https://github.com/m0n0x41d/quint-code)*
 
-**Engineering decisions that know when they're stale.**
+**True harness engineering for AI-assisted software delivery.**
 
-Frame problems. Compare options fairly. Record decisions as contracts. Know when to revisit.
+Your agents write code fast. Nobody checks if the decisions behind that code are any good — or still valid a month later. Haft does.
 
 ---
 
 ## What is Haft?
 
-Haft is a local-first engineering governor for software projects. It helps engineers frame problems before solving them, compare options honestly, record decisions as contracts with invariants, track evidence with decay, and know when to revisit.
+Haft is the engineering governor that sits between your intentions and your agents' execution. It enforces the discipline that separates "we shipped fast" from "we shipped right": frame the problem before solving it, compare options under parity, record decisions as falsifiable contracts, and know the moment assumptions go stale.
 
 **Think → Run → Govern.**
+
+Not a coding agent. Not a documentation tool. Not a project manager. The handle between the tool and the hand — the part that turns raw capability into directed engineering work.
 
 ### Two primary surfaces
 
@@ -168,6 +170,43 @@ Features: dashboard with governance findings, problem board, decision detail wit
 `/h-reason` gives your AI agent an FPF-native operating system for engineering decisions: problem framing before solutions, characterization before comparison, parity enforcement, evidence with congruence penalties, weakest-link assurance, and the lemniscate cycle that closes itself when evidence ages or measurements fail.
 
 `haft fpf search` gives access to the indexed FPF specification with tiered retrieval: exact pattern id → route-aware concept matching → keyword fallback.
+
+---
+
+## Roadmap
+
+### v6.1 — Harden the Contract (shipped)
+
+Decision quality enforcement before automating execution:
+- `haft check` for CI governance verification
+- `/h-verify` surfaces full governance state (problems, invariants, drift — not just decisions)
+- `.haft/workflow.md` — repo-level agent policy, injected into every prompt
+- Problem typing (optimization / diagnosis / search / synthesis)
+- G1/G2/G4 enforcement: one decision per problem, parity warnings, subjective dimension detection
+- CL0+supports rejection, claim-scoped R_eff and evidence supersession
+- Deep `/h-onboard` with module-by-module analysis for legacy projects
+
+### v6.2 — Dashboard + Execution Primitives (next)
+
+The desktop becomes an operator surface, not just a viewer:
+- **Unified Dashboard** — active decisions, governance findings, automations in one view
+- **Implement** — click a decision, agent spawns in worktree with full reasoning context
+- **Adopt** — governance finding (stale/drifted) → agent thread for interactive resolution
+- **Automation triggers** — CI fail, dependency update, scheduled → auto-create ProblemCards
+- **DDR→Task Pipeline** — Implement generates subtasks from decision, runs sequentially with auto-advance
+- **Deep onboard** — `/h-onboard --deep` generates task plan from coverage gaps
+
+### v7 — Desktop Loop MVP
+
+One proved cycle: **Decision → Implement → Verify → Baseline → PR draft**. If verification fails → reopen as ProblemCard, not straight to PR. Local-first PR output.
+
+### v8 — Governor Signals
+
+Background detection loops (stale, drift, dependencies) with dashboard alerts. Autonomous actuation only after trust is earned through detect-only phase.
+
+### Not on the roadmap
+
+Cloud/SaaS. Mobile app. Slack bot. Browser extension. General personal assistant. Competing with Claude Code on code editing. The product is the engineering governor, not another surface.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,30 @@ The binary is the same — only the MCP config and command/prompt installation l
 
 Existing project? Run `/h-onboard` after init — the agent scans your codebase for existing decisions worth capturing.
 
+## CI
+
+Use `haft check` anywhere you want a pass/fail signal for governance debt:
+
+```yaml
+# .github/workflows/haft-check.yml
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Install haft
+    run: |
+      curl -fsSL https://raw.githubusercontent.com/m0n0x41d/haft/main/install.sh | bash
+      echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+  - name: Check governance debt
+    run: haft check
+```
+
+`haft check` scans stale artifacts, drifted decisions, unassessed decisions, and coverage gaps.
+Exit `0` means the project is clean. Governance findings exit `1`. Command or setup errors also
+fail the job with a non-zero exit code, which keeps CI badges red for both unhealthy and broken states.
+
+Need machine-readable output? Run `haft check --json`.
+
 ---
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Haft is the engineering governor that sits between your intentions and your agen
 
 **Think → Run → Govern.**
 
-Not a coding agent. Not a documentation tool. Not a project manager. The handle between the tool and the hand — the part that turns raw capability into directed engineering work.
+Not a coding agent. Not a documentation tool. The handle between the tool and the hand — the part that turns raw capability into directed engineering work.
 
 ### Two primary surfaces
 
@@ -75,30 +75,6 @@ The binary is the same — only the MCP config and command/prompt installation l
 **Important for Cursor:** After init, open Cursor Settings → MCP → find `haft` → enable the toggle. Cursor adds MCP servers as disabled by default.
 
 Existing project? Run `/h-onboard` after init — the agent scans your codebase for existing decisions worth capturing.
-
-## CI
-
-Use `haft check` anywhere you want a pass/fail signal for governance debt:
-
-```yaml
-# .github/workflows/haft-check.yml
-steps:
-  - uses: actions/checkout@v4
-
-  - name: Install haft
-    run: |
-      curl -fsSL https://raw.githubusercontent.com/m0n0x41d/haft/main/install.sh | bash
-      echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-  - name: Check governance debt
-    run: haft check
-```
-
-`haft check` scans stale artifacts, drifted decisions, unassessed decisions, and coverage gaps.
-Exit `0` means the project is clean. Governance findings exit `1`. Command or setup errors also
-fail the job with a non-zero exit code, which keeps CI badges red for both unhealthy and broken states.
-
-Need machine-readable output? Run `haft check --json`.
 
 ---
 
@@ -178,35 +154,30 @@ Features: dashboard with governance findings, problem board, decision detail wit
 ### v6.1 — Harden the Contract (shipped)
 
 Decision quality enforcement before automating execution:
-- `haft check` for CI governance verification
-- `/h-verify` surfaces full governance state (problems, invariants, drift — not just decisions)
+- `haft check` for local governance verification (exit 0 = clean, exit 1 = findings)
+- `/h-verify` surfaces full governance state (problems, invariants, drift)
 - `.haft/workflow.md` — repo-level agent policy, injected into every prompt
 - Problem typing (optimization / diagnosis / search / synthesis)
 - G1/G2/G4 enforcement: one decision per problem, parity warnings, subjective dimension detection
-- CL0+supports rejection, claim-scoped R_eff and evidence supersession
+- Claim-scoped R_eff, evidence supersession, CL0 rejection
 - Deep `/h-onboard` with module-by-module analysis for legacy projects
 
 ### v6.2 — Dashboard + Execution Primitives (next)
 
-The desktop becomes an operator surface, not just a viewer:
-- **Unified Dashboard** — active decisions, governance findings, automations in one view
+The desktop becomes an operator surface:
+- **Unified Dashboard** — decisions, governance findings, automations in one view
 - **Implement** — click a decision, agent spawns in worktree with full reasoning context
-- **Adopt** — governance finding (stale/drifted) → agent thread for interactive resolution
+- **Adopt** — governance finding → agent thread for interactive resolution
 - **Automation triggers** — CI fail, dependency update, scheduled → auto-create ProblemCards
-- **DDR→Task Pipeline** — Implement generates subtasks from decision, runs sequentially with auto-advance
-- **Deep onboard** — `/h-onboard --deep` generates task plan from coverage gaps
+- **DDR→Task Pipeline** — Implement generates subtasks from decision, auto-advance mode
 
 ### v7 — Desktop Loop MVP
 
-One proved cycle: **Decision → Implement → Verify → Baseline → PR draft**. If verification fails → reopen as ProblemCard, not straight to PR. Local-first PR output.
+One proved cycle: **Decision → Implement → Verify → Baseline → PR draft**. Verification failure → reopen as ProblemCard.
 
 ### v8 — Governor Signals
 
-Background detection loops (stale, drift, dependencies) with dashboard alerts. Autonomous actuation only after trust is earned through detect-only phase.
-
-### Not on the roadmap
-
-Cloud/SaaS. Mobile app. Slack bot. Browser extension. General personal assistant. Competing with Claude Code on code editing. The product is the engineering governor, not another surface.
+Background detection loops (stale, drift, dependencies) with dashboard alerts. Autonomous actuation after trust is earned.
 
 ---
 

--- a/desktop/agents.go
+++ b/desktop/agents.go
@@ -26,6 +26,7 @@ const (
 
 const (
 	taskOutputMaxLines      = 500
+	taskOutputMaxChars      = 64000
 	taskOutputFlushInterval = 350 * time.Millisecond
 )
 
@@ -53,8 +54,8 @@ type TaskState struct {
 	StartedAt      string `json:"started_at"`
 	CompletedAt    string `json:"completed_at"`
 	ErrorMessage   string `json:"error_message"`
-	Output         string `json:"output"` // bounded output tail
-	AutoRun        bool   `json:"auto_run"`       // true = agent runs without pausing
+	Output         string `json:"output"`   // bounded output tail
+	AutoRun        bool   `json:"auto_run"` // true = agent runs without pausing
 }
 
 type TaskOutputEvent struct {
@@ -464,14 +465,30 @@ func (b *taskOutputBuffer) Append(chunk string) string {
 		b.lines = append([]string(nil), b.lines[len(b.lines)-b.maxLines:]...)
 	}
 
-	return b.snapshotLocked()
+	snapshot := b.snapshotLocked()
+	normalized := normalizeTaskOutput(snapshot)
+
+	if normalized != snapshot {
+		b.lines = nil
+		b.partial = normalized
+	}
+
+	return normalized
 }
 
 func (b *taskOutputBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	return b.snapshotLocked()
+	snapshot := b.snapshotLocked()
+	normalized := normalizeTaskOutput(snapshot)
+
+	if normalized != snapshot {
+		b.lines = nil
+		b.partial = normalized
+	}
+
+	return normalized
 }
 
 func (b *taskOutputBuffer) snapshotLocked() string {
@@ -485,6 +502,43 @@ func (b *taskOutputBuffer) snapshotLocked() string {
 
 	parts := append(append([]string(nil), b.lines...), b.partial)
 	return strings.Join(parts, "\n")
+}
+
+func normalizeTaskOutput(output string) string {
+	bounded := trimTaskOutputLines(output, taskOutputMaxLines)
+	bounded = trimTaskOutputRunes(bounded, taskOutputMaxChars)
+	return bounded
+}
+
+func trimTaskOutputLines(output string, maxLines int) string {
+	if output == "" || maxLines <= 0 {
+		return output
+	}
+
+	lines := strings.Split(output, "\n")
+
+	if len(lines) <= maxLines {
+		return output
+	}
+
+	start := len(lines) - maxLines
+	tail := lines[start:]
+	return strings.Join(tail, "\n")
+}
+
+func trimTaskOutputRunes(output string, maxRunes int) string {
+	if output == "" || maxRunes <= 0 {
+		return output
+	}
+
+	runes := []rune(output)
+
+	if len(runes) <= maxRunes {
+		return output
+	}
+
+	start := len(runes) - maxRunes
+	return string(runes[start:])
 }
 
 // --- App binding methods ---

--- a/desktop/agents_test.go
+++ b/desktop/agents_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTaskOutputBufferKeepsNewestLongSingleLine(t *testing.T) {
+	buffer := newTaskOutputBuffer(taskOutputMaxLines, "")
+	head := "STARTMARKER"
+	tail := strings.Repeat("tail", 2000) + "ENDMARKER"
+	body := strings.Repeat("H", taskOutputMaxChars)
+	longLine := head + body + tail
+
+	got := buffer.Append(longLine)
+
+	if utf8.RuneCountInString(got) > taskOutputMaxChars {
+		t.Fatalf("expected output <= %d runes, got %d", taskOutputMaxChars, utf8.RuneCountInString(got))
+	}
+
+	if strings.Contains(got, "STARTMARKER") {
+		t.Fatalf("expected oldest prefix marker to be trimmed from output")
+	}
+
+	if !strings.HasSuffix(got, "ENDMARKER") {
+		t.Fatalf("expected newest output tail to be preserved, got suffix %q", got[maxInt(len(got)-32, 0):])
+	}
+}
+
+func TestNormalizeTaskOutputKeepsNewestLines(t *testing.T) {
+	lines := make([]string, 0, taskOutputMaxLines+25)
+
+	for i := range taskOutputMaxLines + 25 {
+		lines = append(lines, fmt.Sprintf("line-%03d", i))
+	}
+
+	output := strings.Join(lines, "\n")
+	got := normalizeTaskOutput(output)
+	gotLines := strings.Split(got, "\n")
+
+	if len(gotLines) != taskOutputMaxLines {
+		t.Fatalf("expected %d lines after normalization, got %d", taskOutputMaxLines, len(gotLines))
+	}
+
+	if gotLines[0] != "line-025" {
+		t.Fatalf("expected first retained line line-025, got %q", gotLines[0])
+	}
+
+	if gotLines[len(gotLines)-1] != "line-524" {
+		t.Fatalf("expected last retained line line-524, got %q", gotLines[len(gotLines)-1])
+	}
+}
+
+func maxInt(a int, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -145,17 +145,29 @@ func (a *App) GetDashboard() (*DashboardView, error) {
 	stale, _ := a.store.FindStaleArtifacts(a.ctx)
 	notes, _ := a.store.ListActiveByKind(a.ctx, artifact.KindNote, 50)
 	portfolios, _ := a.store.ListActiveByKind(a.ctx, artifact.KindSolutionPortfolio, 100)
+	statusData, err := artifact.FetchStatusData(a.ctx, a.store, "")
+	if err != nil {
+		return nil, err
+	}
+
+	healthyDecisions := mapArtifacts(statusData.HealthyDecisions, toDecisionView, 8)
+	pendingDecisions := mapArtifacts(statusData.PendingDecisions, toDecisionView, 8)
+	unassessedDecisions := mapArtifacts(statusData.UnassessedDecisions, toDecisionView, 8)
+	recentDecisions := mapArtifacts(decisions, toDecisionView, 8)
 
 	return &DashboardView{
-		ProjectName:     a.projectName,
-		ProblemCount:    len(problems),
-		DecisionCount:   len(decisions),
-		PortfolioCount:  len(portfolios),
-		NoteCount:       len(notes),
-		StaleCount:      len(stale),
-		RecentProblems:  mapArtifacts(problems, toProblemView, 8),
-		RecentDecisions: mapArtifacts(decisions, toDecisionView, 8),
-		StaleItems:      mapArtifacts(stale, toArtifactView, 10),
+		ProjectName:         a.projectName,
+		ProblemCount:        len(problems),
+		DecisionCount:       len(decisions),
+		PortfolioCount:      len(portfolios),
+		NoteCount:           len(notes),
+		StaleCount:          len(stale),
+		RecentProblems:      mapArtifacts(problems, toProblemView, 8),
+		RecentDecisions:     safeDecisionViews(recentDecisions),
+		HealthyDecisions:    safeDecisionViews(healthyDecisions),
+		PendingDecisions:    safeDecisionViews(pendingDecisions),
+		UnassessedDecisions: safeDecisionViews(unassessedDecisions),
+		StaleItems:          mapArtifacts(stale, toArtifactView, 10),
 	}, nil
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   PanelLeftClose,
   PanelLeftOpen,
@@ -57,6 +57,14 @@ export default function App() {
   const [notifications, setNotifications] = useState<DesktopNotification[]>([]);
   const [terminalOpen, setTerminalOpen] = useState(false);
 
+  const refreshTasks = useCallback(() => {
+    return listTasks()
+      .then(setTasks)
+      .catch((error) => {
+        reportError(error, "tasks");
+      });
+  }, []);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -87,19 +95,15 @@ export default function App() {
   }, [refreshKey]);
 
   useEffect(() => {
-    const load = () =>
-      listTasks()
-        .then(setTasks)
-        .catch((error) => {
-          reportError(error, "tasks");
-        });
+    void refreshTasks();
 
-    load();
-    // Sidebar task list: 10s poll is enough for status dots.
-    // Tasks.tsx has its own 2s poll + event-driven updates for the active task.
-    const interval = setInterval(load, 10000);
+    // Single shared polling loop for both sidebar badges and Tasks page.
+    const interval = setInterval(() => {
+      void refreshTasks();
+    }, 2000);
+
     return () => clearInterval(interval);
-  }, [refreshKey]);
+  }, [refreshKey, refreshTasks]);
 
   useEffect(() => {
     const stopListening = listenForErrors((detail) => {
@@ -370,6 +374,9 @@ export default function App() {
                 selectedTaskId={selectedId}
                 showNewTask={showNewTask}
                 onNewTaskClose={() => setShowNewTask(false)}
+                tasks={tasks}
+                onTasksChange={setTasks}
+                onTasksRefresh={refreshTasks}
               />
             )}
             {page === "settings" && (

--- a/desktop/frontend/src/lib/api.ts
+++ b/desktop/frontend/src/lib/api.ts
@@ -11,6 +11,9 @@ export interface DashboardData {
   stale_count: number;
   recent_problems: ProblemSummary[];
   recent_decisions: DecisionSummary[];
+  healthy_decisions: DecisionSummary[];
+  pending_decisions: DecisionSummary[];
+  unassessed_decisions: DecisionSummary[];
   stale_items: ArtifactSummary[];
 }
 
@@ -944,6 +947,9 @@ export async function getDashboard(): Promise<DashboardData> {
     stale_count: mockGovernanceOverview.findings.length,
     recent_problems: mockProblems,
     recent_decisions: mockDecisions,
+    healthy_decisions: mockDecisions,
+    pending_decisions: [],
+    unassessed_decisions: [],
     stale_items: mockGovernanceOverview.findings.map((finding) => ({
       id: finding.artifact_ref,
       kind: finding.kind,

--- a/desktop/frontend/src/pages/Dashboard.tsx
+++ b/desktop/frontend/src/pages/Dashboard.tsx
@@ -198,27 +198,28 @@ export function Dashboard({ onNavigate }: { onNavigate: NavigateFn }) {
             <CoverageSummary overview={overview} />
           </Section>
 
-          <Section title="Recent Decisions">
-            {data.recent_decisions.length === 0 ? (
+          <Section title="Decision Health">
+            {data.healthy_decisions.length === 0 &&
+            data.pending_decisions.length === 0 &&
+            data.unassessed_decisions.length === 0 ? (
               <EmptyState text="No active decisions" />
             ) : (
-              <div className="space-y-2">
-                {data.recent_decisions.map((decision: DecisionSummary) => (
-                  <button
-                    key={decision.id}
-                    onClick={() => onNavigate("decisions", decision.id)}
-                    className="w-full rounded-xl border border-border bg-surface-1 px-4 py-3 text-left transition-colors hover:border-border-bright hover:bg-surface-2"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="text-sm font-medium text-text-primary">{decision.selected_title}</span>
-                      <span className="font-mono text-[11px] text-text-muted">{decision.id}</span>
-                    </div>
-                    <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-text-muted">
-                      <span>WLNK: {decision.weakest_link}</span>
-                      {decision.valid_until && <span>Valid until {decision.valid_until}</span>}
-                    </div>
-                  </button>
-                ))}
+              <div className="space-y-4">
+                <DecisionBucket
+                  title="Shipped / Healthy"
+                  decisions={data.healthy_decisions}
+                  onOpenDecision={(decisionID) => onNavigate("decisions", decisionID)}
+                />
+                <DecisionBucket
+                  title="Pending"
+                  decisions={data.pending_decisions}
+                  onOpenDecision={(decisionID) => onNavigate("decisions", decisionID)}
+                />
+                <DecisionBucket
+                  title="Unassessed"
+                  decisions={data.unassessed_decisions}
+                  onOpenDecision={(decisionID) => onNavigate("decisions", decisionID)}
+                />
               </div>
             )}
           </Section>
@@ -246,6 +247,48 @@ export function Dashboard({ onNavigate }: { onNavigate: NavigateFn }) {
           </Section>
         </div>
       </div>
+    </div>
+  );
+}
+
+function DecisionBucket({
+  title,
+  decisions,
+  onOpenDecision,
+}: {
+  title: string;
+  decisions: DecisionSummary[];
+  onOpenDecision: (decisionID: string) => void;
+}) {
+  if (decisions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] uppercase tracking-[0.22em] text-text-muted">{title}</p>
+        <span className="rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[11px] text-text-secondary">
+          {decisions.length}
+        </span>
+      </div>
+
+      {decisions.map((decision) => (
+        <button
+          key={decision.id}
+          onClick={() => onOpenDecision(decision.id)}
+          className="w-full rounded-xl border border-border bg-surface-1 px-4 py-3 text-left transition-colors hover:border-border-bright hover:bg-surface-2"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium text-text-primary">{decision.selected_title}</span>
+            <span className="font-mono text-[11px] text-text-muted">{decision.id}</span>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-text-muted">
+            <span>WLNK: {decision.weakest_link}</span>
+            {decision.valid_until && <span>Valid until {decision.valid_until}</span>}
+          </div>
+        </button>
+      ))}
     </div>
   );
 }

--- a/desktop/frontend/src/pages/Tasks.tsx
+++ b/desktop/frontend/src/pages/Tasks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react";
 
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 import {
@@ -30,12 +30,18 @@ export function Tasks({
   selectedTaskId: externalSelectedTask,
   showNewTask: externalShow,
   onNewTaskClose,
+  tasks: controlledTasks,
+  onTasksChange,
+  onTasksRefresh,
 }: {
   selectedTaskId?: string | null;
   showNewTask?: boolean;
   onNewTaskClose?: () => void;
+  tasks?: TaskState[];
+  onTasksChange?: Dispatch<SetStateAction<TaskState[]>>;
+  onTasksRefresh?: () => Promise<void> | void;
 } = {}) {
-  const [tasks, setTasks] = useState<TaskState[]>([]);
+  const [internalTasks, setInternalTasks] = useState<TaskState[]>([]);
   const [agents, setAgents] = useState<InstalledAgent[]>([]);
   const [config, setConfig] = useState<DesktopConfig | null>(null);
   const [internalShow, setInternalShow] = useState(false);
@@ -43,6 +49,8 @@ export function Tasks({
   const [showHandoff, setShowHandoff] = useState(false);
   const [handoffAgent, setHandoffAgent] = useState("codex");
   const outputRef = useRef<HTMLDivElement | null>(null);
+  const tasks = controlledTasks ?? internalTasks;
+  const setTasks = onTasksChange ?? setInternalTasks;
 
   const showNewTask = externalShow || internalShow;
 
@@ -55,13 +63,18 @@ export function Tasks({
   };
 
   const refresh = useCallback(async () => {
+    if (onTasksRefresh) {
+      await onTasksRefresh();
+      return;
+    }
+
     try {
       const nextTasks = await listTasks();
       setTasks(nextTasks);
     } catch (error) {
       reportError(error, "tasks");
     }
-  }, []);
+  }, [onTasksRefresh, setTasks]);
 
   useEffect(() => {
     if (externalShow) {
@@ -90,16 +103,20 @@ export function Tasks({
         reportError(error, "task config");
       });
 
-    void refresh();
-
-    const interval = window.setInterval(() => {
+    if (!onTasksRefresh) {
       void refresh();
-    }, 2000);
 
-    return () => {
-      window.clearInterval(interval);
-    };
-  }, [refresh]);
+      const interval = window.setInterval(() => {
+        void refresh();
+      }, 2000);
+
+      return () => {
+        window.clearInterval(interval);
+      };
+    }
+
+    return undefined;
+  }, [onTasksRefresh, refresh]);
 
   useEffect(() => {
     const stopOutput = EventsOn("task.output", (payload: TaskOutputEvent) => {

--- a/desktop/projects.go
+++ b/desktop/projects.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/m0n0x41d/haft/db"
 	"github.com/m0n0x41d/haft/internal/project"
@@ -77,14 +80,64 @@ func saveRegistry(reg *ProjectRegistry) error {
 	return atomicWriteFile(path, data, 0o644)
 }
 
-// atomicWriteFile writes data to a temp file then renames — prevents
-// corruption if two concurrent calls race or the process crashes mid-write.
+var atomicWriteMu sync.Mutex
+
+// atomicWriteFile serializes concurrent writers, writes to a unique temp file,
+// then renames atomically. This avoids torn JSON writes under concurrent saves.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, perm); err != nil {
+	atomicWriteMu.Lock()
+	defer atomicWriteMu.Unlock()
+
+	release, err := acquireAtomicWriteLock(path + ".lock")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	defer release()
+
+	dir := filepath.Dir(path)
+	prefix := filepath.Base(path) + "."
+	tmpFile, err := os.CreateTemp(dir, prefix+"*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	if err := tmpFile.Chmod(perm); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}
+
+func acquireAtomicWriteLock(lockPath string) (func(), error) {
+	deadline := time.Now().Add(2 * time.Second)
+
+	for {
+		file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		switch {
+		case err == nil:
+			_ = file.Close()
+			return func() {
+				_ = os.Remove(lockPath)
+			}, nil
+		case errors.Is(err, os.ErrExist):
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("acquire write lock %s: timeout", lockPath)
+			}
+			time.Sleep(10 * time.Millisecond)
+		default:
+			return nil, err
+		}
+	}
 }
 
 // --- App binding methods for project management ---

--- a/desktop/projects_test.go
+++ b/desktop/projects_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/m0n0x41d/haft/internal/project"
@@ -109,5 +112,53 @@ func TestStartupUsesExplicitProjectRootInsteadOfCurrentWorkingDirectory(t *testi
 
 	if app.projectRoot != expectedRoot {
 		t.Fatalf("expected project root %q, got %q", expectedRoot, app.projectRoot)
+	}
+}
+
+func TestAtomicWriteFile_ConcurrentWritersLeaveValidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "desktop-projects.json")
+	payloads := make([][]byte, 0, 12)
+
+	for index := range 12 {
+		payloads = append(payloads, []byte(
+			strings.ReplaceAll(
+				`{"projects":[{"path":"/tmp/project-INDEX","name":"project","id":"proj-INDEX"}]}`,
+				"INDEX",
+				string(rune('0'+index)),
+			),
+		))
+	}
+
+	var wg sync.WaitGroup
+	for _, payload := range payloads {
+		wg.Add(1)
+		go func(payload []byte) {
+			defer wg.Done()
+			if err := atomicWriteFile(path, payload, 0o644); err != nil {
+				t.Errorf("atomicWriteFile: %v", err)
+			}
+		}(payload)
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var registry ProjectRegistry
+	if err := json.Unmarshal(data, &registry); err != nil {
+		t.Fatalf("written file must stay valid JSON, got %q: %v", string(data), err)
+	}
+
+	matchesKnownPayload := false
+	for _, payload := range payloads {
+		if string(data) == string(payload) {
+			matchesKnownPayload = true
+			break
+		}
+	}
+	if !matchesKnownPayload {
+		t.Fatalf("final file should match one complete payload, got %q", string(data))
 	}
 }

--- a/desktop/task_store.go
+++ b/desktop/task_store.go
@@ -68,7 +68,7 @@ func (s *desktopTaskStore) UpsertTask(ctx context.Context, state TaskState) erro
 		state.WorktreePath,
 		boolToInt(state.ReusedWorktree),
 		state.ErrorMessage,
-		state.Output,
+		normalizeTaskOutput(state.Output),
 		state.StartedAt,
 		nullString(state.CompletedAt),
 		nowRFC3339(),
@@ -87,7 +87,7 @@ func (s *desktopTaskStore) UpdateOutput(ctx context.Context, id string, output s
 		`UPDATE desktop_tasks
 		SET output_tail = ?, updated_at = ?
 		WHERE id = ?`,
-		output,
+		normalizeTaskOutput(output),
 		nowRFC3339(),
 		id,
 	)
@@ -205,7 +205,7 @@ func (s *desktopTaskStore) GetTaskOutput(ctx context.Context, id string) (string
 		return "", err
 	}
 
-	return output, nil
+	return normalizeTaskOutput(output), nil
 }
 
 func (s *desktopTaskStore) MarkRunningTasksInterrupted(ctx context.Context, projectPath string) error {
@@ -331,6 +331,7 @@ func scanTaskState(scanner rowScanner) (TaskState, error) {
 	state.Worktree = worktree == 1
 	state.ReusedWorktree = reusedWorktree == 1
 	state.AutoRun = autoRun == 1
+	state.Output = normalizeTaskOutput(state.Output)
 
 	return state, nil
 }

--- a/desktop/task_store_test.go
+++ b/desktop/task_store_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/m0n0x41d/haft/db"
 )
@@ -91,5 +93,91 @@ func TestDesktopTaskStoreRoundTrip(t *testing.T) {
 
 	if len(remaining) != 0 {
 		t.Fatalf("expected archived task to be hidden, got %d task(s)", len(remaining))
+	}
+}
+
+func TestDesktopTaskStoreNormalizesLegacyOutputOnRead(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "haft.db")
+
+	database, err := db.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer database.Close()
+
+	store := newDesktopTaskStore(database.GetRawDB())
+	ctx := context.Background()
+	rawOutput := strings.Repeat("legacy-output-", 7000) + "ENDMARKER"
+
+	_, err = database.GetRawDB().ExecContext(
+		ctx,
+		`INSERT INTO desktop_tasks (
+			id,
+			project_name,
+			project_path,
+			title,
+			agent,
+			status,
+			prompt,
+			branch,
+			worktree,
+			worktree_path,
+			reused_worktree,
+			error_message,
+			output_tail,
+			started_at,
+			completed_at,
+			updated_at,
+			archived_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL)`,
+		"legacy-task",
+		"haft",
+		"/tmp/haft",
+		"Legacy output",
+		"codex",
+		"completed",
+		"Inspect legacy output handling",
+		"",
+		0,
+		"",
+		0,
+		"",
+		rawOutput,
+		nowRFC3339(),
+		nowRFC3339(),
+	)
+	if err != nil {
+		t.Fatalf("insert legacy task: %v", err)
+	}
+
+	tasks, err := store.ListTasks(ctx, "/tmp/haft")
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+
+	if utf8.RuneCountInString(tasks[0].Output) > taskOutputMaxChars {
+		t.Fatalf("expected listed task output <= %d runes, got %d", taskOutputMaxChars, utf8.RuneCountInString(tasks[0].Output))
+	}
+
+	if !strings.HasSuffix(tasks[0].Output, "ENDMARKER") {
+		t.Fatalf("expected listed task output to preserve newest tail")
+	}
+
+	output, err := store.GetTaskOutput(ctx, "legacy-task")
+	if err != nil {
+		t.Fatalf("GetTaskOutput: %v", err)
+	}
+
+	if utf8.RuneCountInString(output) > taskOutputMaxChars {
+		t.Fatalf("expected fetched task output <= %d runes, got %d", taskOutputMaxChars, utf8.RuneCountInString(output))
+	}
+
+	if !strings.HasSuffix(output, "ENDMARKER") {
+		t.Fatalf("expected fetched task output to preserve newest tail")
 	}
 }

--- a/desktop/views.go
+++ b/desktop/views.go
@@ -29,6 +29,13 @@ func safeArtifactViews(s []ArtifactView) []ArtifactView {
 	return s
 }
 
+func safeDecisionViews(s []DecisionView) []DecisionView {
+	if s == nil {
+		return []DecisionView{}
+	}
+	return s
+}
+
 func safeRejections(s []RejectionView) []RejectionView {
 	if s == nil {
 		return []RejectionView{}
@@ -94,19 +101,23 @@ func safeDimensions(s []DimensionView) []DimensionView {
 	}
 	return s
 }
+
 // No domain logic here — just data projection.
 
 // DashboardView is the landing page data.
 type DashboardView struct {
-	ProjectName     string         `json:"project_name"`
-	ProblemCount    int            `json:"problem_count"`
-	DecisionCount   int            `json:"decision_count"`
-	PortfolioCount  int            `json:"portfolio_count"`
-	NoteCount       int            `json:"note_count"`
-	StaleCount      int            `json:"stale_count"`
-	RecentProblems  []ProblemView  `json:"recent_problems"`
-	RecentDecisions []DecisionView `json:"recent_decisions"`
-	StaleItems      []ArtifactView `json:"stale_items"`
+	ProjectName         string         `json:"project_name"`
+	ProblemCount        int            `json:"problem_count"`
+	DecisionCount       int            `json:"decision_count"`
+	PortfolioCount      int            `json:"portfolio_count"`
+	NoteCount           int            `json:"note_count"`
+	StaleCount          int            `json:"stale_count"`
+	RecentProblems      []ProblemView  `json:"recent_problems"`
+	RecentDecisions     []DecisionView `json:"recent_decisions"`
+	HealthyDecisions    []DecisionView `json:"healthy_decisions"`
+	PendingDecisions    []DecisionView `json:"pending_decisions"`
+	UnassessedDecisions []DecisionView `json:"unassessed_decisions"`
+	StaleItems          []ArtifactView `json:"stale_items"`
 }
 
 // ArtifactView is the minimal representation for lists and search results.
@@ -227,9 +238,9 @@ type ClaimView struct {
 // EvidenceItemView is a single piece of evidence with F/G/R decomposition.
 type EvidenceItemView struct {
 	ID              string   `json:"id"`
-	Type            string   `json:"type"`    // measurement, test, research, benchmark, audit
+	Type            string   `json:"type"` // measurement, test, research, benchmark, audit
 	Content         string   `json:"content"`
-	Verdict         string   `json:"verdict"` // supports, weakens, refutes
+	Verdict         string   `json:"verdict"`          // supports, weakens, refutes
 	FormalityLevel  int      `json:"formality_level"`  // F0=informal, F1=test, F2=formal, F3=proof
 	CongruenceLevel int      `json:"congruence_level"` // CL0-CL3
 	ClaimRefs       []string `json:"claim_refs"`       // which claims this covers

--- a/install.sh
+++ b/install.sh
@@ -92,6 +92,7 @@ find_archive_binary() {
 find_archive_tui_bundle() {
     local archive_root="$1"
     local candidates=(
+        "$archive_root/tui.mjs"
         "$archive_root/tui/bundle.mjs"
         "$archive_root/tui/tui.mjs"
         "$archive_root/bundle.mjs"

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ YELLOW='\033[33m'
 CYAN='\033[36m'
 WHITE='\033[37m'
 
-REPO="m0n0x41d/quint-code"
+REPO="m0n0x41d/haft"
 BIN_NAME="haft"
 BIN_DIRS=("$HOME/.local/bin" "/usr/local/bin")
 TUI_INSTALL_DIR="$HOME/.haft/tui"

--- a/internal/agentloop/coordinator_test.go
+++ b/internal/agentloop/coordinator_test.go
@@ -112,8 +112,8 @@ func TestComputeClosedCycleAssurance_SyncsArtifactEvidenceAndTraversesDependenci
 		t.Fatalf("query synced evidence: %v", err)
 	}
 
-	if storedVerdict != "accepted" {
-		t.Fatalf("stored verdict = %q, want accepted", storedVerdict)
+	if storedVerdict != "supports" {
+		t.Fatalf("stored verdict = %q, want supports", storedVerdict)
 	}
 	if storedFormality != 2 {
 		t.Fatalf("stored formality = %d, want 2", storedFormality)

--- a/internal/artifact/core_boundary_test.go
+++ b/internal/artifact/core_boundary_test.go
@@ -1,0 +1,74 @@
+package artifact
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCorePackagesDoNotDependOnDesktop(t *testing.T) {
+	root := projectRootFromTestFile(t)
+	patterns := []string{
+		"./internal/artifact/...",
+		"./internal/graph/...",
+		"./internal/fpf/...",
+		"./internal/reff/...",
+		"./internal/codebase/...",
+	}
+	args := append([]string{"list", "-deps"}, patterns...)
+	cmd := exec.Command("go", args...)
+	cmd.Dir = root
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps failed: %v\n%s", err, output)
+	}
+
+	offenders := collectDesktopDependencies(string(output))
+	if len(offenders) == 0 {
+		return
+	}
+
+	t.Fatalf("core packages depend on desktop packages:\n%s", strings.Join(offenders, "\n"))
+}
+
+func projectRootFromTestFile(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func collectDesktopDependencies(output string) []string {
+	offenders := make([]string, 0)
+	seen := make(map[string]struct{})
+
+	for _, line := range strings.Split(output, "\n") {
+		importPath := strings.TrimSpace(line)
+		if importPath == "" || strings.HasPrefix(importPath, "go:") {
+			continue
+		}
+		if !isDesktopImportPath(importPath) {
+			continue
+		}
+		if _, exists := seen[importPath]; exists {
+			continue
+		}
+
+		seen[importPath] = struct{}{}
+		offenders = append(offenders, importPath)
+	}
+
+	return offenders
+}
+
+func isDesktopImportPath(importPath string) bool {
+	return importPath == "github.com/m0n0x41d/haft/desktop" ||
+		strings.HasPrefix(importPath, "github.com/m0n0x41d/haft/desktop/")
+}

--- a/internal/artifact/decision.go
+++ b/internal/artifact/decision.go
@@ -1323,11 +1323,17 @@ func Measure(ctx context.Context, store ArtifactStore, haftDir string, input Mea
 		input.CriteriaNotMet,
 		criteriaNotMetScope,
 	)
+	measurementItems := decisionMeasurementEvidenceItems(
+		decisionFields.Claims,
+		*evidenceItem,
+		claimEvidence,
+	)
 	activeEvidence, err := decisionActiveClaimEvidenceAfterMeasurement(
 		ctx,
 		store,
 		a.Meta.ID,
-		claimEvidence,
+		decisionFields.Claims,
+		measurementItems,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("load claim evidence: %w", err)
@@ -1381,8 +1387,12 @@ func Measure(ctx context.Context, store ArtifactStore, haftDir string, input Mea
 
 	evidenceItem.CongruenceLevel = measureCL
 	evidenceItem.FormalityLevel = 2
+	for index := range measurementItems {
+		measurementItems[index].CongruenceLevel = measureCL
+		measurementItems[index].FormalityLevel = 2
+	}
 
-	if err := store.CommitMeasurement(ctx, a, evidenceItem); err != nil {
+	if err := store.CommitMeasurement(ctx, a, measurementItems); err != nil {
 		return nil, fmt.Errorf("record measurement: %w", err)
 	}
 
@@ -1398,6 +1408,7 @@ func decisionActiveClaimEvidenceAfterMeasurement(
 	ctx context.Context,
 	store ArtifactStore,
 	decisionID string,
+	decisionClaims []DecisionClaim,
 	incoming []EvidenceItem,
 ) ([]EvidenceItem, error) {
 	items, err := store.GetEvidenceItems(ctx, decisionID)
@@ -1406,12 +1417,33 @@ func decisionActiveClaimEvidenceAfterMeasurement(
 	}
 
 	active := make([]EvidenceItem, 0, len(items)+len(incoming))
+	incomingKeys := make([][]string, 0, len(incoming))
+
+	for _, item := range incoming {
+		incomingKeys = append(incomingKeys, measurementBindingKeys(decisionClaims, item))
+	}
 
 	for _, item := range items {
 		if item.Verdict == "superseded" {
 			continue
 		}
-		if item.Type == "measurement" {
+		if item.Type != "measurement" {
+			active = append(active, item)
+			continue
+		}
+
+		existingKeys := measurementBindingKeys(decisionClaims, item)
+		overlapsIncoming := false
+
+		for _, keys := range incomingKeys {
+			if !measurementKeysOverlap(existingKeys, keys) {
+				continue
+			}
+
+			overlapsIncoming = true
+			break
+		}
+		if overlapsIncoming {
 			continue
 		}
 
@@ -1421,6 +1453,81 @@ func decisionActiveClaimEvidenceAfterMeasurement(
 	active = append(active, incoming...)
 
 	return active, nil
+}
+
+func decisionMeasurementEvidenceItems(
+	claims []DecisionClaim,
+	base EvidenceItem,
+	claimEvidence []EvidenceItem,
+) []EvidenceItem {
+	if len(claimEvidence) == 0 {
+		return []EvidenceItem{base}
+	}
+
+	normalizedClaims := normalizeDecisionClaims(claims)
+	aliasIndex := buildDecisionClaimAliasIndex(normalizedClaims)
+	scopeByPrediction := make(map[int][]string, len(normalizedClaims))
+	sharedScope := make([]string, 0, len(base.ClaimScope))
+	claimIndex := make(map[string]int, len(normalizedClaims))
+	items := make([]EvidenceItem, 0, len(claimEvidence))
+
+	for index, claim := range normalizedClaims {
+		claimIndex[claim.ID] = index
+	}
+
+	for _, scope := range normalizeClaimScope(base.ClaimScope) {
+		predictionIndex, ok := resolvePredictionAlias(scope, aliasIndex)
+		if ok {
+			scopeByPrediction[predictionIndex] = append(scopeByPrediction[predictionIndex], scope)
+			continue
+		}
+
+		sharedScope = append(sharedScope, scope)
+	}
+
+	for index, claimItem := range claimEvidence {
+		item := base
+		item.ID = fmt.Sprintf("%s-claim-%03d", base.ID, index+1)
+		item.Verdict = claimItem.Verdict
+		item.ClaimRefs = normalizeClaimRefs(claimItem.ClaimRefs)
+		item.ClaimScope = decisionMeasurementClaimScope(
+			normalizedClaims,
+			item.ClaimRefs,
+			claimIndex,
+			scopeByPrediction,
+			sharedScope,
+		)
+		items = append(items, item)
+	}
+
+	return items
+}
+
+func decisionMeasurementClaimScope(
+	claims []DecisionClaim,
+	claimRefs []string,
+	claimIndex map[string]int,
+	scopeByPrediction map[int][]string,
+	sharedScope []string,
+) []string {
+	scope := make([]string, 0, len(sharedScope)+len(claimRefs))
+	scope = append(scope, sharedScope...)
+
+	for _, ref := range normalizeClaimRefs(claimRefs) {
+		index, ok := claimIndex[ref]
+		if !ok {
+			continue
+		}
+
+		scope = append(scope, scopeByPrediction[index]...)
+	}
+
+	scope = normalizeClaimScope(scope)
+	if len(scope) > 0 {
+		return scope
+	}
+
+	return decisionClaimScopeFromRefs(claims, claimRefs)
 }
 
 // AttachEvidence adds an evidence item to any artifact.

--- a/internal/artifact/decision.go
+++ b/internal/artifact/decision.go
@@ -512,6 +512,154 @@ func MergeProblemRefs(single string, multiple []string) []string {
 	return refs
 }
 
+func decisionBlocksReplacement(status Status) bool {
+	return status == StatusActive || status == StatusRefreshDue
+}
+
+func resolvePortfolioProblemRefs(portfolio *Artifact) []string {
+	if portfolio == nil {
+		return nil
+	}
+
+	resolvedRefs := []string{}
+	fields := portfolio.UnmarshalPortfolioFields()
+
+	if fields.ProblemRef != "" {
+		resolvedRefs = appendUniqueString(resolvedRefs, fields.ProblemRef)
+	}
+
+	for _, link := range portfolio.Meta.Links {
+		if link.Type != "based_on" {
+			continue
+		}
+		if !strings.HasPrefix(link.Ref, KindProblemCard.IDPrefix()+"-") {
+			continue
+		}
+
+		resolvedRefs = appendUniqueString(resolvedRefs, link.Ref)
+	}
+
+	sort.Strings(resolvedRefs)
+	return resolvedRefs
+}
+
+func resolveDecisionProblemRefs(ctx context.Context, store ArtifactStore, decision *Artifact) []string {
+	if decision == nil {
+		return nil
+	}
+
+	resolvedRefs := cloneStringSlice(decision.UnmarshalDecisionFields().ProblemRefs)
+
+	for _, link := range decision.Meta.Links {
+		if link.Type != "based_on" {
+			continue
+		}
+
+		if strings.HasPrefix(link.Ref, KindProblemCard.IDPrefix()+"-") {
+			resolvedRefs = appendUniqueString(resolvedRefs, link.Ref)
+			continue
+		}
+
+		linkedArtifact, err := store.Get(ctx, link.Ref)
+		if err != nil {
+			continue
+		}
+		if linkedArtifact.Meta.Kind != KindSolutionPortfolio {
+			continue
+		}
+
+		for _, problemRef := range resolvePortfolioProblemRefs(linkedArtifact) {
+			resolvedRefs = appendUniqueString(resolvedRefs, problemRef)
+		}
+	}
+
+	sort.Strings(resolvedRefs)
+	return resolvedRefs
+}
+
+func resolveIncomingDecisionProblemRefs(
+	ctx context.Context,
+	store ArtifactStore,
+	problemRefs []string,
+	portfolioRef string,
+) []string {
+	resolvedRefs := cloneStringSlice(problemRefs)
+
+	if portfolioRef == "" {
+		sort.Strings(resolvedRefs)
+		return resolvedRefs
+	}
+
+	portfolio, err := store.Get(ctx, portfolioRef)
+	if err != nil || portfolio.Meta.Kind != KindSolutionPortfolio {
+		sort.Strings(resolvedRefs)
+		return resolvedRefs
+	}
+
+	for _, problemRef := range resolvePortfolioProblemRefs(portfolio) {
+		resolvedRefs = appendUniqueString(resolvedRefs, problemRef)
+	}
+
+	sort.Strings(resolvedRefs)
+	return resolvedRefs
+}
+
+func validateNoActiveDecisionConflict(
+	ctx context.Context,
+	store ArtifactStore,
+	problemRefs []string,
+	portfolioRef string,
+) error {
+	resolvedIncomingRefs := resolveIncomingDecisionProblemRefs(ctx, store, problemRefs, portfolioRef)
+
+	if len(resolvedIncomingRefs) == 0 {
+		return nil
+	}
+
+	decisions, err := store.ListByKind(ctx, KindDecisionRecord, 0)
+	if err != nil {
+		return fmt.Errorf("list decision records: %w", err)
+	}
+
+	for _, decision := range decisions {
+		if !decisionBlocksReplacement(decision.Meta.Status) {
+			continue
+		}
+
+		fullDecision, err := store.Get(ctx, decision.Meta.ID)
+		if err != nil {
+			continue
+		}
+
+		for _, existingProblemRef := range resolveDecisionProblemRefs(ctx, store, fullDecision) {
+			if !slicesContains(resolvedIncomingRefs, existingProblemRef) {
+				continue
+			}
+
+			return fmt.Errorf(
+				"problem_ref %s already has live DecisionRecord %s (%s) — supersede the previous decision or close the problem first",
+				existingProblemRef,
+				fullDecision.Meta.ID,
+				fullDecision.Meta.Title,
+			)
+		}
+	}
+
+	return nil
+}
+
+func slicesContains(values []string, target string) bool {
+	for _, value := range values {
+		if value != target {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
 // BuildLinks constructs artifact links from problem refs and portfolio ref. Pure.
 func BuildLinks(problemRefs []string, portfolioRef string) []Link {
 	var links []Link
@@ -528,6 +676,11 @@ func BuildLinks(problemRefs []string, portfolioRef string) []Link {
 func Decide(ctx context.Context, store ArtifactStore, haftDir string, input DecideInput) (*Artifact, string, error) {
 	input = normalizeDecisionInput(input)
 
+	problemRefs := MergeProblemRefs(input.ProblemRef, input.ProblemRefs)
+	if err := validateNoActiveDecisionConflict(ctx, store, problemRefs, input.PortfolioRef); err != nil {
+		return nil, "", err
+	}
+
 	seq, err := store.NextSequence(ctx, KindDecisionRecord)
 	if err != nil {
 		return nil, "", fmt.Errorf("generate ID: %w", err)
@@ -537,7 +690,6 @@ func Decide(ctx context.Context, store ArtifactStore, haftDir string, input Deci
 	now := time.Now().UTC()
 
 	// Pure: merge refs
-	problemRefs := MergeProblemRefs(input.ProblemRef, input.ProblemRefs)
 	links := BuildLinks(problemRefs, input.PortfolioRef)
 
 	// Effects: compute mode from chain

--- a/internal/artifact/decision.go
+++ b/internal/artifact/decision.go
@@ -1467,6 +1467,11 @@ func AttachEvidence(ctx context.Context, store ArtifactStore, input EvidenceInpu
 	if input.FormalityLevel < 0 {
 		input.FormalityLevel = defaultEvidenceFormalityLevel(input.Type)
 	}
+	storedVerdict := canonicalStoredEvidenceVerdict(input.Type, input.Verdict)
+	err = validateEvidenceCongruenceAtIngest(storedVerdict, input.CongruenceLevel)
+	if err != nil {
+		return nil, err
+	}
 
 	id := fmt.Sprintf("evid-%s-%09d", time.Now().Format("20060102"), time.Now().UnixNano()%1000000000)
 
@@ -1474,7 +1479,7 @@ func AttachEvidence(ctx context.Context, store ArtifactStore, input EvidenceInpu
 		ID:              id,
 		Type:            input.Type,
 		Content:         input.Content,
-		Verdict:         input.Verdict,
+		Verdict:         storedVerdict,
 		CarrierRef:      input.CarrierRef,
 		CongruenceLevel: input.CongruenceLevel,
 		FormalityLevel:  normalizeFormalityLevel(input.FormalityLevel),

--- a/internal/artifact/decision_health.go
+++ b/internal/artifact/decision_health.go
@@ -1,0 +1,116 @@
+package artifact
+
+import "context"
+
+// DecisionMaturity is the derived maturity axis for active decisions.
+type DecisionMaturity string
+
+const (
+	DecisionMaturityUnassessed DecisionMaturity = "Unassessed"
+	DecisionMaturityPending    DecisionMaturity = "Pending"
+	DecisionMaturityShipped    DecisionMaturity = "Shipped"
+)
+
+// DecisionFreshness is the derived freshness axis for shipped decisions.
+type DecisionFreshness string
+
+const (
+	DecisionFreshnessHealthy DecisionFreshness = "Healthy"
+	DecisionFreshnessStale   DecisionFreshness = "Stale"
+	DecisionFreshnessAtRisk  DecisionFreshness = "AT RISK"
+)
+
+// DecisionHealth is the derived, never-stored decision health view.
+type DecisionHealth struct {
+	Maturity  DecisionMaturity
+	Freshness DecisionFreshness
+}
+
+func (health DecisionHealth) Label() string {
+	if health.Maturity != DecisionMaturityShipped {
+		return string(health.Maturity)
+	}
+
+	if health.Freshness == "" {
+		return string(health.Maturity)
+	}
+
+	return string(health.Maturity) + " / " + string(health.Freshness)
+}
+
+// DeriveDecisionHealth computes the derived maturity + freshness view from
+// active evidence only. The result is never persisted.
+func DeriveDecisionHealth(ctx context.Context, store ArtifactStore, decisionID string) DecisionHealth {
+	items, err := store.GetEvidenceItems(ctx, decisionID)
+	if err != nil {
+		return DecisionHealth{Maturity: DecisionMaturityUnassessed}
+	}
+
+	activeItems := activeEvidenceItems(items)
+	if len(activeItems) == 0 {
+		return DecisionHealth{Maturity: DecisionMaturityUnassessed}
+	}
+
+	if !hasAcceptedMeasurementEvidence(activeItems) {
+		return DecisionHealth{Maturity: DecisionMaturityPending}
+	}
+
+	health := DecisionHealth{Maturity: DecisionMaturityShipped}
+	reliability := ComputeWLNKSummary(ctx, store, decisionID).REff
+
+	if reliability < 0.3 {
+		health.Freshness = DecisionFreshnessAtRisk
+		return health
+	}
+
+	if reliability < 0.5 {
+		health.Freshness = DecisionFreshnessStale
+		return health
+	}
+
+	health.Freshness = DecisionFreshnessHealthy
+	return health
+}
+
+func activeEvidenceItems(items []EvidenceItem) []EvidenceItem {
+	activeItems := make([]EvidenceItem, 0, len(items))
+
+	for _, item := range items {
+		if item.Verdict == "superseded" {
+			continue
+		}
+
+		activeItems = append(activeItems, item)
+	}
+
+	return activeItems
+}
+
+func hasAcceptedMeasurementEvidence(items []EvidenceItem) bool {
+	for _, item := range items {
+		if item.Type != "measurement" {
+			continue
+		}
+
+		if item.Verdict == "supports" || item.Verdict == "accepted" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasMeasurement(ctx context.Context, store ArtifactStore, decisionID string) bool {
+	items, err := store.GetEvidenceItems(ctx, decisionID)
+	if err != nil {
+		return false
+	}
+
+	for _, item := range activeEvidenceItems(items) {
+		if item.Type == "measurement" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/artifact/decision_measure_test.go
+++ b/internal/artifact/decision_measure_test.go
@@ -482,12 +482,13 @@ func TestMeasure_KeepsActiveAttachedEvidenceOnUntouchedClaims(t *testing.T) {
 	}
 
 	_, err = AttachEvidence(ctx, store, EvidenceInput{
-		ArtifactRef: dec.Meta.ID,
-		Content:     "Benchmark confirms latency stayed under 50ms.",
-		Type:        "benchmark",
-		Verdict:     "supports",
-		ClaimRefs:   []string{"claim-001"},
-		ClaimScope:  []string{"Latency stays under 50ms"},
+		ArtifactRef:     dec.Meta.ID,
+		Content:         "Benchmark confirms latency stayed under 50ms.",
+		Type:            "benchmark",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimRefs:       []string{"claim-001"},
+		ClaimScope:      []string{"Latency stays under 50ms"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -641,11 +642,12 @@ func TestAttachEvidence_AcceptsEquivalentClaimRefsAndScopeInDifferentOrders(t *t
 	}))
 
 	item, err := AttachEvidence(ctx, store, EvidenceInput{
-		ArtifactRef: dec.Meta.ID,
-		Content:     "Equivalent binding in a different order.",
-		Type:        "benchmark",
-		Verdict:     "supports",
-		ClaimRefs:   []string{"claim-002", "claim-001"},
+		ArtifactRef:     dec.Meta.ID,
+		Content:         "Equivalent binding in a different order.",
+		Type:            "benchmark",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimRefs:       []string{"claim-002", "claim-001"},
 		ClaimScope: []string{
 			"Latency stays under 50ms",
 			"Throughput stays above 100k events/sec",
@@ -698,11 +700,12 @@ func TestAttachEvidence_AcceptsMixedCoverageLabelsWithResolvableClaimScope(t *te
 	}
 
 	item, err := AttachEvidence(ctx, store, EvidenceInput{
-		ArtifactRef: dec.Meta.ID,
-		Content:     "Latency acceptance and throughput benchmark both passed.",
-		Type:        "benchmark",
-		Verdict:     "supports",
-		ClaimRefs:   []string{"claim-001", "claim-002"},
+		ArtifactRef:     dec.Meta.ID,
+		Content:         "Latency acceptance and throughput benchmark both passed.",
+		Type:            "benchmark",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimRefs:       []string{"claim-001", "claim-002"},
 		ClaimScope: []string{
 			"P99 latency under 50ms",
 			"throughput",
@@ -740,11 +743,12 @@ func TestAttachEvidence_ResolvesClaimRefsFromLegacyScope(t *testing.T) {
 	}
 
 	item, err := AttachEvidence(ctx, store, EvidenceInput{
-		ArtifactRef: dec.Meta.ID,
-		Content:     "Load test: p99 latency stayed at 42ms.",
-		Type:        "benchmark",
-		Verdict:     "supports",
-		ClaimScope:  []string{"latency"},
+		ArtifactRef:     dec.Meta.ID,
+		Content:         "Load test: p99 latency stayed at 42ms.",
+		Type:            "benchmark",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimScope:      []string{"latency"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -793,12 +797,13 @@ func TestWLNKSummary_PrefersStoredClaimScopeOverClaimText(t *testing.T) {
 	}
 
 	err = store.AddEvidenceItem(ctx, &EvidenceItem{
-		ID:         "evid-throughput-only",
-		Type:       "benchmark",
-		Content:    "Latency evidence only.",
-		Verdict:    "supports",
-		ClaimRefs:  []string{"claim-001"},
-		ClaimScope: []string{"P99 latency under 50ms"},
+		ID:              "evid-throughput-only",
+		Type:            "benchmark",
+		Content:         "Latency evidence only.",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimRefs:       []string{"claim-001"},
+		ClaimScope:      []string{"P99 latency under 50ms"},
 	}, dec.Meta.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -847,11 +852,12 @@ func TestWLNKSummary_ClaimRefCoverageSatisfiesAliasedAcceptanceCriterion(t *test
 	}
 
 	_, err = AttachEvidence(ctx, store, EvidenceInput{
-		ArtifactRef: dec.Meta.ID,
-		Content:     "Benchmark confirms the latency envelope held.",
-		Type:        "benchmark",
-		Verdict:     "supports",
-		ClaimRefs:   []string{"claim-001"},
+		ArtifactRef:     dec.Meta.ID,
+		Content:         "Benchmark confirms the latency envelope held.",
+		Type:            "benchmark",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimRefs:       []string{"claim-001"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -895,11 +901,12 @@ func TestWLNKSummary_KeepsDistinctCoverageForClaimsWithSharedText(t *testing.T) 
 	}
 
 	err = store.AddEvidenceItem(ctx, &EvidenceItem{
-		ID:        "evid-duplicate-claim-text",
-		Type:      "benchmark",
-		Content:   "Both latency measurements passed.",
-		Verdict:   "supports",
-		ClaimRefs: []string{"claim-001", "claim-002"},
+		ID:              "evid-duplicate-claim-text",
+		Type:            "benchmark",
+		Content:         "Both latency measurements passed.",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimRefs:       []string{"claim-001", "claim-002"},
 	}, dec.Meta.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -1379,7 +1386,7 @@ func TestREff_CL1Penalty(t *testing.T) {
 	assertREff(t, wlnk.REff, 0.6)
 }
 
-func TestREff_CL0Penalty(t *testing.T) {
+func TestAttachEvidence_RejectsCL0SupportingEvidence(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()
 	haftDir := t.TempDir()
@@ -1389,19 +1396,28 @@ func TestREff_CL0Penalty(t *testing.T) {
 		WhySelected:   "Because",
 	}))
 
-	// CL0: supports(1.0) - 0.9 = 0.1
-	// This also verifies CL=0 is NOT silently upgraded to CL=3 (known issue S4)
-	AttachEvidence(ctx, store, EvidenceInput{
+	_, err := AttachEvidence(ctx, store, EvidenceInput{
 		ArtifactRef:     dec.Meta.ID,
 		Content:         "Opposed context evidence",
 		Verdict:         "supports",
 		CongruenceLevel: 0,
-		FormalityLevel:  0, // also 0 — should NOT be defaulted
+		FormalityLevel:  0,
 		ValidUntil:      "2027-01-01T00:00:00Z",
 	})
+	if err == nil {
+		t.Fatal("expected CL0 supporting evidence to be rejected")
+	}
+	if err.Error() != cl0EvidenceSupportsError {
+		t.Fatalf("error = %q, want %q", err.Error(), cl0EvidenceSupportsError)
+	}
 
-	wlnk := ComputeWLNKSummary(ctx, store, dec.Meta.ID)
-	assertREff(t, wlnk.REff, 0.1)
+	items, err := store.GetEvidenceItems(ctx, dec.Meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no stored evidence items, got %d", len(items))
+	}
 }
 
 func TestREff_ExpiredEvidence(t *testing.T) {

--- a/internal/artifact/decision_measure_test.go
+++ b/internal/artifact/decision_measure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -183,15 +184,14 @@ func TestMeasure_UpdatesPredictionStatusToSupported(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("expected 1 evidence item, got %d", len(items))
-	}
-	if got := strings.Join(items[0].ClaimRefs, ","); got != "claim-001,claim-002" {
-		t.Fatalf("measurement claim_refs = %q, want claim-001,claim-002", got)
-	}
-	if got := strings.Join(items[0].ClaimScope, ","); got != "Throughput stays above 100k events/sec,publish latency p99 < 50ms" {
-		t.Fatalf("measurement claim_scope = %q, want preserved measured claim scope", got)
-	}
+	assertMeasurementItemVerdicts(t, items, map[string]string{
+		"claim-001": "supports",
+		"claim-002": "supports",
+	})
+	assertMeasurementItemScopes(t, items, map[string]string{
+		"claim-001": "publish latency p99 < 50ms",
+		"claim-002": "Throughput stays above 100k events/sec",
+	})
 
 	reloaded, err := store.Get(ctx, dec.Meta.ID)
 	if err != nil {
@@ -375,14 +375,14 @@ func TestMeasure_PreservesUnverifiedPredictionStatusWhenNothingMatches(t *testin
 	})
 }
 
-func TestMeasure_ResetsUntouchedPredictionsWhenLaterMeasurementSupersedesPriorEvidence(t *testing.T) {
+func TestMeasure_KeepsUntouchedPredictionsWhenLaterMeasurementSupersedesOnlyMatchingClaimEvidence(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()
 	haftDir := t.TempDir()
 
 	dec, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
 		SelectedTitle: "JetStream",
-		WhySelected:   "Prediction state should only move when the measurement touches that claim.",
+		WhySelected:   "Supersession must be claim-scoped.",
 		Predictions: []PredictionInput{
 			{
 				Claim:      "Latency stays under 50ms",
@@ -390,9 +390,9 @@ func TestMeasure_ResetsUntouchedPredictionsWhenLaterMeasurementSupersedesPriorEv
 				Threshold:  "< 50ms",
 			},
 			{
-				Claim:      "Throughput stays above 100k events/sec",
-				Observable: "throughput",
-				Threshold:  "> 100k events/sec",
+				Claim:      "Latency stays under 50ms",
+				Observable: "consumer latency p99",
+				Threshold:  "< 50ms",
 			},
 		},
 	}))
@@ -402,10 +402,10 @@ func TestMeasure_ResetsUntouchedPredictionsWhenLaterMeasurementSupersedesPriorEv
 
 	_, err = Measure(ctx, store, haftDir, MeasureInput{
 		DecisionRef: dec.Meta.ID,
-		Findings:    "Both rollout checks passed.",
+		Findings:    "Both latency checks passed.",
 		CriteriaMet: []string{
 			"publish latency p99 < 50ms (observed: 42ms)",
-			"Throughput stays above 100k events/sec (observed: 120k events/sec)",
+			"consumer latency p99 < 50ms (observed: 38ms)",
 		},
 		Verdict: "accepted",
 	})
@@ -415,9 +415,9 @@ func TestMeasure_ResetsUntouchedPredictionsWhenLaterMeasurementSupersedesPriorEv
 
 	_, err = Measure(ctx, store, haftDir, MeasureInput{
 		DecisionRef: dec.Meta.ID,
-		Findings:    "The follow-up run only rechecked throughput and it regressed.",
+		Findings:    "The follow-up run only rechecked consumer latency and it regressed.",
 		CriteriaNotMet: []string{
-			"Throughput stays above 100k events/sec (observed: 87k events/sec)",
+			"consumer latency p99 < 50ms (observed: 61ms)",
 		},
 		Verdict: "partial",
 	})
@@ -431,7 +431,7 @@ func TestMeasure_ResetsUntouchedPredictionsWhenLaterMeasurementSupersedesPriorEv
 	}
 
 	assertDecisionPredictionStatuses(t, reloaded, []ClaimStatus{
-		ClaimStatusUnverified,
+		ClaimStatusSupported,
 		ClaimStatusRefuted,
 	})
 
@@ -439,20 +439,16 @@ func TestMeasure_ResetsUntouchedPredictionsWhenLaterMeasurementSupersedesPriorEv
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(items) != 2 {
-		t.Fatalf("expected 2 measurement evidence items, got %d", len(items))
-	}
-	verdictByClaimRefs := make(map[string]string, len(items))
-
-	for _, item := range items {
-		verdictByClaimRefs[strings.Join(item.ClaimRefs, ",")] = item.Verdict
+	if len(items) != 3 {
+		t.Fatalf("expected 3 measurement evidence items, got %d", len(items))
 	}
 
-	if got := verdictByClaimRefs["claim-002"]; got == "superseded" {
-		t.Fatalf("latest measurement for claim-002 should stay active, got verdict %q", got)
+	verdictsByClaimRef := measurementVerdictsByClaimRef(items)
+	if got := verdictsByClaimRef["claim-001"]; !reflect.DeepEqual(got, []string{"supports"}) {
+		t.Fatalf("claim-001 verdict history = %#v, want [supports]", got)
 	}
-	if got := verdictByClaimRefs["claim-001,claim-002"]; got != "superseded" {
-		t.Fatalf("prior overlapping measurement should be superseded, got verdict %q", got)
+	if got := verdictsByClaimRef["claim-002"]; !reflect.DeepEqual(got, []string{"refutes", "superseded"}) {
+		t.Fatalf("claim-002 verdict history = %#v, want [refutes superseded]", got)
 	}
 }
 
@@ -1015,6 +1011,67 @@ func assertDecisionPredictionStatuses(t *testing.T, decision *Artifact, want []C
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("prediction statuses = %#v, want %#v", got, want)
 	}
+}
+
+func assertMeasurementItemVerdicts(t *testing.T, items []EvidenceItem, want map[string]string) {
+	t.Helper()
+
+	if len(items) != len(want) {
+		t.Fatalf("expected %d measurement evidence items, got %d", len(want), len(items))
+	}
+
+	for _, item := range items {
+		if len(item.ClaimRefs) != 1 {
+			t.Fatalf("measurement claim_refs = %#v, want exactly one claim_ref per item", item.ClaimRefs)
+		}
+
+		claimRef := item.ClaimRefs[0]
+		wantVerdict, ok := want[claimRef]
+		if !ok {
+			t.Fatalf("unexpected measurement claim_ref %q", claimRef)
+		}
+		if item.Verdict != wantVerdict {
+			t.Fatalf("measurement verdict for %s = %q, want %q", claimRef, item.Verdict, wantVerdict)
+		}
+	}
+}
+
+func assertMeasurementItemScopes(t *testing.T, items []EvidenceItem, want map[string]string) {
+	t.Helper()
+
+	for _, item := range items {
+		if len(item.ClaimRefs) != 1 {
+			t.Fatalf("measurement claim_refs = %#v, want exactly one claim_ref per item", item.ClaimRefs)
+		}
+
+		claimRef := item.ClaimRefs[0]
+		wantScope, ok := want[claimRef]
+		if !ok {
+			t.Fatalf("unexpected measurement claim_ref %q", claimRef)
+		}
+		if got := strings.Join(item.ClaimScope, ","); got != wantScope {
+			t.Fatalf("measurement claim_scope for %s = %q, want %q", claimRef, got, wantScope)
+		}
+	}
+}
+
+func measurementVerdictsByClaimRef(items []EvidenceItem) map[string][]string {
+	result := make(map[string][]string, len(items))
+
+	for _, item := range items {
+		if len(item.ClaimRefs) != 1 {
+			continue
+		}
+
+		claimRef := item.ClaimRefs[0]
+		result[claimRef] = append(result[claimRef], item.Verdict)
+	}
+
+	for claimRef := range result {
+		sort.Strings(result[claimRef])
+	}
+
+	return result
 }
 
 func TestAttachEvidence_MissingArtifact(t *testing.T) {

--- a/internal/artifact/decision_measure_test.go
+++ b/internal/artifact/decision_measure_test.go
@@ -61,8 +61,8 @@ func TestMeasure_Success(t *testing.T) {
 	if len(items) == 0 {
 		t.Error("expected evidence item from measurement")
 	}
-	if items[0].Verdict != "partial" {
-		t.Errorf("evidence verdict = %q, want partial", items[0].Verdict)
+	if items[0].Verdict != "weakens" {
+		t.Errorf("evidence verdict = %q, want weakens", items[0].Verdict)
 	}
 	if items[0].FormalityLevel != 2 {
 		t.Errorf("evidence formality = %d, want 2", items[0].FormalityLevel)
@@ -90,6 +90,54 @@ func TestMeasure_MissingRequired(t *testing.T) {
 	_, err = Measure(ctx, store, t.TempDir(), MeasureInput{DecisionRef: "x", Findings: "y"})
 	if err == nil {
 		t.Error("expected error for missing verdict")
+	}
+}
+
+func TestMeasure_NormalizesVerdictAliasesBeforeStorage(t *testing.T) {
+	cases := []struct {
+		name    string
+		verdict string
+		want    string
+	}{
+		{name: "accepted", verdict: "accepted", want: "supports"},
+		{name: "partial", verdict: "partial", want: "weakens"},
+		{name: "failed", verdict: "failed", want: "refutes"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := setupTestDB(t)
+			ctx := context.Background()
+			haftDir := t.TempDir()
+
+			dec, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+				SelectedTitle: "JetStream",
+				WhySelected:   "Verify measurement verdict normalization",
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = Measure(ctx, store, haftDir, MeasureInput{
+				DecisionRef: dec.Meta.ID,
+				Findings:    "Measured outcome recorded.",
+				Verdict:     tc.verdict,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			items, err := store.GetEvidenceItems(ctx, dec.Meta.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(items) != 1 {
+				t.Fatalf("expected 1 evidence item, got %d", len(items))
+			}
+			if got := items[0].Verdict; got != tc.want {
+				t.Fatalf("stored verdict = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -942,8 +990,8 @@ func TestMeasure_RollsBackDecisionAndEvidenceWhenMeasurementInsertFails(t *testi
 	if len(items) != 1 {
 		t.Fatalf("expected original evidence to remain after rollback, got %d item(s)", len(items))
 	}
-	if items[0].Verdict != "accepted" {
-		t.Fatalf("existing evidence verdict = %q, want accepted after rollback", items[0].Verdict)
+	if items[0].Verdict != "supports" {
+		t.Fatalf("existing evidence verdict = %q, want supports after rollback", items[0].Verdict)
 	}
 }
 

--- a/internal/artifact/decision_test.go
+++ b/internal/artifact/decision_test.go
@@ -352,6 +352,196 @@ func TestDecide_RejectsSelectedVariantAsRejectedAlternative(t *testing.T) {
 	}
 }
 
+func TestDecide_RejectsDuplicateLiveDecisionForProblem(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title:  "Event pipeline redesign",
+		Signal: "Current broker drops messages during failover.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("NATS", "cluster tuning", "Lean broker with smaller operational surface."),
+			testVariant("Kafka", "ops overhead", "Mature streaming platform with heavier operations."),
+		},
+		NoSteppingStoneRationale: "Both variants are direct production paths.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  firstPortfolio.Meta.ID,
+		SelectedTitle: "NATS",
+		WhySelected:   "Smaller operational surface wins at the current scale.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("RabbitMQ quorum", "migration risk", "Reuse existing AMQP tooling with a more resilient queue mode."),
+			testVariant("Kafka", "ops overhead", "Mature streaming platform with heavier operations."),
+		},
+		NoSteppingStoneRationale: "Both variants still target the same production decision.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  secondPortfolio.Meta.ID,
+		SelectedTitle: "RabbitMQ quorum",
+		WhySelected:   "It would reduce migration effort.",
+	}))
+	if err == nil {
+		t.Fatal("expected duplicate live decision error")
+	}
+	if !strings.Contains(err.Error(), problem.Meta.ID) {
+		t.Fatalf("expected problem_ref in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), firstDecision.Meta.ID) {
+		t.Fatalf("expected existing decision ref in error, got %v", err)
+	}
+}
+
+func TestDecide_RejectsPortfolioOnlyDecisionWhenProblemAlreadyHasLiveDecision(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title:  "Auth token rotation",
+		Signal: "Refresh tokens stay valid after key rotation.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Rotate signing key in place", "cache invalidation", "Smaller code change, but clients may cache the old verifier."),
+			testVariant("Dual-key grace period", "operational complexity", "Accept both keys during the migration window."),
+		},
+		NoSteppingStoneRationale: "Both variants are immediate production candidates.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  firstPortfolio.Meta.ID,
+		SelectedTitle: "Dual-key grace period",
+		WhySelected:   "It avoids breaking active sessions during rotation.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Opaque sessions", "storage growth", "Move token validity to server-side session lookup."),
+			testVariant("Dual-key grace period", "operational complexity", "Keep the current token model with safer rotation."),
+		},
+		NoSteppingStoneRationale: "Both variants remain valid responses to the same problem.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		PortfolioRef:  secondPortfolio.Meta.ID,
+		SelectedTitle: "Opaque sessions",
+		WhySelected:   "It centralizes revocation control.",
+	}))
+	if err == nil {
+		t.Fatal("expected duplicate live decision error for portfolio-only lineage")
+	}
+	if !strings.Contains(err.Error(), problem.Meta.ID) {
+		t.Fatalf("expected derived problem_ref in error, got %v", err)
+	}
+}
+
+func TestDecide_AllowsReplacementAfterSupersede(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title:  "Background job queue",
+		Signal: "Queue latency is rising faster than expected.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Single Redis queue", "head-of-line blocking", "Keep the architecture simple and local."),
+			testVariant("Sharded Redis queues", "routing complexity", "Split heavy and light jobs into separate lanes."),
+		},
+		NoSteppingStoneRationale: "Both variants are direct implementation paths.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  firstPortfolio.Meta.ID,
+		SelectedTitle: "Single Redis queue",
+		WhySelected:   "It is enough until job volume proves otherwise.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = SupersedeArtifact(ctx, store, haftDir, firstDecision.Meta.ID, "", "A broader queue redesign replaced the first choice.")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: problem.Meta.ID,
+		Variants: []Variant{
+			testVariant("Sharded Redis queues", "routing complexity", "Split heavy and light jobs into separate lanes."),
+			testVariant("Postgres-backed queue", "db load", "Reuse existing operational tooling for jobs."),
+		},
+		NoSteppingStoneRationale: "Both variants remain immediate candidates after the supersession.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacementDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
+		ProblemRef:    problem.Meta.ID,
+		PortfolioRef:  secondPortfolio.Meta.ID,
+		SelectedTitle: "Sharded Redis queues",
+		WhySelected:   "Volume now justifies splitting hot and cold workloads.",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacementDecision.Meta.ID == "" {
+		t.Fatal("expected replacement decision to be created")
+	}
+}
+
 func TestApply_ReturnsBody(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/artifact/iface.go
+++ b/internal/artifact/iface.go
@@ -48,7 +48,7 @@ type ArtifactStore interface {
 	AddEvidenceItem(ctx context.Context, item *EvidenceItem, artifactRef string) error
 	GetEvidenceItems(ctx context.Context, artifactRef string) ([]EvidenceItem, error)
 	SupersedeEvidenceByType(ctx context.Context, artifactRef string, evidenceType string) error
-	CommitMeasurement(ctx context.Context, decision *Artifact, item *EvidenceItem) error
+	CommitMeasurement(ctx context.Context, decision *Artifact, items []EvidenceItem) error
 
 	// Timing
 	LastRefreshScan(ctx context.Context) time.Time

--- a/internal/artifact/problem.go
+++ b/internal/artifact/problem.go
@@ -11,6 +11,7 @@ import (
 // ProblemFrameInput is the input for framing a problem.
 type ProblemFrameInput struct {
 	Title                 string   `json:"title"`
+	ProblemType           string   `json:"problem_type,omitempty"`
 	Signal                string   `json:"signal"`
 	Constraints           []string `json:"constraints,omitempty"`
 	OptimizationTargets   []string `json:"optimization_targets,omitempty"`
@@ -50,12 +51,15 @@ func BuildProblemArtifact(id string, now time.Time, input ProblemFrameInput, rec
 	if input.Signal == "" {
 		return nil, fmt.Errorf("signal is required — what's anomalous or broken?")
 	}
+	problemType, err := ParseProblemType(input.ProblemType)
+	if err != nil {
+		return nil, err
+	}
 
 	var mode Mode
 	if input.Mode == "" {
 		mode = ModeStandard
 	} else {
-		var err error
 		mode, err = ParseMode(input.Mode)
 		if err != nil {
 			return nil, fmt.Errorf("%w (valid: note, tactical, standard, deep)", err)
@@ -65,6 +69,10 @@ func BuildProblemArtifact(id string, now time.Time, input ProblemFrameInput, rec
 	var body strings.Builder
 	body.WriteString(fmt.Sprintf("# %s\n\n", input.Title))
 	body.WriteString(fmt.Sprintf("## Signal\n\n%s\n", input.Signal))
+
+	if problemType != "" {
+		body.WriteString(fmt.Sprintf("\n## Problem Type\n\n%s\n", problemType))
+	}
 
 	if len(input.Constraints) > 0 {
 		body.WriteString("\n## Constraints\n\n")
@@ -120,6 +128,7 @@ func BuildProblemArtifact(id string, now time.Time, input ProblemFrameInput, rec
 
 	// Populate structured data — canonical fields alongside markdown body
 	sd, _ := json.Marshal(ProblemFields{
+		ProblemType:           problemType,
 		Signal:                input.Signal,
 		Constraints:           input.Constraints,
 		OptimizationTargets:   input.OptimizationTargets,

--- a/internal/artifact/problem_test.go
+++ b/internal/artifact/problem_test.go
@@ -12,9 +12,10 @@ func TestFrameProblem_Success(t *testing.T) {
 	haftDir := t.TempDir()
 
 	input := ProblemFrameInput{
-		Title:   "Webhook delivery unreliable",
-		Signal:  "Payment webhook retries hitting 15% failure rate",
-		Context: "payments",
+		Title:       "Webhook delivery unreliable",
+		ProblemType: string(ProblemTypeDiagnosis),
+		Signal:      "Payment webhook retries hitting 15% failure rate",
+		Context:     "payments",
 		Constraints: []string{
 			"Must maintain <500ms p99 latency",
 			"Cannot break existing merchant integrations",
@@ -43,6 +44,9 @@ func TestFrameProblem_Success(t *testing.T) {
 	if a.Meta.Mode != ModeStandard {
 		t.Errorf("mode = %q, want standard", a.Meta.Mode)
 	}
+	if got := a.UnmarshalProblemFields().ProblemType; got != ProblemTypeDiagnosis {
+		t.Errorf("problem_type = %q, want %q", got, ProblemTypeDiagnosis)
+	}
 	if filePath == "" {
 		t.Error("file path should not be empty")
 	}
@@ -53,6 +57,9 @@ func TestFrameProblem_Success(t *testing.T) {
 	}
 	if !strings.Contains(a.Body, "## Constraints") {
 		t.Error("missing Constraints section")
+	}
+	if !strings.Contains(a.Body, "## Problem Type") {
+		t.Error("missing Problem Type section")
 	}
 	if !strings.Contains(a.Body, "## Optimization Targets") {
 		t.Error("missing Optimization Targets section")
@@ -98,6 +105,20 @@ func TestFrameProblem_MissingSignal(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("expected error for missing signal")
+	}
+}
+
+func TestFrameProblem_InvalidProblemType(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	_, _, err := FrameProblem(ctx, store, t.TempDir(), ProblemFrameInput{
+		Title:       "Some problem",
+		ProblemType: "mystery",
+		Signal:      "something is broken",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid problem_type")
 	}
 }
 

--- a/internal/artifact/projection.go
+++ b/internal/artifact/projection.go
@@ -302,21 +302,66 @@ func buildProjectionEvidenceSummary(ctx context.Context, store ArtifactStore, ar
 	}
 
 	measurementCount := 0
-	measurementVerdict := ""
+	measurementVerdict := aggregateMeasurementVerdict(activeItems)
+	measurementRuns := make(map[string]struct{})
+
 	for _, item := range activeItems {
-		if item.Type == "measurement" {
-			measurementCount++
-			if measurementVerdict == "" {
-				measurementVerdict = strings.TrimSpace(item.Verdict)
-			}
+		if item.Type != "measurement" {
+			continue
 		}
+
+		measurementRuns[measurementRunID(item)] = struct{}{}
 	}
+
+	measurementCount = len(measurementRuns)
 
 	return ProjectionEvidenceSummary{
 		MeasurementCount:   measurementCount,
 		MeasurementVerdict: measurementVerdict,
 		WLNK:               ComputeWLNKSummary(ctx, store, artifactID),
 	}
+}
+
+func aggregateMeasurementVerdict(items []EvidenceItem) string {
+	measurementItems := make([]EvidenceItem, 0, len(items))
+
+	for _, item := range items {
+		if item.Type != "measurement" {
+			continue
+		}
+
+		measurementItems = append(measurementItems, item)
+	}
+
+	status := claimStatusFromEvidenceItems(measurementItems)
+	verdict, ok := evidenceVerdictFromClaimStatus(status)
+	if ok {
+		return verdict
+	}
+
+	for _, item := range measurementItems {
+		verdict := strings.TrimSpace(item.Verdict)
+		if verdict != "" {
+			return verdict
+		}
+	}
+
+	return ""
+}
+
+func measurementRunID(item EvidenceItem) string {
+	const claimSuffix = "-claim-"
+
+	if item.Type != "measurement" {
+		return ""
+	}
+
+	index := strings.LastIndex(item.ID, claimSuffix)
+	if index == -1 {
+		return item.ID
+	}
+
+	return item.ID[:index]
 }
 
 func projectionAffectedFilePaths(ctx context.Context, store ArtifactStore, artifactID string) ([]string, error) {

--- a/internal/artifact/projection.go
+++ b/internal/artifact/projection.go
@@ -107,6 +107,7 @@ type DecisionProjection struct {
 	RollbackTriggers     []string
 	RefreshTriggers      []string
 	Evidence             ProjectionEvidenceSummary
+	Health               DecisionHealth
 	Measured             bool
 }
 
@@ -193,6 +194,7 @@ func FetchProjectionGraph(ctx context.Context, store ArtifactStore, contextName 
 		if err != nil {
 			return ProjectionGraph{}, err
 		}
+		health := DeriveDecisionHealth(ctx, store, decision.Meta.ID)
 
 		graph.Decisions = append(graph.Decisions, DecisionProjection{
 			Meta:                 decision.Meta,
@@ -214,6 +216,7 @@ func FetchProjectionGraph(ctx context.Context, store ArtifactStore, contextName 
 			RollbackTriggers:     cloneStringSlice(fields.RollbackTriggers),
 			RefreshTriggers:      cloneStringSlice(fields.RefreshTriggers),
 			Evidence:             buildProjectionEvidenceSummary(ctx, store, decision.Meta.ID),
+			Health:               health,
 			Measured:             hasMeasurement(ctx, store, decision.Meta.ID),
 		})
 	}

--- a/internal/artifact/projection_test.go
+++ b/internal/artifact/projection_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestFetchProjectionGraph_BuildsSharedGraphFromArtifacts(t *testing.T) {
@@ -141,6 +142,82 @@ func TestFetchProjectionGraph_BuildsSharedGraphFromArtifacts(t *testing.T) {
 	}
 	if len(decisionNode.PortfolioRefs) != 1 || decisionNode.PortfolioRefs[0] != portfolio.Meta.ID {
 		t.Fatalf("unexpected decision portfolio refs: %+v", decisionNode.PortfolioRefs)
+	}
+}
+
+func TestFetchProjectionGraph_DerivesDecisionHealthBuckets(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mustCreateDecision := func(id string, title string) {
+		t.Helper()
+
+		err := store.Create(ctx, &Artifact{
+			Meta: Meta{
+				ID:        id,
+				Kind:      KindDecisionRecord,
+				Title:     title,
+				Status:    StatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			Body: title,
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	mustAddEvidence := func(decisionID string, item EvidenceItem) {
+		t.Helper()
+
+		err := store.AddEvidenceItem(ctx, &item, decisionID)
+		if err != nil {
+			t.Fatalf("add evidence to %s: %v", decisionID, err)
+		}
+	}
+
+	mustCreateDecision("dec-unassessed", "Unassessed decision")
+
+	mustCreateDecision("dec-pending", "Pending decision")
+	mustAddEvidence("dec-pending", EvidenceItem{
+		ID:              "evid-pending",
+		Type:            "research",
+		Content:         "Design review completed",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ValidUntil:      now.Add(24 * time.Hour).Format(time.RFC3339),
+	})
+
+	mustCreateDecision("dec-shipped", "Shipped decision")
+	mustAddEvidence("dec-shipped", EvidenceItem{
+		ID:              "evid-shipped",
+		Type:            "measurement",
+		Content:         "Latency target met in rollout",
+		Verdict:         "accepted",
+		CongruenceLevel: 3,
+		ValidUntil:      now.Add(24 * time.Hour).Format(time.RFC3339),
+	})
+
+	graph, err := FetchProjectionGraph(ctx, store, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]DecisionMaturity{}
+	for _, decision := range graph.Decisions {
+		got[decision.Meta.ID] = decision.Health.Maturity
+	}
+
+	want := map[string]DecisionMaturity{
+		"dec-unassessed": DecisionMaturityUnassessed,
+		"dec-pending":    DecisionMaturityPending,
+		"dec-shipped":    DecisionMaturityShipped,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projection decision health = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/artifact/projection_test.go
+++ b/internal/artifact/projection_test.go
@@ -470,8 +470,8 @@ func TestFetchProjectionGraph_UpdatesProjectedPredictionStatusesAfterMeasure(t *
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("projected prediction statuses = %#v, want %#v", got, want)
 	}
-	if got := graphAfterMeasure.Decisions[0].Evidence.MeasurementVerdict; got != "partial" {
-		t.Fatalf("projected measurement verdict = %q, want %q", got, "partial")
+	if got := graphAfterMeasure.Decisions[0].Evidence.MeasurementVerdict; got != "weakens" {
+		t.Fatalf("projected measurement verdict = %q, want %q", got, "weakens")
 	}
 }
 

--- a/internal/artifact/projection_test.go
+++ b/internal/artifact/projection_test.go
@@ -86,11 +86,12 @@ func TestFetchProjectionGraph_BuildsSharedGraphFromArtifacts(t *testing.T) {
 	}
 
 	_, err = AttachEvidence(ctx, store, EvidenceInput{
-		ArtifactRef: decision.Meta.ID,
-		Content:     "Replay benchmark kept p95 latency below 25ms in the candidate environment.",
-		Type:        "measurement",
-		Verdict:     "supports",
-		ClaimScope:  []string{"latency"},
+		ArtifactRef:     decision.Meta.ID,
+		Content:         "Replay benchmark kept p95 latency below 25ms in the candidate environment.",
+		Type:            "measurement",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimScope:      []string{"latency"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/artifact/query.go
+++ b/internal/artifact/query.go
@@ -89,15 +89,17 @@ func decisionCandidatesForAdoption(
 
 // StatusData holds all data needed to render the status dashboard.
 type StatusData struct {
-	ShippedDecisions   []*Artifact
-	PendingDecisions   []*Artifact
-	StaleItems         []StaleItem
-	InProgressProblems []*Artifact
-	InProgressBy       map[string]string // problem ID -> portfolio ID
-	BacklogProblems    []*Artifact
-	AddressedProblems  []*Artifact
-	AddressedBy        map[string]string // problem ID -> decision ID
-	RecentNotes        []*Artifact
+	HealthyDecisions    []*Artifact
+	PendingDecisions    []*Artifact
+	UnassessedDecisions []*Artifact
+	DecisionHealth      map[string]DecisionHealth // decision ID -> derived maturity/freshness
+	StaleItems          []StaleItem
+	InProgressProblems  []*Artifact
+	InProgressBy        map[string]string // problem ID -> portfolio ID
+	BacklogProblems     []*Artifact
+	AddressedProblems   []*Artifact
+	AddressedBy         map[string]string // problem ID -> decision ID
+	RecentNotes         []*Artifact
 }
 
 // FetchStatusData gathers all dashboard data without formatting.
@@ -105,6 +107,7 @@ func FetchStatusData(ctx context.Context, store ArtifactStore, contextFilter str
 	var data StatusData
 	data.InProgressBy = make(map[string]string)
 	data.AddressedBy = make(map[string]string)
+	data.DecisionHealth = make(map[string]DecisionHealth)
 
 	// Active decisions
 	var decisions []*Artifact
@@ -120,10 +123,21 @@ func FetchStatusData(ctx context.Context, store ArtifactStore, contextFilter str
 	}
 	activeDecisions := filterActive(decisions)
 	for _, d := range activeDecisions {
-		if hasMeasurement(ctx, store, d.Meta.ID) {
-			data.ShippedDecisions = append(data.ShippedDecisions, d)
-		} else {
+		health := DeriveDecisionHealth(ctx, store, d.Meta.ID)
+		data.DecisionHealth[d.Meta.ID] = health
+
+		if health.Maturity == DecisionMaturityUnassessed {
+			data.UnassessedDecisions = append(data.UnassessedDecisions, d)
+			continue
+		}
+
+		if health.Maturity == DecisionMaturityPending {
 			data.PendingDecisions = append(data.PendingDecisions, d)
+			continue
+		}
+
+		if health.Freshness == DecisionFreshnessHealthy {
+			data.HealthyDecisions = append(data.HealthyDecisions, d)
 		}
 	}
 
@@ -349,20 +363,6 @@ func selectLatestArtifact(artifacts []*Artifact, include func(*Artifact) bool) *
 
 func adoptionIncludesStatus(status Status) bool {
 	return status == StatusActive || status == StatusRefreshDue
-}
-
-// hasMeasurement checks if a decision has any measurement evidence (type=measurement, verdict not superseded).
-func hasMeasurement(ctx context.Context, store ArtifactStore, decisionID string) bool {
-	items, err := store.GetEvidenceItems(ctx, decisionID)
-	if err != nil {
-		return false
-	}
-	for _, e := range items {
-		if e.Type == "measurement" && e.Verdict != "superseded" {
-			return true
-		}
-	}
-	return false
 }
 
 func filterActive(artifacts []*Artifact) []*Artifact {

--- a/internal/artifact/query_test.go
+++ b/internal/artifact/query_test.go
@@ -80,9 +80,11 @@ func TestFetchStatusData_Dashboard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hasPendingOrShipped := len(data.PendingDecisions) > 0 || len(data.ShippedDecisions) > 0
-	if !hasPendingOrShipped {
-		t.Error("missing pending or shipped decisions")
+	hasDecisionHealth := len(data.PendingDecisions) > 0 ||
+		len(data.HealthyDecisions) > 0 ||
+		len(data.UnassessedDecisions) > 0
+	if !hasDecisionHealth {
+		t.Error("missing decision health buckets")
 	}
 	if len(data.BacklogProblems) == 0 {
 		t.Error("missing backlog problems")
@@ -101,7 +103,8 @@ func TestFetchStatusData_Empty(t *testing.T) {
 		t.Fatal(err)
 	}
 	hasAny := len(data.PendingDecisions) > 0 ||
-		len(data.ShippedDecisions) > 0 ||
+		len(data.HealthyDecisions) > 0 ||
+		len(data.UnassessedDecisions) > 0 ||
 		len(data.StaleItems) > 0 ||
 		len(data.InProgressProblems) > 0 ||
 		len(data.BacklogProblems) > 0 ||
@@ -110,6 +113,122 @@ func TestFetchStatusData_Empty(t *testing.T) {
 	if hasAny {
 		t.Error("expected empty status data for empty DB")
 	}
+}
+
+func TestFetchStatusData_DerivesDecisionHealthBuckets(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mustCreateDecision := func(id string, title string) {
+		t.Helper()
+
+		err := store.Create(ctx, &Artifact{
+			Meta: Meta{
+				ID:        id,
+				Kind:      KindDecisionRecord,
+				Title:     title,
+				Status:    StatusActive,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			Body: title,
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	mustAddEvidence := func(decisionID string, item EvidenceItem) {
+		t.Helper()
+
+		err := store.AddEvidenceItem(ctx, &item, decisionID)
+		if err != nil {
+			t.Fatalf("add evidence to %s: %v", decisionID, err)
+		}
+	}
+
+	mustCreateDecision("dec-healthy", "Healthy decision")
+	mustAddEvidence("dec-healthy", EvidenceItem{
+		ID:              "evid-healthy",
+		Type:            "measurement",
+		Content:         "latency meets target",
+		Verdict:         "accepted",
+		CongruenceLevel: 3,
+		ValidUntil:      now.Add(24 * time.Hour).Format(time.RFC3339),
+	})
+
+	mustCreateDecision("dec-pending", "Pending decision")
+	mustAddEvidence("dec-pending", EvidenceItem{
+		ID:              "evid-pending",
+		Type:            "research",
+		Content:         "design review completed",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ValidUntil:      now.Add(24 * time.Hour).Format(time.RFC3339),
+	})
+
+	mustCreateDecision("dec-unassessed", "Unassessed decision")
+
+	mustCreateDecision("dec-stale", "Stale decision")
+	mustAddEvidence("dec-stale", EvidenceItem{
+		ID:              "evid-stale-measure",
+		Type:            "measurement",
+		Content:         "rollout met initial threshold",
+		Verdict:         "accepted",
+		CongruenceLevel: 3,
+		ValidUntil:      now.Add(24 * time.Hour).Format(time.RFC3339),
+	})
+	mustAddEvidence("dec-stale", EvidenceItem{
+		ID:              "evid-stale-research",
+		Type:            "research",
+		Content:         "follow-up field evidence weakens the result",
+		Verdict:         "weakens",
+		CongruenceLevel: 2,
+		ValidUntil:      now.Add(24 * time.Hour).Format(time.RFC3339),
+	})
+
+	data, err := FetchStatusData(ctx, store, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data.HealthyDecisions) != 1 || data.HealthyDecisions[0].Meta.ID != "dec-healthy" {
+		t.Fatalf("healthy decisions = %#v, want dec-healthy only", decisionIDs(data.HealthyDecisions))
+	}
+
+	if len(data.PendingDecisions) != 1 || data.PendingDecisions[0].Meta.ID != "dec-pending" {
+		t.Fatalf("pending decisions = %#v, want dec-pending only", decisionIDs(data.PendingDecisions))
+	}
+
+	if len(data.UnassessedDecisions) != 1 || data.UnassessedDecisions[0].Meta.ID != "dec-unassessed" {
+		t.Fatalf("unassessed decisions = %#v, want dec-unassessed only", decisionIDs(data.UnassessedDecisions))
+	}
+
+	staleHealth := data.DecisionHealth["dec-stale"]
+	if got := staleHealth.Label(); got != "Shipped / Stale" {
+		t.Fatalf("stale decision label = %q, want %q", got, "Shipped / Stale")
+	}
+
+	foundStale := false
+	for _, item := range data.StaleItems {
+		if item.ID == "dec-stale" {
+			foundStale = true
+		}
+	}
+	if !foundStale {
+		t.Fatal("expected stale decision in refresh queue")
+	}
+}
+
+func decisionIDs(items []*Artifact) []string {
+	ids := make([]string, 0, len(items))
+
+	for _, item := range items {
+		ids = append(ids, item.Meta.ID)
+	}
+
+	return ids
 }
 
 func TestFetchRelatedArtifacts_FindsByFile(t *testing.T) {

--- a/internal/artifact/query_test.go
+++ b/internal/artifact/query_test.go
@@ -303,7 +303,7 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		t.Fatal(err)
 	}
 
-	otherPortfolio, _, err := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+	_, _, err = ExploreSolutions(ctx, store, haftDir, ExploreInput{
 		ProblemRef: problem.Meta.ID,
 		Variants: []Variant{
 			testVariant("WebSocket", "connection lifecycle complexity", "Keep duplex sessions alive"),
@@ -311,16 +311,6 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		},
 		NoSteppingStoneRationale: "Both transports are direct target architectures.",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	otherDecision, _, err := Decide(ctx, store, haftDir, completeDecision(DecideInput{
-		ProblemRef:    problem.Meta.ID,
-		PortfolioRef:  otherPortfolio.Meta.ID,
-		SelectedTitle: "WebSocket",
-		WhySelected:   "A newer alternative path should not hijack adoption refs for the compared portfolio.",
-	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,18 +327,6 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		t.Fatal(err)
 	}
 
-	_, err = store.DB().ExecContext(ctx, `
-		UPDATE artifacts
-		SET created_at = ?, updated_at = ?
-		WHERE id = ?`,
-		"2026-01-03T00:00:00Z",
-		"2026-01-03T00:00:00Z",
-		otherDecision.Meta.ID,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	refs := ResolveProblemAdoptionRefs(ctx, store, problem.Meta.ID)
 	if refs.PortfolioRef != comparedPortfolio.Meta.ID {
 		t.Fatalf("PortfolioRef = %q, want %q", refs.PortfolioRef, comparedPortfolio.Meta.ID)
@@ -357,6 +335,6 @@ func TestResolveProblemAdoptionRefs_KeepsDecisionOnSelectedPortfolioChain(t *tes
 		t.Fatalf("ComparedPortfolioRef = %q, want %q", refs.ComparedPortfolioRef, comparedPortfolio.Meta.ID)
 	}
 	if refs.DecisionRef != comparedDecision.Meta.ID {
-		t.Fatalf("DecisionRef = %q, want %q (not newer %q)", refs.DecisionRef, comparedDecision.Meta.ID, otherDecision.Meta.ID)
+		t.Fatalf("DecisionRef = %q, want %q", refs.DecisionRef, comparedDecision.Meta.ID)
 	}
 }

--- a/internal/artifact/refresh.go
+++ b/internal/artifact/refresh.go
@@ -90,6 +90,25 @@ type decisionDebtAccumulator struct {
 	MostOverdueDays int
 }
 
+type GovernanceAttention struct {
+	BacklogCount             int
+	InProgressCount          int
+	AddressedWithoutDecision []AddressedProblemGap
+	InvariantViolations      []InvariantViolationFinding
+}
+
+type AddressedProblemGap struct {
+	ProblemID string
+	Title     string
+}
+
+type InvariantViolationFinding struct {
+	DecisionID    string
+	DecisionTitle string
+	Invariant     string
+	Reason        string
+}
+
 // ScanStale finds all stale decisions and returns actionable info.
 // If projectRoot is non-empty, also checks for file drift on baselined decisions.
 func ScanStale(ctx context.Context, store ArtifactStore, projectRoot ...string) ([]StaleItem, error) {

--- a/internal/artifact/solution.go
+++ b/internal/artifact/solution.go
@@ -827,6 +827,35 @@ func BuildComparisonBody(existingBody string, results ComparisonResult, compared
 	return body
 }
 
+// ExtractComparisonWarnings returns the rendered warning lines from a comparison body.
+func ExtractComparisonWarnings(body string) []string {
+	section := extractMarkdownSection(body, "## Comparison Warnings")
+	if section == "" {
+		return nil
+	}
+
+	lines := strings.Split(section, "\n")
+	warnings := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "## Comparison Warnings" {
+			continue
+		}
+		trimmed = strings.TrimPrefix(trimmed, "- ")
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "⚠"))
+		if trimmed == "" {
+			continue
+		}
+		warnings = append(warnings, trimmed)
+	}
+
+	if len(warnings) == 0 {
+		return nil
+	}
+
+	return warnings
+}
+
 // charDim holds a parsed dimension with its indicator role and freshness.
 type charDim struct {
 	Name       string
@@ -1396,23 +1425,30 @@ func extractLegacyParityRules(body string) string {
 }
 
 func latestCharacterizationSection(body string) string {
-	lastIdx := -1
 	for i := 100; i >= 1; i-- {
 		marker := fmt.Sprintf("## Characterization v%d", i)
-		if idx := strings.Index(body, marker); idx != -1 {
-			lastIdx = idx
-			break
+		section := extractMarkdownSection(body, marker)
+		if section != "" {
+			return section
 		}
 	}
-	if lastIdx == -1 {
+
+	return ""
+}
+
+func extractMarkdownSection(body string, heading string) string {
+	start := strings.Index(body, heading)
+	if start == -1 {
 		return ""
 	}
 
-	section := body[lastIdx:]
-	if endIdx := strings.Index(section[1:], "\n## "); endIdx != -1 {
-		section = section[:endIdx+1]
+	section := body[start:]
+	nextHeading := strings.Index(section[len(heading):], "\n## ")
+	if nextHeading == -1 {
+		return section
 	}
-	return section
+
+	return section[:len(heading)+nextHeading]
 }
 
 func mergeLegacyParityRules(parityPlan *ParityPlan, parityRules string) *ParityPlan {

--- a/internal/artifact/solution.go
+++ b/internal/artifact/solution.go
@@ -458,6 +458,33 @@ func ValidateParityPlan(plan ParityPlan) error {
 	return nil
 }
 
+func parityPlanWarning(mode Mode, source parityPlanSource) string {
+	if mode != ModeStandard && mode != ModeDeep {
+		return ""
+	}
+
+	modeLabel := string(mode)
+
+	if source == parityPlanSourceNone {
+		return fmt.Sprintf(
+			"%s mode comparison proceeds without a parity_plan — declare baseline_set, window, budget, and missing_data_policy",
+			modeLabel,
+		)
+	}
+
+	if source == parityPlanSourceExplicit {
+		return fmt.Sprintf(
+			"%s mode comparison received an unstructured parity_plan — fill baseline_set, window, budget, and missing_data_policy",
+			modeLabel,
+		)
+	}
+
+	return fmt.Sprintf(
+		"%s mode comparison is using legacy parity notes only — add a structured parity_plan with baseline_set, window, budget, and missing_data_policy",
+		modeLabel,
+	)
+}
+
 // ValidateCompareInput applies FPF compare-time validation without side effects.
 func ValidateCompareInput(input CompareInput, ctx CompareValidationContext) (CompareValidationResult, error) {
 	result := CompareValidationResult{}
@@ -474,11 +501,6 @@ func ValidateCompareInput(input CompareInput, ctx CompareValidationContext) (Com
 	effectiveParity := cloneParityPlan(ctx.ParityPlan)
 	comparedVariants := dedupeTrimmedStrings(ctx.PortfolioVariants)
 	switch {
-	case ctx.ParitySource == parityPlanSourceExplicit:
-		if err := ValidateParityPlan(*effectiveParity); err != nil {
-			return result, err
-		}
-		result.EffectiveParity = effectiveParity
 	case effectiveParity != nil && effectiveParity.IsStructured():
 		if err := ValidateParityPlan(*effectiveParity); err != nil {
 			return result, err
@@ -486,20 +508,14 @@ func ValidateCompareInput(input CompareInput, ctx CompareValidationContext) (Com
 		result.EffectiveParity = effectiveParity
 	case effectiveParity != nil:
 		result.EffectiveParity = effectiveParity
-		if ctx.Mode == ModeDeep {
-			return result, fmt.Errorf("deep mode comparison requires a structured parity plan with baseline_set, window, budget, and missing_data_policy")
-		}
-		if ctx.Mode == ModeStandard {
-			warnings = append(warnings,
-				"standard mode comparison is using legacy parity notes only — add a structured parity plan with baseline_set, window, budget, and missing_data_policy")
+		warning := parityPlanWarning(ctx.Mode, ctx.ParitySource)
+		if warning != "" {
+			warnings = append(warnings, warning)
 		}
 	default:
-		if ctx.Mode == ModeDeep {
-			return result, fmt.Errorf("deep mode comparison requires a parity plan")
-		}
-		if ctx.Mode == ModeStandard {
-			warnings = append(warnings,
-				"standard mode comparison proceeds without a parity plan — declare baseline_set, window, budget, and missing_data_policy")
+		warning := parityPlanWarning(ctx.Mode, ctx.ParitySource)
+		if warning != "" {
+			warnings = append(warnings, warning)
 		}
 	}
 

--- a/internal/artifact/solution.go
+++ b/internal/artifact/solution.go
@@ -634,12 +634,11 @@ func ValidateCompareInput(input CompareInput, ctx CompareValidationContext) (Com
 		}
 	}
 
+	warnings = append(warnings, subjectiveComparisonDimensionWarnings(input.Results.Dimensions, charByName)...)
+
 	missingDataPolicy := comparisonMissingDataPolicy(result.EffectiveParity)
 	for _, dimension := range input.Results.Dimensions {
-		role := "target"
-		if characterized, ok := charByName[normalizeArtifactKey(dimension)]; ok && characterized.Role != "" {
-			role = characterized.Role
-		}
+		role := comparisonDimensionRole(dimension, charByName)
 		if role == "observation" {
 			continue
 		}
@@ -905,6 +904,22 @@ type parsedScore struct {
 }
 
 var numericScorePattern = regexp.MustCompile(`^\s*([^\d+\-]*)([+\-]?\d[\d,]*(?:\.\d+)?)([kKmMbB]?)(.*)$`)
+
+var subjectiveDimensionTextReplacer = strings.NewReplacer("-", " ", "_", " ", "/", " ")
+
+var subjectiveComparisonDimensionTriggers = []string{
+	"maintainable",
+	"simple",
+	"scalable",
+	"robust",
+	"reliable",
+	"clean",
+	"user friendly",
+	"quality",
+	"fast",
+	"good",
+	"easy",
+}
 
 type portfolioVariantIdentity struct {
 	Key     string
@@ -1342,6 +1357,56 @@ func parityChecklistWarnings(dims []charDim) []string {
 		}
 	}
 	return warnings
+}
+
+func subjectiveComparisonDimensionWarnings(compareDimensions []string, characterized map[string]charDim) []string {
+	var warnings []string
+	for _, dimension := range compareDimensions {
+		if comparisonDimensionRole(dimension, characterized) == "observation" {
+			continue
+		}
+		if !isSubjectiveComparisonDimension(dimension) {
+			continue
+		}
+
+		warnings = append(warnings,
+			fmt.Sprintf("dimension '%s' is subjective — decompose into measurables or tag as observation-only", dimension))
+	}
+	return warnings
+}
+
+func comparisonDimensionRole(dimension string, characterized map[string]charDim) string {
+	characterizedDimension, ok := characterized[normalizeArtifactKey(dimension)]
+	if !ok {
+		return "target"
+	}
+	if characterizedDimension.Role == "" {
+		return "target"
+	}
+	return characterizedDimension.Role
+}
+
+func isSubjectiveComparisonDimension(dimension string) bool {
+	normalizedDimension := normalizeSubjectiveDimensionText(dimension)
+	if normalizedDimension == "" {
+		return false
+	}
+
+	paddedDimension := " " + normalizedDimension + " "
+	for _, trigger := range subjectiveComparisonDimensionTriggers {
+		paddedTrigger := " " + trigger + " "
+		if strings.Contains(paddedDimension, paddedTrigger) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSubjectiveDimensionText(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = subjectiveDimensionTextReplacer.Replace(normalized)
+	normalized = strings.Join(strings.Fields(normalized), " ")
+	return normalized
 }
 
 func parseComparisonExpiry(raw string) (time.Time, bool) {

--- a/internal/artifact/solution_test.go
+++ b/internal/artifact/solution_test.go
@@ -1783,6 +1783,35 @@ func TestCompare_DeepModeWarnsOnUnstructuredParityPlan(t *testing.T) {
 	}
 }
 
+func TestExtractComparisonWarnings(t *testing.T) {
+	body := strings.Join([]string{
+		"# Solution Portfolio",
+		"",
+		"## Comparison",
+		"",
+		"## Comparison Warnings",
+		"",
+		"- ⚠ standard mode comparison proceeds without a parity_plan — declare baseline_set, window, budget, and missing_data_policy",
+		"- ⚠ Parity checklist (per characterized dimension):",
+		"",
+		"## Next Section",
+		"",
+		"ignored",
+	}, "\n")
+
+	warnings := ExtractComparisonWarnings(body)
+
+	if len(warnings) != 2 {
+		t.Fatalf("expected 2 warnings, got %d: %+v", len(warnings), warnings)
+	}
+	if warnings[0] != "standard mode comparison proceeds without a parity_plan — declare baseline_set, window, budget, and missing_data_policy" {
+		t.Fatalf("unexpected first warning: %q", warnings[0])
+	}
+	if warnings[1] != "Parity checklist (per characterized dimension):" {
+		t.Fatalf("unexpected second warning: %q", warnings[1])
+	}
+}
+
 func TestCompare_PersistsStructuredComparison(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/artifact/solution_test.go
+++ b/internal/artifact/solution_test.go
@@ -1220,6 +1220,160 @@ func TestCompare_NoWarningsWhenFullCoverage(t *testing.T) {
 	}
 }
 
+func TestIsSubjectiveComparisonDimension(t *testing.T) {
+	cases := []struct {
+		dimension string
+		want      bool
+	}{
+		{dimension: "maintainable", want: true},
+		{dimension: "simple", want: true},
+		{dimension: "scalable", want: true},
+		{dimension: "robust", want: true},
+		{dimension: "reliable", want: true},
+		{dimension: "clean", want: true},
+		{dimension: "user-friendly", want: true},
+		{dimension: "quality", want: true},
+		{dimension: "fast", want: true},
+		{dimension: "good", want: true},
+		{dimension: "easy", want: true},
+		{dimension: "fast rollout", want: true},
+		{dimension: "user friendly onboarding", want: true},
+		{dimension: "latency", want: false},
+		{dimension: "throughput", want: false},
+		{dimension: "goodput", want: false},
+	}
+
+	for _, tc := range cases {
+		got := isSubjectiveComparisonDimension(tc.dimension)
+		if got != tc.want {
+			t.Fatalf("isSubjectiveComparisonDimension(%q) = %v, want %v", tc.dimension, got, tc.want)
+		}
+	}
+}
+
+func TestCompare_WarnsOnSubjectiveTargetDimension(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	prob, _, _ := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title: "Queue design", Signal: "Delivery pressure", Context: "ops",
+	})
+	CharacterizeProblem(ctx, store, haftDir, CharacterizeInput{
+		ProblemRef: prob.Meta.ID,
+		Dimensions: []ComparisonDimension{
+			{Name: "maintainable", Role: "target", Polarity: "higher_better"},
+		},
+		ParityPlan: &ParityPlan{
+			BaselineSet:       []string{"Redis", "NATS"},
+			Window:            "same replay window",
+			Budget:            "$100/month",
+			MissingDataPolicy: MissingDataPolicyExplicitAbstain,
+			PinnedConditions:  []string{"Same team and workload"},
+		},
+	})
+
+	portfolio, _, _ := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: prob.Meta.ID,
+		Variants: []Variant{
+			testVariant("Redis", "head-of-line blocking", "Keep the existing operational surface"),
+			testVariant("NATS", "ecosystem maturity", "Adopt a dedicated broker with a different scaling path"),
+		},
+		NoSteppingStoneRationale: "Both queue options are direct production candidates.",
+	})
+
+	a, _, err := CompareSolutions(ctx, store, haftDir, CompareInput{
+		PortfolioRef: portfolio.Meta.ID,
+		Results: ComparisonResult{
+			Dimensions: []string{"maintainable"},
+			Scores: map[string]map[string]string{
+				"Redis": {"maintainable": "high"},
+				"NATS":  {"maintainable": "medium"},
+			},
+			NonDominatedSet: []string{"Redis"},
+			DominatedVariants: []DominatedVariantExplanation{
+				{
+					Variant:     "NATS",
+					DominatedBy: []string{"Redis"},
+					Summary:     "Lower maintainability score in the current comparison.",
+				},
+			},
+			ParetoTradeoffs: []ParetoTradeoffNote{
+				{Variant: "Redis", Summary: "Best maintainability score in this fixture."},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(a.Body, "dimension 'maintainable' is subjective — decompose into measurables or tag as observation-only") {
+		t.Fatalf("expected subjective-dimension warning, body: %s", a.Body)
+	}
+}
+
+func TestCompare_SkipsSubjectiveWarningForObservationDimension(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	prob, _, _ := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title: "Queue design", Signal: "Delivery pressure", Context: "ops",
+	})
+	CharacterizeProblem(ctx, store, haftDir, CharacterizeInput{
+		ProblemRef: prob.Meta.ID,
+		Dimensions: []ComparisonDimension{
+			{Name: "latency", Role: "target"},
+			{Name: "quality", Role: "observation"},
+		},
+		ParityPlan: &ParityPlan{
+			BaselineSet:       []string{"Redis", "NATS"},
+			Window:            "same replay window",
+			Budget:            "$100/month",
+			MissingDataPolicy: MissingDataPolicyExplicitAbstain,
+			PinnedConditions:  []string{"Same team and workload"},
+		},
+	})
+
+	portfolio, _, _ := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: prob.Meta.ID,
+		Variants: []Variant{
+			testVariant("Redis", "head-of-line blocking", "Keep the existing operational surface"),
+			testVariant("NATS", "ecosystem maturity", "Adopt a dedicated broker with a different scaling path"),
+		},
+		NoSteppingStoneRationale: "Both queue options are direct production candidates.",
+	})
+
+	a, _, err := CompareSolutions(ctx, store, haftDir, CompareInput{
+		PortfolioRef: portfolio.Meta.ID,
+		Results: ComparisonResult{
+			Dimensions: []string{"latency", "quality"},
+			Scores: map[string]map[string]string{
+				"Redis": {"latency": "10ms", "quality": "high"},
+				"NATS":  {"latency": "15ms", "quality": "medium"},
+			},
+			NonDominatedSet: []string{"Redis"},
+			DominatedVariants: []DominatedVariantExplanation{
+				{
+					Variant:     "NATS",
+					DominatedBy: []string{"Redis"},
+					Summary:     "Higher latency under the same conditions.",
+				},
+			},
+			ParetoTradeoffs: []ParetoTradeoffNote{
+				{Variant: "Redis", Summary: "Best latency while quality stays observation-only."},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(a.Body, "dimension 'quality' is subjective") {
+		t.Fatalf("did not expect subjective warning for observation dimension, body: %s", a.Body)
+	}
+}
+
 func TestCompare_WarnsWithoutParityPlanInStandardMode(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/artifact/solution_test.go
+++ b/internal/artifact/solution_test.go
@@ -1259,7 +1259,7 @@ func TestCompare_WarnsWithoutParityPlanInStandardMode(t *testing.T) {
 	if !strings.Contains(a.Body, "Comparison Warnings") {
 		t.Fatal("expected warning section without parity plan in standard mode")
 	}
-	if !strings.Contains(a.Body, "without a parity plan") {
+	if !strings.Contains(a.Body, "without a parity_plan") {
 		t.Fatalf("expected missing parity plan warning, body: %s", a.Body)
 	}
 }
@@ -1676,7 +1676,7 @@ func TestExplore_WarnsOnDuplicateNoveltyMarkers(t *testing.T) {
 	}
 }
 
-func TestCompare_DeepModeRequiresParityPlan(t *testing.T) {
+func TestCompare_DeepModeWarnsWithoutParityPlan(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()
 	haftDir := t.TempDir()
@@ -1698,7 +1698,7 @@ func TestCompare_DeepModeRequiresParityPlan(t *testing.T) {
 		NoSteppingStoneRationale: "Both transports are direct architecture candidates.",
 	})
 
-	_, _, err := CompareSolutions(ctx, store, haftDir, CompareInput{
+	a, _, err := CompareSolutions(ctx, store, haftDir, CompareInput{
 		PortfolioRef: portfolio.Meta.ID,
 		Results: ComparisonResult{
 			Dimensions: []string{"latency"},
@@ -1707,13 +1707,79 @@ func TestCompare_DeepModeRequiresParityPlan(t *testing.T) {
 				"gRPC": {"latency": "18ms"},
 			},
 			NonDominatedSet: []string{"gRPC"},
+			DominatedVariants: []DominatedVariantExplanation{
+				{
+					Variant:     "REST",
+					DominatedBy: []string{"gRPC"},
+					Summary:     "Higher latency with no compensating benefit in this comparison.",
+				},
+			},
+			ParetoTradeoffs: []ParetoTradeoffNote{
+				{Variant: "gRPC", Summary: "Lowest latency result among the compared variants."},
+			},
 		},
 	})
-	if err == nil {
-		t.Fatal("expected deep-mode parity error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "requires a parity plan") {
-		t.Fatalf("expected parity-plan error, got %v", err)
+	if !strings.Contains(a.Body, "Comparison Warnings") {
+		t.Fatalf("expected warning section in deep mode, body: %s", a.Body)
+	}
+	if !strings.Contains(a.Body, "deep mode comparison proceeds without a parity_plan") {
+		t.Fatalf("expected deep-mode missing parity warning, body: %s", a.Body)
+	}
+}
+
+func TestCompare_DeepModeWarnsOnUnstructuredParityPlan(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	prob, _, _ := FrameProblem(ctx, store, haftDir, ProblemFrameInput{
+		Title: "Transport choice", Signal: "Latency variance", Context: "api", Mode: "deep",
+	})
+
+	portfolio, _, _ := ExploreSolutions(ctx, store, haftDir, ExploreInput{
+		ProblemRef: prob.Meta.ID,
+		Variants: []Variant{
+			testVariant("REST", "chatty serialization", "Keep the existing HTTP semantics"),
+			testVariant("gRPC", "tooling overhead", "Adopt binary RPC for lower-latency transport"),
+		},
+		NoSteppingStoneRationale: "Both transports are direct architecture candidates.",
+	})
+
+	a, _, err := CompareSolutions(ctx, store, haftDir, CompareInput{
+		PortfolioRef: portfolio.Meta.ID,
+		Results: ComparisonResult{
+			Dimensions: []string{"latency"},
+			Scores: map[string]map[string]string{
+				"REST": {"latency": "42ms"},
+				"gRPC": {"latency": "18ms"},
+			},
+			NonDominatedSet: []string{"gRPC"},
+			DominatedVariants: []DominatedVariantExplanation{
+				{
+					Variant:     "REST",
+					DominatedBy: []string{"gRPC"},
+					Summary:     "Higher latency with no compensating benefit in this comparison.",
+				},
+			},
+			ParetoTradeoffs: []ParetoTradeoffNote{
+				{Variant: "gRPC", Summary: "Lowest latency result among the compared variants."},
+			},
+			ParityPlan: &ParityPlan{
+				Window: "same 15m replay window",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(a.Body, "Comparison Warnings") {
+		t.Fatalf("expected warning section for unstructured parity plan, body: %s", a.Body)
+	}
+	if !strings.Contains(a.Body, "received an unstructured parity_plan") {
+		t.Fatalf("expected unstructured parity warning, body: %s", a.Body)
 	}
 }
 

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -549,6 +549,8 @@ func (s *Store) GetAffectedSymbols(ctx context.Context, artifactID string) ([]Af
 
 // --- Evidence Items ---
 
+const cl0EvidenceSupportsError = "CL0 evidence cannot support — re-evaluate or change verdict"
+
 // AddEvidenceItem adds an evidence item linked to an artifact.
 func (s *Store) AddEvidenceItem(ctx context.Context, item *EvidenceItem, artifactRef string) error {
 	return s.addEvidenceItemWithExec(ctx, s.db, item, artifactRef)
@@ -557,6 +559,10 @@ func (s *Store) AddEvidenceItem(ctx context.Context, item *EvidenceItem, artifac
 func (s *Store) addEvidenceItemWithExec(ctx context.Context, execer sqlExecer, item *EvidenceItem, artifactRef string) error {
 	formality := normalizeFormalityLevel(item.FormalityLevel)
 	storedVerdict := canonicalStoredEvidenceVerdict(item.Type, item.Verdict)
+	err := validateEvidenceCongruenceAtIngest(storedVerdict, item.CongruenceLevel)
+	if err != nil {
+		return err
+	}
 	hasClaimScope, err := s.tableHasColumn(ctx, "evidence_items", "claim_scope")
 	if err != nil {
 		return err
@@ -721,6 +727,14 @@ func canonicalStoredEvidenceVerdict(evidenceType string, verdict string) string 
 	default:
 		return normalizedVerdict
 	}
+}
+
+func validateEvidenceCongruenceAtIngest(storedVerdict string, congruenceLevel int) error {
+	if congruenceLevel == 0 && strings.EqualFold(strings.TrimSpace(storedVerdict), "supports") {
+		return fmt.Errorf(cl0EvidenceSupportsError)
+	}
+
+	return nil
 }
 
 // SupersedeEvidenceByType marks all evidence items of the given type on an artifact as superseded.

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -556,6 +556,7 @@ func (s *Store) AddEvidenceItem(ctx context.Context, item *EvidenceItem, artifac
 
 func (s *Store) addEvidenceItemWithExec(ctx context.Context, execer sqlExecer, item *EvidenceItem, artifactRef string) error {
 	formality := normalizeFormalityLevel(item.FormalityLevel)
+	storedVerdict := canonicalStoredEvidenceVerdict(item.Type, item.Verdict)
 	hasClaimScope, err := s.tableHasColumn(ctx, "evidence_items", "claim_scope")
 	if err != nil {
 		return err
@@ -594,7 +595,7 @@ func (s *Store) addEvidenceItemWithExec(ctx context.Context, execer sqlExecer, i
 		"formality_level",
 	}
 	args := []any{
-		item.ID, artifactRef, item.Type, item.Content, item.Verdict,
+		item.ID, artifactRef, item.Type, item.Content, storedVerdict,
 		item.CarrierRef, item.CongruenceLevel, formality,
 	}
 	if hasClaimScope {
@@ -621,6 +622,7 @@ func (s *Store) addEvidenceItemWithExec(ctx context.Context, execer sqlExecer, i
 	)
 
 	_, err = execer.ExecContext(ctx, query, args...)
+	item.Verdict = storedVerdict
 	return err
 }
 
@@ -686,7 +688,7 @@ func (s *Store) GetEvidenceItems(ctx context.Context, artifactRef string) ([]Evi
 		if err := rows.Scan(dest...); err != nil {
 			return nil, err
 		}
-		e.Verdict = verdict.String
+		e.Verdict = canonicalStoredEvidenceVerdict(e.Type, verdict.String)
 		e.CarrierRef = carrierRef.String
 		e.FormalityLevel = normalizeFormalityLevel(e.FormalityLevel)
 		if claimScope.String != "" {
@@ -701,6 +703,24 @@ func (s *Store) GetEvidenceItems(ctx context.Context, artifactRef string) ([]Evi
 		items = append(items, e)
 	}
 	return items, rows.Err()
+}
+
+func canonicalStoredEvidenceVerdict(evidenceType string, verdict string) string {
+	normalizedVerdict := strings.TrimSpace(verdict)
+	if !strings.EqualFold(strings.TrimSpace(evidenceType), "measurement") {
+		return normalizedVerdict
+	}
+
+	switch normalizedVerdict {
+	case "accepted":
+		return "supports"
+	case "partial":
+		return "weakens"
+	case "failed":
+		return "refutes"
+	default:
+		return normalizedVerdict
+	}
 }
 
 // SupersedeEvidenceByType marks all evidence items of the given type on an artifact as superseded.

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -23,6 +23,10 @@ type sqlExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
+type sqlQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
 // Compile-time check: Store must implement ArtifactStore.
 var _ ArtifactStore = (*Store)(nil)
 
@@ -634,6 +638,10 @@ func (s *Store) addEvidenceItemWithExec(ctx context.Context, execer sqlExecer, i
 
 // GetEvidenceItems returns evidence items for an artifact.
 func (s *Store) GetEvidenceItems(ctx context.Context, artifactRef string) ([]EvidenceItem, error) {
+	return s.getEvidenceItemsWithQueryer(ctx, s.db, artifactRef)
+}
+
+func (s *Store) getEvidenceItemsWithQueryer(ctx context.Context, queryer sqlQueryer, artifactRef string) ([]EvidenceItem, error) {
 	hasClaimScope, err := s.tableHasColumn(ctx, "evidence_items", "claim_scope")
 	if err != nil {
 		return nil, err
@@ -665,7 +673,7 @@ func (s *Store) GetEvidenceItems(ctx context.Context, artifactRef string) ([]Evi
 		strings.Join(columns, ", ") +
 		" FROM evidence_items WHERE artifact_ref = ? ORDER BY created_at DESC"
 
-	rows, err := s.db.QueryContext(ctx, query, artifactRef)
+	rows, err := queryer.QueryContext(ctx, query, artifactRef)
 	if err != nil {
 		return nil, err
 	}
@@ -750,8 +758,115 @@ func (s *Store) supersedeEvidenceByTypeWithExec(ctx context.Context, execer sqlE
 	return err
 }
 
-// CommitMeasurement atomically updates a decision and replaces its active measurement evidence.
-func (s *Store) CommitMeasurement(ctx context.Context, decision *Artifact, item *EvidenceItem) error {
+func (s *Store) supersedeEvidenceByIDWithExec(ctx context.Context, execer sqlExecer, ids []string) error {
+	for _, id := range ids {
+		_, err := execer.ExecContext(ctx,
+			`UPDATE evidence_items SET verdict = 'superseded' WHERE id = ? AND verdict != 'superseded'`,
+			id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func measurementBindingKeys(claims []DecisionClaim, item EvidenceItem) []string {
+	normalizedClaims := normalizeDecisionClaims(claims)
+	if len(normalizedClaims) == 0 {
+		return nil
+	}
+
+	resolvedRefs, err := resolveDecisionEvidenceClaimRefs(
+		normalizedClaims,
+		item.ClaimRefs,
+		item.ClaimScope,
+	)
+	if err != nil || len(resolvedRefs) == 0 {
+		return nil
+	}
+
+	claimIndex := make(map[string]DecisionClaim, len(normalizedClaims))
+	keys := make([]string, 0, len(resolvedRefs))
+
+	for _, claim := range normalizedClaims {
+		claimIndex[claim.ID] = claim
+	}
+
+	for _, ref := range normalizeClaimRefs(resolvedRefs) {
+		claim, ok := claimIndex[ref]
+		if !ok {
+			continue
+		}
+
+		key := strings.TrimSpace(ref) + "\x00" + strings.TrimSpace(claim.Observable)
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func measurementKeysOverlap(left []string, right []string) bool {
+	if len(left) == 0 || len(right) == 0 {
+		return len(left) == 0 && len(right) == 0
+	}
+
+	index := make(map[string]struct{}, len(left))
+
+	for _, value := range left {
+		index[value] = struct{}{}
+	}
+
+	for _, value := range right {
+		if _, ok := index[value]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *Store) measurementEvidenceIDsToSupersede(
+	ctx context.Context,
+	queryer sqlQueryer,
+	decision *Artifact,
+	items []EvidenceItem,
+) ([]string, error) {
+	existingItems, err := s.getEvidenceItemsWithQueryer(ctx, queryer, decision.Meta.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	decisionClaims := decision.UnmarshalDecisionFields().Claims
+	incomingKeys := make([][]string, 0, len(items))
+	ids := make([]string, 0)
+
+	for _, item := range items {
+		incomingKeys = append(incomingKeys, measurementBindingKeys(decisionClaims, item))
+	}
+
+	for _, existing := range existingItems {
+		if existing.Type != "measurement" || existing.Verdict == "superseded" {
+			continue
+		}
+
+		existingKeys := measurementBindingKeys(decisionClaims, existing)
+
+		for _, keys := range incomingKeys {
+			if !measurementKeysOverlap(existingKeys, keys) {
+				continue
+			}
+
+			ids = append(ids, existing.ID)
+			break
+		}
+	}
+
+	return ids, nil
+}
+
+// CommitMeasurement atomically updates a decision and supersedes only overlapping active measurement evidence.
+func (s *Store) CommitMeasurement(ctx context.Context, decision *Artifact, items []EvidenceItem) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -761,11 +876,20 @@ func (s *Store) CommitMeasurement(ctx context.Context, decision *Artifact, item 
 	if err := s.updateArtifactWithExec(ctx, tx, decision); err != nil {
 		return err
 	}
-	if err := s.supersedeEvidenceByTypeWithExec(ctx, tx, decision.Meta.ID, item.Type); err != nil {
+
+	supersededIDs, err := s.measurementEvidenceIDsToSupersede(ctx, tx, decision, items)
+	if err != nil {
 		return err
 	}
-	if err := s.addEvidenceItemWithExec(ctx, tx, item, decision.Meta.ID); err != nil {
+	if err := s.supersedeEvidenceByIDWithExec(ctx, tx, supersededIDs); err != nil {
 		return err
+	}
+
+	for _, item := range items {
+		item := item
+		if err := s.addEvidenceItemWithExec(ctx, tx, &item, decision.Meta.ID); err != nil {
+			return err
+		}
 	}
 
 	return tx.Commit()

--- a/internal/artifact/store_test.go
+++ b/internal/artifact/store_test.go
@@ -571,6 +571,43 @@ func TestAddEvidenceItem_NormalizesMeasurementVerdictAliases(t *testing.T) {
 	}
 }
 
+func TestAddEvidenceItem_RejectsCL0SupportingEvidence(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	err := store.Create(ctx, &Artifact{
+		Meta: Meta{ID: "dec-cl0-supports", Kind: KindDecisionRecord, Title: "Decision"},
+		Body: "d",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	item := &EvidenceItem{
+		ID:              "evid-cl0-supports",
+		Type:            "benchmark",
+		Content:         "Opposed-context benchmark",
+		Verdict:         "supports",
+		CongruenceLevel: 0,
+		FormalityLevel:  2,
+	}
+	err = store.AddEvidenceItem(ctx, item, "dec-cl0-supports")
+	if err == nil {
+		t.Fatal("expected CL0 supporting evidence to be rejected")
+	}
+	if err.Error() != cl0EvidenceSupportsError {
+		t.Fatalf("error = %q, want %q", err.Error(), cl0EvidenceSupportsError)
+	}
+
+	items, err := store.GetEvidenceItems(ctx, "dec-cl0-supports")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no stored evidence items, got %d", len(items))
+	}
+}
+
 func TestNextSequence(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/artifact/store_test.go
+++ b/internal/artifact/store_test.go
@@ -512,6 +512,65 @@ func TestAddEvidenceItem_LegacySchemaWithoutClaimRefs(t *testing.T) {
 	}
 }
 
+func TestAddEvidenceItem_NormalizesMeasurementVerdictAliases(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	err := store.Create(ctx, &Artifact{
+		Meta: Meta{ID: "dec-measure-aliases", Kind: KindDecisionRecord, Title: "Decision"},
+		Body: "d",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		id      string
+		verdict string
+		want    string
+	}{
+		{id: "evid-accepted", verdict: "accepted", want: "supports"},
+		{id: "evid-partial", verdict: "partial", want: "weakens"},
+		{id: "evid-failed", verdict: "failed", want: "refutes"},
+	}
+
+	for _, tc := range cases {
+		item := &EvidenceItem{
+			ID:              tc.id,
+			Type:            "measurement",
+			Content:         tc.verdict,
+			Verdict:         tc.verdict,
+			CongruenceLevel: 3,
+			FormalityLevel:  2,
+		}
+		if err := store.AddEvidenceItem(ctx, item, "dec-measure-aliases"); err != nil {
+			t.Fatalf("add evidence item %s: %v", tc.id, err)
+		}
+		if got := item.Verdict; got != tc.want {
+			t.Fatalf("item verdict after insert = %q, want %q", got, tc.want)
+		}
+	}
+
+	items, err := store.GetEvidenceItems(ctx, "dec-measure-aliases")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != len(cases) {
+		t.Fatalf("expected %d items, got %d", len(cases), len(items))
+	}
+
+	verdictByID := make(map[string]string, len(items))
+	for _, item := range items {
+		verdictByID[item.ID] = item.Verdict
+	}
+
+	for _, tc := range cases {
+		if got := verdictByID[tc.id]; got != tc.want {
+			t.Fatalf("stored verdict for %s = %q, want %q", tc.id, got, tc.want)
+		}
+	}
+}
+
 func TestNextSequence(t *testing.T) {
 	store := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/artifact/types.go
+++ b/internal/artifact/types.go
@@ -224,8 +224,30 @@ type Artifact struct {
 	StructuredData string `yaml:"-" json:"structured_data"` // JSON: canonical structured fields (eliminates markdown re-parsing)
 }
 
+type ProblemType string
+
+const (
+	ProblemTypeOptimization ProblemType = "optimization"
+	ProblemTypeDiagnosis    ProblemType = "diagnosis"
+	ProblemTypeSearch       ProblemType = "search"
+	ProblemTypeSynthesis    ProblemType = "synthesis"
+)
+
+func ParseProblemType(value string) (ProblemType, error) {
+	normalized := ProblemType(strings.TrimSpace(value))
+	switch normalized {
+	case "":
+		return "", nil
+	case ProblemTypeOptimization, ProblemTypeDiagnosis, ProblemTypeSearch, ProblemTypeSynthesis:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("problem_type must be optimization, diagnosis, search, or synthesis")
+	}
+}
+
 // ProblemFields holds structured data for a ProblemCard. Stored as JSON in StructuredData.
 type ProblemFields struct {
+	ProblemType           ProblemType                `json:"problem_type,omitempty"`
 	Signal                string                     `json:"signal"`
 	Constraints           []string                   `json:"constraints,omitempty"`
 	OptimizationTargets   []string                   `json:"optimization_targets,omitempty"`
@@ -308,6 +330,19 @@ func (a *Artifact) UnmarshalProblemFields() ProblemFields {
 	var pf ProblemFields
 	_ = json.Unmarshal([]byte(a.StructuredData), &pf)
 	return pf
+}
+
+func ProblemTypeLabel(a *Artifact) string {
+	if a == nil {
+		return ""
+	}
+
+	fields := a.UnmarshalProblemFields()
+	if fields.ProblemType == "" {
+		return ""
+	}
+
+	return string(fields.ProblemType)
 }
 
 // UnmarshalDecisionFields extracts structured fields from an artifact's StructuredData.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -203,6 +203,12 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		Cwd:         cwd,
 		Lemniscate:  true,
 	}) + agent.LoadProjectContext(projectRoot)
+	workflow, workflowErr := project.LoadWorkflow(projectRoot)
+	if workflowErr != nil {
+		logger.Warn().Err(workflowErr).Msg("agent.workflow.load_failed")
+	} else if workflow != nil {
+		systemPrompt = workflow.PromptPrefix() + "\n\n" + systemPrompt
+	}
 
 	// 9. Agent definition
 	agentDef := agent.HaftAgent()

--- a/internal/cli/board.go
+++ b/internal/cli/board.go
@@ -28,9 +28,27 @@ Use --check for CI/hooks: prints compact summary and exits with code 1 if critic
 	RunE: runBoard,
 }
 
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "CI governance check — exit 1 if findings",
+	Long: `Scan for governance debt: stale artifacts, drifted decisions, unassessed decisions, coverage gaps.
+
+Exit 0 = clean. Exit 1 = findings. Use --json for machine-readable output.
+
+This is equivalent to "haft board --check".`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		checkMode = true
+		return runBoard(cmd, args)
+	},
+}
+
+var checkJSON bool
+
 func init() {
 	boardCmd.Flags().BoolVar(&checkMode, "check", false, "CI mode: compact summary, exit 1 if critical")
+	checkCmd.Flags().BoolVar(&checkJSON, "json", false, "Output findings as JSON")
 	rootCmd.AddCommand(boardCmd)
+	rootCmd.AddCommand(checkCmd)
 }
 
 func runBoard(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -319,9 +319,28 @@ func summarizeCheckDrift(report artifact.DriftReport) string {
 }
 
 func writeCheckJSON(w io.Writer, report checkReport) error {
+	report = normalizeCheckReport(report)
+
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(report)
+}
+
+func normalizeCheckReport(report checkReport) checkReport {
+	if report.Stale == nil {
+		report.Stale = []checkStaleFinding{}
+	}
+	if report.Drifted == nil {
+		report.Drifted = []checkDriftFinding{}
+	}
+	if report.Unassessed == nil {
+		report.Unassessed = []checkDecisionFinding{}
+	}
+	if report.CoverageGaps == nil {
+		report.CoverageGaps = []checkCoverageGapFinding{}
+	}
+
+	return report
 }
 
 func writeCheckSummary(w io.Writer, report checkReport) error {

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -1,0 +1,396 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/m0n0x41d/haft/internal/artifact"
+	"github.com/m0n0x41d/haft/internal/project"
+)
+
+type checkReport struct {
+	Stale        []checkStaleFinding       `json:"stale"`
+	Drifted      []checkDriftFinding       `json:"drifted"`
+	Unassessed   []checkDecisionFinding    `json:"unassessed"`
+	CoverageGaps []checkCoverageGapFinding `json:"coverage_gaps"`
+	Summary      checkSummary              `json:"summary"`
+}
+
+type checkSummary struct {
+	TotalFindings int `json:"total_findings"`
+}
+
+type checkStaleFinding struct {
+	ID         string  `json:"id"`
+	Title      string  `json:"title"`
+	Kind       string  `json:"kind"`
+	Category   string  `json:"category"`
+	Reason     string  `json:"reason"`
+	ValidUntil string  `json:"valid_until,omitempty"`
+	DaysStale  int     `json:"days_stale,omitempty"`
+	REff       float64 `json:"r_eff,omitempty"`
+}
+
+type checkDriftFinding struct {
+	DecisionID        string               `json:"decision_id"`
+	DecisionTitle     string               `json:"decision_title"`
+	HasBaseline       bool                 `json:"has_baseline"`
+	LikelyImplemented bool                 `json:"likely_implemented,omitempty"`
+	Summary           string               `json:"summary"`
+	Files             []artifact.DriftItem `json:"files,omitempty"`
+}
+
+type checkDecisionFinding struct {
+	DecisionID string `json:"decision_id"`
+	Title      string `json:"title"`
+	Context    string `json:"context,omitempty"`
+}
+
+type checkCoverageGapFinding struct {
+	DecisionID string   `json:"decision_id"`
+	Title      string   `json:"title"`
+	Gaps       []string `json:"gaps"`
+}
+
+var (
+	checkJSON bool
+	checkExit = os.Exit
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check governance debt for CI",
+	Long: `Run governance checks for stale artifacts, drift, unassessed decisions, and coverage gaps.
+
+Exit code 0 means clean.
+Exit code 1 means findings were detected.`,
+	RunE: runCheck,
+}
+
+func init() {
+	checkCmd.Flags().BoolVar(&checkJSON, "json", false, "print structured JSON output")
+	rootCmd.AddCommand(checkCmd)
+}
+
+func runCheck(cmd *cobra.Command, _ []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return fmt.Errorf("not a haft project: %w", err)
+	}
+
+	haftDir := filepath.Join(projectRoot, ".haft")
+	projCfg, err := project.Load(haftDir)
+	if err != nil {
+		return fmt.Errorf("load project config: %w", err)
+	}
+	if projCfg == nil {
+		return fmt.Errorf("project not initialized — run 'haft init' first")
+	}
+
+	dbPath, err := projCfg.DBPath()
+	if err != nil {
+		return fmt.Errorf("get DB path: %w", err)
+	}
+
+	dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(3000)"
+	sqlDB, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return fmt.Errorf("open DB: %w", err)
+	}
+
+	store := artifact.NewStore(sqlDB)
+	report, err := buildCheckReport(context.Background(), store, projectRoot)
+	if err != nil {
+		_ = sqlDB.Close()
+		return err
+	}
+
+	output := cmd.OutOrStdout()
+	if checkJSON {
+		err = writeCheckJSON(output, report)
+	} else {
+		err = writeCheckSummary(output, report)
+	}
+	if err != nil {
+		_ = sqlDB.Close()
+		return err
+	}
+
+	if closeErr := sqlDB.Close(); closeErr != nil {
+		return fmt.Errorf("close DB: %w", closeErr)
+	}
+
+	if report.hasFindings() {
+		checkExit(1)
+	}
+
+	return nil
+}
+
+func buildCheckReport(ctx context.Context, store *artifact.Store, projectRoot string) (checkReport, error) {
+	report := checkReport{}
+
+	staleItems, err := artifact.ScanStale(ctx, store)
+	if err != nil {
+		return report, fmt.Errorf("scan stale artifacts: %w", err)
+	}
+
+	driftReports, err := artifact.CheckDrift(ctx, store, projectRoot)
+	if err != nil {
+		return report, fmt.Errorf("scan drift: %w", err)
+	}
+
+	decisions, err := store.ListByKind(ctx, artifact.KindDecisionRecord, 0)
+	if err != nil {
+		return report, fmt.Errorf("list decisions: %w", err)
+	}
+
+	activeDecisions := filterCheckActiveDecisions(decisions)
+
+	report.Stale = mapCheckStaleFindings(staleItems)
+	report.Drifted = mapCheckDriftFindings(driftReports)
+	report.Unassessed = collectUnassessedFindings(ctx, store, activeDecisions)
+	report.CoverageGaps = collectCoverageGapFindings(ctx, store, activeDecisions)
+	report.Summary = checkSummary{
+		TotalFindings: len(report.Stale) + len(report.Drifted) + len(report.Unassessed) + len(report.CoverageGaps),
+	}
+
+	return report, nil
+}
+
+func filterCheckActiveDecisions(decisions []*artifact.Artifact) []*artifact.Artifact {
+	active := make([]*artifact.Artifact, 0, len(decisions))
+
+	for _, decision := range decisions {
+		if decision.Meta.Status != artifact.StatusActive {
+			continue
+		}
+
+		active = append(active, decision)
+	}
+
+	return active
+}
+
+func mapCheckStaleFindings(items []artifact.StaleItem) []checkStaleFinding {
+	findings := make([]checkStaleFinding, 0, len(items))
+
+	for _, item := range items {
+		findings = append(findings, checkStaleFinding{
+			ID:         item.ID,
+			Title:      item.Title,
+			Kind:       item.Kind,
+			Category:   string(item.Category),
+			Reason:     item.Reason,
+			ValidUntil: item.ValidUntil,
+			DaysStale:  item.DaysStale,
+			REff:       item.REff,
+		})
+	}
+
+	return findings
+}
+
+func mapCheckDriftFindings(reports []artifact.DriftReport) []checkDriftFinding {
+	findings := make([]checkDriftFinding, 0, len(reports))
+
+	for _, report := range reports {
+		findings = append(findings, checkDriftFinding{
+			DecisionID:        report.DecisionID,
+			DecisionTitle:     report.DecisionTitle,
+			HasBaseline:       report.HasBaseline,
+			LikelyImplemented: report.LikelyImplemented,
+			Summary:           summarizeCheckDrift(report),
+			Files:             report.Files,
+		})
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].DecisionID < findings[j].DecisionID
+	})
+
+	return findings
+}
+
+func collectUnassessedFindings(
+	ctx context.Context,
+	store *artifact.Store,
+	decisions []*artifact.Artifact,
+) []checkDecisionFinding {
+	findings := make([]checkDecisionFinding, 0, len(decisions))
+
+	for _, decision := range decisions {
+		health := artifact.DeriveDecisionHealth(ctx, store, decision.Meta.ID)
+		if health.Maturity != artifact.DecisionMaturityUnassessed {
+			continue
+		}
+
+		findings = append(findings, checkDecisionFinding{
+			DecisionID: decision.Meta.ID,
+			Title:      decision.Meta.Title,
+			Context:    decision.Meta.Context,
+		})
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].DecisionID < findings[j].DecisionID
+	})
+
+	return findings
+}
+
+func collectCoverageGapFindings(
+	ctx context.Context,
+	store *artifact.Store,
+	decisions []*artifact.Artifact,
+) []checkCoverageGapFinding {
+	findings := make([]checkCoverageGapFinding, 0, len(decisions))
+
+	for _, decision := range decisions {
+		wlnk := artifact.ComputeWLNKSummary(ctx, store, decision.Meta.ID)
+		if len(wlnk.CoverageGaps) == 0 {
+			continue
+		}
+
+		findings = append(findings, checkCoverageGapFinding{
+			DecisionID: decision.Meta.ID,
+			Title:      decision.Meta.Title,
+			Gaps:       append([]string(nil), wlnk.CoverageGaps...),
+		})
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].DecisionID < findings[j].DecisionID
+	})
+
+	return findings
+}
+
+func summarizeCheckDrift(report artifact.DriftReport) string {
+	if !report.HasBaseline {
+		summary := fmt.Sprintf("no baseline — %d file(s) unmonitored", len(report.Files))
+		if report.LikelyImplemented {
+			summary += " — git activity detected after decision date"
+		}
+		return summary
+	}
+
+	modified := 0
+	added := 0
+	missing := 0
+	unbaselined := 0
+
+	for _, file := range report.Files {
+		switch file.Status {
+		case artifact.DriftModified:
+			modified++
+		case artifact.DriftAdded:
+			added++
+		case artifact.DriftMissing:
+			missing++
+		case artifact.DriftNoBaseline:
+			unbaselined++
+		}
+	}
+
+	parts := []string{
+		fmt.Sprintf("%d modified", modified),
+	}
+	if added > 0 {
+		parts = append(parts, fmt.Sprintf("%d added", added))
+	}
+	if missing > 0 {
+		parts = append(parts, fmt.Sprintf("%d missing", missing))
+	}
+	if unbaselined > 0 {
+		parts = append(parts, fmt.Sprintf("%d unbaselined", unbaselined))
+	}
+
+	return "code drift — " + strings.Join(parts, ", ")
+}
+
+func writeCheckJSON(w io.Writer, report checkReport) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}
+
+func writeCheckSummary(w io.Writer, report checkReport) error {
+	var sb strings.Builder
+
+	if report.hasFindings() {
+		sb.WriteString(fmt.Sprintf("haft check: governance debt found (%d finding(s))\n", report.Summary.TotalFindings))
+	} else {
+		sb.WriteString("haft check: clean\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("stale: %d\n", len(report.Stale)))
+	sb.WriteString(fmt.Sprintf("drifted: %d\n", len(report.Drifted)))
+	sb.WriteString(fmt.Sprintf("unassessed: %d\n", len(report.Unassessed)))
+	sb.WriteString(fmt.Sprintf("coverage gaps: %d\n", len(report.CoverageGaps)))
+
+	appendStaleSection(&sb, report.Stale)
+	appendDriftSection(&sb, report.Drifted)
+	appendUnassessedSection(&sb, report.Unassessed)
+	appendCoverageSection(&sb, report.CoverageGaps)
+
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+func appendStaleSection(sb *strings.Builder, findings []checkStaleFinding) {
+	if len(findings) == 0 {
+		return
+	}
+
+	sb.WriteString("\nStale\n")
+	for _, finding := range findings {
+		sb.WriteString(fmt.Sprintf("- %s [%s]: %s\n", finding.Title, finding.ID, finding.Reason))
+	}
+}
+
+func appendDriftSection(sb *strings.Builder, findings []checkDriftFinding) {
+	if len(findings) == 0 {
+		return
+	}
+
+	sb.WriteString("\nDrift\n")
+	for _, finding := range findings {
+		sb.WriteString(fmt.Sprintf("- %s [%s]: %s\n", finding.DecisionTitle, finding.DecisionID, finding.Summary))
+	}
+}
+
+func appendUnassessedSection(sb *strings.Builder, findings []checkDecisionFinding) {
+	if len(findings) == 0 {
+		return
+	}
+
+	sb.WriteString("\nUnassessed\n")
+	for _, finding := range findings {
+		sb.WriteString(fmt.Sprintf("- %s [%s]\n", finding.Title, finding.DecisionID))
+	}
+}
+
+func appendCoverageSection(sb *strings.Builder, findings []checkCoverageGapFinding) {
+	if len(findings) == 0 {
+		return
+	}
+
+	sb.WriteString("\nCoverage Gaps\n")
+	for _, finding := range findings {
+		sb.WriteString(fmt.Sprintf("- %s [%s]: %s\n", finding.Title, finding.DecisionID, strings.Join(finding.Gaps, ", ")))
+	}
+}
+
+func (report checkReport) hasFindings() bool {
+	return report.Summary.TotalFindings > 0
+}

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -1,0 +1,454 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/m0n0x41d/haft/internal/artifact"
+	"github.com/m0n0x41d/haft/internal/project"
+)
+
+type checkTestProject struct {
+	root    string
+	haftDir string
+	store   *artifact.Store
+}
+
+type checkSeedData struct {
+	staleID string
+	driftID string
+	gapID   string
+}
+
+func TestBuildCheckReport_CleanProject(t *testing.T) {
+	fixture := newCheckTestProject(t)
+
+	report, err := buildCheckReport(context.Background(), fixture.store, fixture.root)
+	if err != nil {
+		t.Fatalf("buildCheckReport returned error: %v", err)
+	}
+
+	if report.hasFindings() {
+		t.Fatalf("expected clean report, got %+v", report)
+	}
+	if report.Summary.TotalFindings != 0 {
+		t.Fatalf("total_findings = %d, want 0", report.Summary.TotalFindings)
+	}
+}
+
+func TestBuildCheckReport_FindsGovernanceDebt(t *testing.T) {
+	fixture := newCheckTestProject(t)
+	seeded := seedGovernanceDebt(t, fixture)
+
+	report, err := buildCheckReport(context.Background(), fixture.store, fixture.root)
+	if err != nil {
+		t.Fatalf("buildCheckReport returned error: %v", err)
+	}
+
+	if got := len(report.Stale); got != 1 {
+		t.Fatalf("len(Stale) = %d, want 1", got)
+	}
+	if got := report.Stale[0].ID; got != seeded.staleID {
+		t.Fatalf("stale ID = %q, want %q", got, seeded.staleID)
+	}
+
+	if got := len(report.Drifted); got != 1 {
+		t.Fatalf("len(Drifted) = %d, want 1", got)
+	}
+	if got := report.Drifted[0].DecisionID; got != seeded.driftID {
+		t.Fatalf("drift decision_id = %q, want %q", got, seeded.driftID)
+	}
+	if !strings.Contains(report.Drifted[0].Summary, "code drift") {
+		t.Fatalf("drift summary = %q, want code drift summary", report.Drifted[0].Summary)
+	}
+
+	if got := len(report.Unassessed); got != 1 {
+		t.Fatalf("len(Unassessed) = %d, want 1", got)
+	}
+	if got := report.Unassessed[0].DecisionID; got != seeded.gapID {
+		t.Fatalf("unassessed decision_id = %q, want %q", got, seeded.gapID)
+	}
+
+	if got := len(report.CoverageGaps); got != 1 {
+		t.Fatalf("len(CoverageGaps) = %d, want 1", got)
+	}
+	if got := report.CoverageGaps[0].DecisionID; got != seeded.gapID {
+		t.Fatalf("coverage decision_id = %q, want %q", got, seeded.gapID)
+	}
+
+	wantGaps := []string{
+		"latency stays below 50ms",
+		"throughput stays above 100k events/sec",
+	}
+	gotGaps := strings.Join(report.CoverageGaps[0].Gaps, ",")
+	if got := gotGaps; got != strings.Join(wantGaps, ",") {
+		t.Fatalf("coverage gaps = %q, want %q", got, strings.Join(wantGaps, ","))
+	}
+
+	if got := report.Summary.TotalFindings; got != 4 {
+		t.Fatalf("total_findings = %d, want 4", got)
+	}
+}
+
+func TestRunCheck_CleanProjectPrintsSummaryAndStaysZero(t *testing.T) {
+	fixture := newCheckTestProject(t)
+	restore := enterTestProjectRoot(t, fixture.root)
+	defer restore()
+
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	restoreJSON := stubCheckJSON(t, false)
+	defer restoreJSON()
+
+	exitCode := stubCheckExit(t)
+
+	err := runCheck(cmd, nil)
+	if err != nil {
+		t.Fatalf("runCheck returned error: %v", err)
+	}
+	if *exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", *exitCode)
+	}
+
+	result := output.String()
+	if !strings.Contains(result, "haft check: clean") {
+		t.Fatalf("summary output = %q, want clean heading", result)
+	}
+}
+
+func TestRunCheck_JSONExitsOneWhenFindingsExist(t *testing.T) {
+	fixture := newCheckTestProject(t)
+	seedGovernanceDebt(t, fixture)
+
+	restore := enterTestProjectRoot(t, fixture.root)
+	defer restore()
+
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	restoreJSON := stubCheckJSON(t, true)
+	defer restoreJSON()
+
+	exitCode := stubCheckExit(t)
+
+	err := runCheck(cmd, nil)
+	if err != nil {
+		t.Fatalf("runCheck returned error: %v", err)
+	}
+	if *exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", *exitCode)
+	}
+
+	var report checkReport
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatalf("decode JSON output: %v", err)
+	}
+	if got := report.Summary.TotalFindings; got != 4 {
+		t.Fatalf("total_findings = %d, want 4", got)
+	}
+}
+
+func newCheckTestProject(t *testing.T) checkTestProject {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	root := t.TempDir()
+	haftDir := filepath.Join(root, ".haft")
+	if err := os.MkdirAll(haftDir, 0o755); err != nil {
+		t.Fatalf("create .haft dir: %v", err)
+	}
+
+	cfg, err := project.Create(haftDir, root)
+	if err != nil {
+		t.Fatalf("create project config: %v", err)
+	}
+
+	dbPath, err := cfg.DBPath()
+	if err != nil {
+		t.Fatalf("resolve DB path: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite DB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	createCheckSchema(t, db)
+
+	return checkTestProject{
+		root:    root,
+		haftDir: haftDir,
+		store:   artifact.NewStore(db),
+	}
+}
+
+func createCheckSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	statements := []string{
+		`CREATE TABLE artifacts (
+			id TEXT PRIMARY KEY,
+			kind TEXT NOT NULL,
+			version INTEGER NOT NULL DEFAULT 1,
+			status TEXT NOT NULL DEFAULT 'active',
+			context TEXT,
+			mode TEXT,
+			title TEXT NOT NULL,
+			content TEXT NOT NULL,
+			file_path TEXT,
+			valid_until TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			search_keywords TEXT DEFAULT '',
+			structured_data TEXT DEFAULT ''
+		)`,
+		`CREATE TABLE artifact_links (
+			source_id TEXT NOT NULL,
+			target_id TEXT NOT NULL,
+			link_type TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (source_id, target_id, link_type)
+		)`,
+		`CREATE TABLE evidence_items (
+			id TEXT PRIMARY KEY,
+			artifact_ref TEXT NOT NULL,
+			type TEXT NOT NULL,
+			content TEXT NOT NULL,
+			verdict TEXT,
+			carrier_ref TEXT,
+			congruence_level INTEGER DEFAULT 3,
+			formality_level INTEGER DEFAULT 5,
+			claim_refs TEXT DEFAULT '[]',
+			claim_scope TEXT DEFAULT '[]',
+			valid_until TEXT,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE TABLE affected_files (
+			artifact_id TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			file_hash TEXT,
+			PRIMARY KEY (artifact_id, file_path)
+		)`,
+		`CREATE TABLE affected_symbols (
+			artifact_id TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			symbol_name TEXT NOT NULL,
+			symbol_kind TEXT NOT NULL,
+			symbol_line INTEGER,
+			symbol_end_line INTEGER,
+			symbol_hash TEXT,
+			PRIMARY KEY (artifact_id, file_path, symbol_name)
+		)`,
+		`CREATE VIRTUAL TABLE artifacts_fts USING fts5(id, title, content, kind, search_keywords, tokenize='porter unicode61')`,
+		`CREATE TRIGGER artifacts_fts_insert AFTER INSERT ON artifacts BEGIN
+			INSERT INTO artifacts_fts(id, title, content, kind, search_keywords)
+			VALUES (new.id, new.title, new.content, new.kind, new.search_keywords);
+		END`,
+		`CREATE TRIGGER artifacts_fts_update AFTER UPDATE ON artifacts BEGIN
+			DELETE FROM artifacts_fts WHERE id = old.id;
+			INSERT INTO artifacts_fts(id, title, content, kind, search_keywords)
+			VALUES (new.id, new.title, new.content, new.kind, new.search_keywords);
+		END`,
+		`CREATE TRIGGER artifacts_fts_delete AFTER DELETE ON artifacts BEGIN
+			DELETE FROM artifacts_fts WHERE id = old.id;
+		END`,
+	}
+
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("create schema: %v\nSQL: %s", err, statement)
+		}
+	}
+}
+
+func seedGovernanceDebt(t *testing.T, fixture checkTestProject) checkSeedData {
+	t.Helper()
+
+	staleValidUntil := time.Now().Add(-72 * time.Hour).Format("2006-01-02")
+
+	staleProblem := mustFrameProblem(t, fixture, artifact.ProblemFrameInput{
+		Title:  "Expired problem framing",
+		Signal: "Need one stale artifact that does not overlap with evidence freshness logic.",
+	})
+	mustSetValidUntil(t, fixture, staleProblem.Meta.ID, staleValidUntil)
+
+	driftPath := filepath.Join(fixture.root, "drifted.go")
+	if err := os.WriteFile(driftPath, []byte("package main\n\nfunc governed() {}\n"), 0o644); err != nil {
+		t.Fatalf("write drift seed file: %v", err)
+	}
+
+	driftDecision := mustCreateDecision(t, fixture, artifact.DecideInput{
+		SelectedTitle:   "Protect drifted file",
+		WhySelected:     "Need a baselined decision that will drift after the baseline.",
+		SelectionPolicy: "Prefer a single-file drift case for deterministic output.",
+		CounterArgument: "The file change may be too small to exercise diff reporting.",
+		WeakestLink:     "Baseline and drift detection must both agree on the governed file.",
+		WhyNotOthers: []artifact.RejectionReason{{
+			Variant: "No drift fixture",
+			Reason:  "Would miss the drift category entirely.",
+		}},
+		Rollback: &artifact.RollbackSpec{
+			Triggers: []string{"Drift findings stop reporting modified files."},
+		},
+		AffectedFiles: []string{"drifted.go"},
+	})
+	mustBaselineDecision(t, fixture, driftDecision.Meta.ID)
+	mustMeasureDecision(t, fixture, driftDecision.Meta.ID)
+
+	if err := os.WriteFile(driftPath, []byte("package main\n\nfunc governed() {\n\tprintln(\"drift\")\n}\n"), 0o644); err != nil {
+		t.Fatalf("write drifted file: %v", err)
+	}
+
+	problem := mustFrameProblem(t, fixture, artifact.ProblemFrameInput{
+		Title:      "Coverage gap problem",
+		Signal:     "Decision evidence has not been attached yet.",
+		Acceptance: "- latency stays below 50ms\n- throughput stays above 100k events/sec",
+	})
+
+	gapDecision := mustCreateDecision(t, fixture, artifact.DecideInput{
+		ProblemRef:      problem.Meta.ID,
+		SelectedTitle:   "Record decision before measurement",
+		WhySelected:     "Need one active decision with explicit acceptance coverage gaps.",
+		SelectionPolicy: "Prefer the smallest decision that still links to a framed problem.",
+		CounterArgument: "An empty evidence chain might be too synthetic.",
+		WeakestLink:     "Coverage depends on the acceptance scope being linked through the problem.",
+		WhyNotOthers: []artifact.RejectionReason{{
+			Variant: "Attach measurement immediately",
+			Reason:  "Would remove the unassessed and coverage-gap findings.",
+		}},
+		Rollback: &artifact.RollbackSpec{
+			Triggers: []string{"Coverage gaps are no longer reported for acceptance criteria."},
+		},
+	})
+
+	return checkSeedData{
+		staleID: staleProblem.Meta.ID,
+		driftID: driftDecision.Meta.ID,
+		gapID:   gapDecision.Meta.ID,
+	}
+}
+
+func mustFrameProblem(t *testing.T, fixture checkTestProject, input artifact.ProblemFrameInput) *artifact.Artifact {
+	t.Helper()
+
+	ctx := context.Background()
+	problem, _, err := artifact.FrameProblem(ctx, fixture.store, fixture.haftDir, input)
+	if err != nil {
+		t.Fatalf("frame problem: %v", err)
+	}
+
+	return problem
+}
+
+func mustCreateDecision(t *testing.T, fixture checkTestProject, input artifact.DecideInput) *artifact.Artifact {
+	t.Helper()
+
+	ctx := context.Background()
+	decision, _, err := artifact.Decide(ctx, fixture.store, fixture.haftDir, input)
+	if err != nil {
+		t.Fatalf("create decision: %v", err)
+	}
+
+	return decision
+}
+
+func mustMeasureDecision(t *testing.T, fixture checkTestProject, decisionID string) {
+	t.Helper()
+
+	ctx := context.Background()
+	_, err := artifact.Measure(ctx, fixture.store, fixture.haftDir, artifact.MeasureInput{
+		DecisionRef:  decisionID,
+		Findings:     "Verification completed successfully.",
+		Measurements: []string{"p99 latency: 18ms"},
+		Verdict:      "accepted",
+	})
+	if err != nil {
+		t.Fatalf("measure decision %s: %v", decisionID, err)
+	}
+}
+
+func mustBaselineDecision(t *testing.T, fixture checkTestProject, decisionID string) {
+	t.Helper()
+
+	ctx := context.Background()
+	_, err := artifact.Baseline(ctx, fixture.store, fixture.root, artifact.BaselineInput{
+		DecisionRef: decisionID,
+	})
+	if err != nil {
+		t.Fatalf("baseline decision %s: %v", decisionID, err)
+	}
+}
+
+func mustSetValidUntil(t *testing.T, fixture checkTestProject, artifactID string, validUntil string) {
+	t.Helper()
+
+	ctx := context.Background()
+	item, err := fixture.store.Get(ctx, artifactID)
+	if err != nil {
+		t.Fatalf("load artifact %s: %v", artifactID, err)
+	}
+
+	item.Meta.ValidUntil = validUntil
+	if err := fixture.store.Update(ctx, item); err != nil {
+		t.Fatalf("update valid_until for %s: %v", artifactID, err)
+	}
+}
+
+func enterTestProjectRoot(t *testing.T, dir string) func() {
+	t.Helper()
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+
+	return func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}
+}
+
+func stubCheckJSON(t *testing.T, value bool) func() {
+	t.Helper()
+
+	previous := checkJSON
+	checkJSON = value
+
+	return func() {
+		checkJSON = previous
+	}
+}
+
+func stubCheckExit(t *testing.T) *int {
+	t.Helper()
+
+	exitCode := new(int)
+	previous := checkExit
+	checkExit = func(code int) {
+		*exitCode = code
+	}
+	t.Cleanup(func() {
+		checkExit = previous
+	})
+
+	return exitCode
+}

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -160,6 +160,52 @@ func TestRunCheck_JSONExitsOneWhenFindingsExist(t *testing.T) {
 	}
 }
 
+func TestWriteCheckJSON_ZeroValueUsesStableSchema(t *testing.T) {
+	var output bytes.Buffer
+
+	err := writeCheckJSON(&output, checkReport{})
+	if err != nil {
+		t.Fatalf("writeCheckJSON returned error: %v", err)
+	}
+
+	var payload map[string]json.RawMessage
+	err = json.Unmarshal(output.Bytes(), &payload)
+	if err != nil {
+		t.Fatalf("decode JSON output: %v", err)
+	}
+
+	wantArrays := map[string]string{
+		"stale":         "[]",
+		"drifted":       "[]",
+		"unassessed":    "[]",
+		"coverage_gaps": "[]",
+	}
+
+	for field, want := range wantArrays {
+		got, ok := payload[field]
+		if !ok {
+			t.Fatalf("missing top-level field %q", field)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %s, want %s", field, string(got), want)
+		}
+	}
+
+	gotSummary, ok := payload["summary"]
+	if !ok {
+		t.Fatalf("missing top-level field %q", "summary")
+	}
+
+	var summary checkSummary
+	err = json.Unmarshal(gotSummary, &summary)
+	if err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.TotalFindings != 0 {
+		t.Fatalf("summary.total_findings = %d, want 0", summary.TotalFindings)
+	}
+}
+
 func newCheckTestProject(t *testing.T) checkTestProject {
 	t.Helper()
 

--- a/internal/cli/commands/h-onboard.md
+++ b/internal/cli/commands/h-onboard.md
@@ -4,11 +4,9 @@ description: "Discover existing project knowledge and build a legacy map"
 
 # Project Onboarding
 
-Quint was just initialized on this project. Help the user discover and capture existing engineering knowledge.
+Haft was just initialized on this project. Discover and capture existing engineering knowledge.
 
-## Discovery protocol
-
-Scan the project systematically. For each finding, use the appropriate Quint tool to record it.
+## Phase 1: Surface scan (always run)
 
 ### 1. Project overview
 - Read `README.md` — extract purpose, tech stack, key components, architecture
@@ -49,27 +47,60 @@ Check `git log --oneline -20` for:
 - Architecture changes
 - Patterns in commit messages that suggest undocumented decisions
 
-### 7. Module coverage analysis
-Run `haft_query(action="coverage")` to get the module map and decision coverage:
-- Identify **blind modules** — parts of the codebase with no engineering decisions
-- Prioritize blind modules by criticality: modules with many dependents and no decisions are the highest-risk blind spots
-- For the most critical blind modules: suggest framing problems for key invariants
-- Report the coverage percentage and highlight the top 3-5 blind spots
+## Phase 2: Module coverage deep scan (always run)
 
-### 8. Unresolved problems
+### 7. Module coverage analysis
+Run `haft_query(action="coverage")` to get the full module map:
+- List ALL modules with their governance status (governed / partial / blind)
+- Count total modules, governed percentage, blind count
+- **Prioritize blind modules** by: number of dependents (from dependency graph), lines of code, recent git activity
+
+### 8. Deep scan of blind modules
+
+**This is the critical step.** For each blind module, starting with highest priority:
+
+- **Read the module's code** — main files, exported interfaces, key types
+- **Determine the module's responsibility** — what does it do, what invariants does it maintain
+- **Identify dependencies** — what does it import, what depends on it
+- **Look for implicit decisions** — coding patterns, error handling conventions, data flow assumptions
+- **Record findings** as `haft_note` with:
+  - Module name and responsibility
+  - Key invariants (what must hold)
+  - Implicit decisions worth making explicit
+  - Risk assessment (what breaks if this module changes without governance)
+
+**If you have subagent/parallel execution capability:** spawn one subagent per blind module for parallel analysis. Each subagent gets:
+- Module path and file list
+- Project context (README, tech stack from Phase 1)
+- Instruction: "Read all code in this module. Report: responsibility, invariants, implicit decisions, dependencies, risks. Record as haft_note."
+
+Merge subagent results and continue.
+
+### 9. Unresolved problems
 If you find architectural tensions, TODO comments about design issues, or open questions:
 - Use `haft_problem(action="frame")` to capture them as ProblemCards
-- These become the starting point for the user's next reasoning cycle
-- Cross-reference with blind modules from step 7 — blind modules with design tensions are highest priority
+- Cross-reference with blind modules — blind modules with design tensions are highest priority
 
 ## Output
-After scanning, report:
-- How many notes were created
-- How many problems were discovered
-- What key decisions are now searchable in Quint
-- What gaps exist (decisions mentioned but not documented, missing ADRs)
-- **Module coverage**: X modules detected, Y% governed, Z blind spots identified
 
-Suggest next steps: `/h-status` to see the knowledge map and module coverage, `/h-frame` for the most pressing unresolved problem or highest-risk blind module.
+After scanning, report:
+
+### Coverage summary
+```
+Modules: X total, Y governed (Z%), W blind
+Blind modules scanned: N (with deep analysis)
+```
+
+### Findings
+- Notes created: N (X from docs, Y from module analysis)
+- Problems discovered: M
+- Key decisions now searchable
+- Gaps: decisions mentioned but not documented, missing ADRs
+- **Top 3 highest-risk blind spots** with reasoning
+
+### Next steps
+- `/h-status` — see the knowledge map and module coverage
+- `/h-frame` — frame the most pressing unresolved problem
+- For very large projects: suggest running onboard again focused on specific subsystems
 
 $ARGUMENTS

--- a/internal/cli/governance_attention.go
+++ b/internal/cli/governance_attention.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/m0n0x41d/haft/internal/artifact"
+	"github.com/m0n0x41d/haft/internal/graph"
+)
+
+func scanGovernanceAttention(ctx context.Context, store *artifact.Store) artifact.GovernanceAttention {
+	if store == nil {
+		return artifact.GovernanceAttention{}
+	}
+
+	statusData, _ := artifact.FetchStatusData(ctx, store, "")
+	attention := artifact.GovernanceAttention{
+		BacklogCount:    len(statusData.BacklogProblems),
+		InProgressCount: len(statusData.InProgressProblems),
+	}
+
+	problems, _ := store.ListByKind(ctx, artifact.KindProblemCard, 0)
+	for _, problem := range problems {
+		if problem.Meta.Status != artifact.StatusAddressed {
+			continue
+		}
+
+		backlinks, err := store.GetBacklinks(ctx, problem.Meta.ID)
+		if err != nil {
+			continue
+		}
+
+		hasDecision := false
+		for _, backlink := range backlinks {
+			if backlink.Type != "based_on" {
+				continue
+			}
+			linked, err := store.Get(ctx, backlink.Ref)
+			if err != nil {
+				continue
+			}
+			if linked.Meta.Kind == artifact.KindDecisionRecord {
+				hasDecision = true
+				break
+			}
+		}
+		if hasDecision {
+			continue
+		}
+
+		attention.AddressedWithoutDecision = append(attention.AddressedWithoutDecision, artifact.AddressedProblemGap{
+			ProblemID: problem.Meta.ID,
+			Title:     problem.Meta.Title,
+		})
+	}
+
+	graphStore := graph.NewStore(store.DB())
+	decisions, _ := store.ListByKind(ctx, artifact.KindDecisionRecord, 0)
+	for _, decision := range decisions {
+		if decision.Meta.Status != artifact.StatusActive && decision.Meta.Status != artifact.StatusRefreshDue {
+			continue
+		}
+
+		results, err := graph.VerifyInvariants(ctx, graphStore, store.DB(), decision.Meta.ID)
+		if err != nil {
+			continue
+		}
+
+		for _, result := range results {
+			if result.Status != graph.InvariantViolated {
+				continue
+			}
+			attention.InvariantViolations = append(attention.InvariantViolations, artifact.InvariantViolationFinding{
+				DecisionID:    decision.Meta.ID,
+				DecisionTitle: decision.Meta.Title,
+				Invariant:     result.Invariant.Text,
+				Reason:        result.Reason,
+			})
+		}
+	}
+
+	return attention
+}

--- a/internal/cli/governance_attention_test.go
+++ b/internal/cli/governance_attention_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/m0n0x41d/haft/internal/artifact"
+)
+
+func TestScanGovernanceAttention_SurfacesProblemCountsOrphansAndInvariantViolations(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+
+	mustExecGovernanceAttentionSQL(t, store,
+		`INSERT INTO codebase_modules(module_id, path, name, lang, last_scanned) VALUES
+			('mod-api', 'internal/api', 'api', 'go', CURRENT_TIMESTAMP),
+			('mod-db', 'internal/database', 'database', 'go', CURRENT_TIMESTAMP)`,
+		`INSERT INTO module_dependencies(source_module, target_module, dep_type, last_scanned) VALUES
+			('mod-api', 'mod-db', 'import', CURRENT_TIMESTAMP)`,
+	)
+
+	backlogProblem := &artifact.Artifact{
+		Meta: artifact.Meta{ID: "prob-backlog", Kind: artifact.KindProblemCard, Status: artifact.StatusActive, Title: "Backlog problem"},
+		Body: "problem",
+	}
+	if err := store.Create(ctx, backlogProblem); err != nil {
+		t.Fatal(err)
+	}
+
+	inProgressProblem := &artifact.Artifact{
+		Meta: artifact.Meta{ID: "prob-progress", Kind: artifact.KindProblemCard, Status: artifact.StatusActive, Title: "In progress problem"},
+		Body: "problem",
+	}
+	if err := store.Create(ctx, inProgressProblem); err != nil {
+		t.Fatal(err)
+	}
+
+	portfolio := &artifact.Artifact{
+		Meta: artifact.Meta{
+			ID:     "sol-001",
+			Kind:   artifact.KindSolutionPortfolio,
+			Status: artifact.StatusActive,
+			Title:  "Portfolio",
+			Links:  []artifact.Link{{Ref: inProgressProblem.Meta.ID, Type: "based_on"}},
+		},
+		Body: "portfolio",
+	}
+	if err := store.Create(ctx, portfolio); err != nil {
+		t.Fatal(err)
+	}
+
+	addressedProblem := &artifact.Artifact{
+		Meta: artifact.Meta{ID: "prob-addressed", Kind: artifact.KindProblemCard, Status: artifact.StatusAddressed, Title: "Addressed without decision"},
+		Body: "problem",
+	}
+	if err := store.Create(ctx, addressedProblem); err != nil {
+		t.Fatal(err)
+	}
+
+	structuredJSON, err := json.Marshal(artifact.DecisionFields{
+		Invariants: []string{"no dependency from api to database"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decision := &artifact.Artifact{
+		Meta: artifact.Meta{ID: "dec-001", Kind: artifact.KindDecisionRecord, Status: artifact.StatusActive, Title: "Invariant decision"},
+		Body: "decision",
+		StructuredData: string(structuredJSON),
+	}
+	if err := store.Create(ctx, decision); err != nil {
+		t.Fatal(err)
+	}
+
+	attention := scanGovernanceAttention(ctx, store)
+
+	if attention.BacklogCount != 1 {
+		t.Fatalf("BacklogCount = %d, want 1", attention.BacklogCount)
+	}
+	if attention.InProgressCount != 1 {
+		t.Fatalf("InProgressCount = %d, want 1", attention.InProgressCount)
+	}
+	if len(attention.AddressedWithoutDecision) != 1 {
+		t.Fatalf("AddressedWithoutDecision = %#v, want 1 item", attention.AddressedWithoutDecision)
+	}
+	if attention.AddressedWithoutDecision[0].ProblemID != "prob-addressed" {
+		t.Fatalf("orphan problem = %#v", attention.AddressedWithoutDecision[0])
+	}
+	if len(attention.InvariantViolations) != 1 {
+		t.Fatalf("InvariantViolations = %#v, want 1 item", attention.InvariantViolations)
+	}
+	if attention.InvariantViolations[0].DecisionID != "dec-001" {
+		t.Fatalf("invariant violation = %#v", attention.InvariantViolations[0])
+	}
+}
+
+func mustExecGovernanceAttentionSQL(t *testing.T, store *artifact.Store, statements ...string) {
+	t.Helper()
+
+	for _, statement := range statements {
+		if _, err := store.DB().Exec(statement); err != nil {
+			t.Fatalf("exec %q: %v", statement, err)
+		}
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -379,6 +379,14 @@ func createDirectoryStructure(haftDir string) error {
 			return err
 		}
 	}
+
+	workflowPath := project.WorkflowPath(haftDir)
+	if _, err := os.Stat(workflowPath); os.IsNotExist(err) {
+		if err := os.WriteFile(workflowPath, []byte(project.ExampleWorkflowMarkdown()), 0o644); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateDirectoryStructure_CreatesWorkflowExample(t *testing.T) {
+	haftDir := filepath.Join(t.TempDir(), ".haft")
+
+	if err := createDirectoryStructure(haftDir); err != nil {
+		t.Fatalf("createDirectoryStructure returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(haftDir, "workflow.md"))
+	if err != nil {
+		t.Fatalf("read workflow example: %v", err)
+	}
+
+	if !strings.Contains(string(data), "## Defaults") {
+		t.Fatalf("workflow example missing Defaults section:\n%s", string(data))
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -73,6 +73,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	server := fpf.NewServer()
 
+	workflow, workflowErr := project.LoadWorkflow(cwd)
+	if workflowErr != nil {
+		logger.Warn().Err(workflowErr).Msg("failed to load workflow policy")
+	} else if workflow != nil {
+		server.SetInstructions(workflow.PromptPrefix())
+	}
+
 	// Load project identity
 	projCfg, err := project.Load(haftDir)
 	if err != nil {
@@ -359,6 +366,9 @@ func handleQuintProblem(ctx context.Context, store *artifact.Store, haftDir stri
 		input := artifact.ProblemFrameInput{Context: contextName}
 		if v, ok := args["title"].(string); ok {
 			input.Title = v
+		}
+		if v, ok := args["problem_type"].(string); ok {
+			input.ProblemType = v
 		}
 		if v, ok := args["signal"].(string); ok {
 			input.Signal = v
@@ -856,6 +866,8 @@ func handleQuintRefresh(ctx context.Context, store *artifact.Store, haftDir stri
 			return "", err
 		}
 		result := present.ScanResponse(items, "")
+		governanceAttention := scanGovernanceAttention(ctx, store)
+		result += present.GovernanceAttentionResponse(governanceAttention)
 
 		// Level C: enrich drift reports with dependency impact
 		driftReports, _ := artifact.CheckDrift(ctx, store, projectRoot)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -394,6 +394,11 @@ func handleQuintProblem(ctx context.Context, store *artifact.Store, haftDir stri
 		if v, ok := args["parity_rules"].(string); ok {
 			input.ParityRules = v
 		}
+		parityPlan, err := parseStrictParityPlanFromArgs(args, "parity_plan")
+		if err != nil {
+			return "", err
+		}
+		input.ParityPlan = parityPlan
 		// Log all args keys and types for debugging
 		for k, v := range args {
 			logger.Debug().Str("key", k).Str("type", fmt.Sprintf("%T", v)).Msg("characterize arg")
@@ -503,6 +508,11 @@ func handleQuintSolution(ctx context.Context, store *artifact.Store, haftDir str
 		_ = parseJSONArg(args, "dominated_variants", &input.Results.DominatedVariants)
 		_ = parseJSONArg(args, "pareto_tradeoffs", &input.Results.ParetoTradeoffs)
 		_ = parseJSONArg(args, "incomparable", &input.Results.Incomparable)
+		parityPlan, err := parseStrictParityPlanFromArgs(args, "parity_plan")
+		if err != nil {
+			return "", err
+		}
+		input.Results.ParityPlan = parityPlan
 		if input.PortfolioRef == "" {
 			p, _ := artifact.FindActivePortfolio(ctx, store, contextName)
 			if p != nil {
@@ -518,7 +528,7 @@ func handleQuintSolution(ctx context.Context, store *artifact.Store, haftDir str
 			return "", err
 		}
 		navStrip := present.NavStrip(artifact.ComputeNavState(ctx, store, contextName))
-		return present.SolutionResponse("compare", a, filePath, navStrip), nil
+		return compareToolResponse(a, filePath, navStrip), nil
 
 	case "similar":
 		query, _ := args["query"].(string)
@@ -1151,6 +1161,20 @@ func parseStrictRollbackSpecFromArgs(args map[string]any, key string) (*artifact
 	return &value, nil
 }
 
+func parseStrictParityPlanFromArgs(args map[string]any, key string) (*artifact.ParityPlan, error) {
+	var value artifact.ParityPlan
+
+	present, err := decodeStrictArgFromArgs(args, key, &value)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be an object with parity plan fields", key)
+	}
+	if !present {
+		return nil, nil
+	}
+
+	return &value, nil
+}
+
 func parsePredictionInputsFromArgs(args map[string]any, key string) ([]artifact.PredictionInput, error) {
 	var predictions []artifact.PredictionInput
 
@@ -1313,6 +1337,26 @@ func parseJSONArg(args map[string]any, key string, target any) bool {
 	}
 
 	return true
+}
+
+func compareToolResponse(a *artifact.Artifact, filePath string, navStrip string) string {
+	response := present.SolutionResponse("compare", a, filePath, "")
+	warnings := artifact.ExtractComparisonWarnings(a.Body)
+	if len(warnings) == 0 {
+		return response + navStrip
+	}
+
+	var builder strings.Builder
+	builder.WriteString(response)
+	builder.WriteString("Comparison warnings:\n")
+	for _, warning := range warnings {
+		builder.WriteString("- ")
+		builder.WriteString(warning)
+		builder.WriteString("\n")
+	}
+	builder.WriteString(navStrip)
+
+	return builder.String()
 }
 
 // parseVariants handles MCP client serialization of the variants array.

--- a/internal/cli/serve_projection_test.go
+++ b/internal/cli/serve_projection_test.go
@@ -202,7 +202,7 @@ func TestHandleQuintQuery_ProjectionRendersChangeRationaleAlias(t *testing.T) {
 		"Rejected alternatives:",
 		"- REST: Higher steady-state latency with no decisive cost advantage.",
 		"Rollback summary: Latency regresses in production.",
-		"Latest measurement verdict: partial",
+		"Latest measurement verdict: weakens",
 		"── Haft",
 	}
 

--- a/internal/cli/serve_projection_test.go
+++ b/internal/cli/serve_projection_test.go
@@ -39,11 +39,12 @@ func TestHandleQuintQuery_ProjectionRendersAuditView(t *testing.T) {
 	}
 
 	_, err = artifact.AttachEvidence(ctx, store, artifact.EvidenceInput{
-		ArtifactRef: decision.Meta.ID,
-		Content:     "Replay benchmark kept p95 latency below 25ms.",
-		Type:        "measurement",
-		Verdict:     "supports",
-		ClaimScope:  []string{"latency"},
+		ArtifactRef:     decision.Meta.ID,
+		Content:         "Replay benchmark kept p95 latency below 25ms.",
+		Type:            "measurement",
+		Verdict:         "supports",
+		CongruenceLevel: 3,
+		ClaimScope:      []string{"latency"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/serve_solution_test.go
+++ b/internal/cli/serve_solution_test.go
@@ -51,6 +51,41 @@ func TestHandleQuintProblem_CharacterizePersistsStructuredParityPlan(t *testing.
 	}
 }
 
+func TestHandleQuintProblem_FramePersistsProblemType(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	result, err := handleQuintProblem(ctx, store, haftDir, map[string]any{
+		"action":       "frame",
+		"title":        "Search for a transport",
+		"problem_type": "search",
+		"signal":       "Existing options do not satisfy the deployment constraints",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "Type: search") {
+		t.Fatalf("expected frame response to show problem type, got %s", result)
+	}
+
+	problems, err := artifact.SelectProblems(ctx, store, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 {
+		t.Fatalf("expected 1 problem, got %d", len(problems))
+	}
+
+	reloaded, err := store.Get(ctx, problems[0].Meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.UnmarshalProblemFields().ProblemType; got != artifact.ProblemTypeSearch {
+		t.Fatalf("problem_type = %q", got)
+	}
+}
+
 func TestHandleQuintSolution_CompareSurfacesMissingParityPlanWarning(t *testing.T) {
 	store := setupCLIArtifactStore(t)
 	ctx := context.Background()

--- a/internal/cli/serve_solution_test.go
+++ b/internal/cli/serve_solution_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/m0n0x41d/haft/internal/artifact"
+)
+
+func TestHandleQuintProblem_CharacterizePersistsStructuredParityPlan(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	problem, _, err := artifact.FrameProblem(ctx, store, haftDir, artifact.ProblemFrameInput{
+		Title:   "Transport choice",
+		Signal:  "Latency variance",
+		Context: "api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = handleQuintProblem(ctx, store, haftDir, map[string]any{
+		"action":      "characterize",
+		"problem_ref": problem.Meta.ID,
+		"dimensions": []any{
+			map[string]any{"name": "latency"},
+		},
+		"parity_plan": `{"baseline_set":["REST","gRPC"],"window":"same 15m replay window","budget":"$200/month","missing_data_policy":"explicit_abstain"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := store.Get(ctx, problem.Meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fields := reloaded.UnmarshalProblemFields()
+	if len(fields.Characterizations) != 1 {
+		t.Fatalf("expected 1 characterization, got %+v", fields.Characterizations)
+	}
+	if fields.Characterizations[0].ParityPlan == nil {
+		t.Fatal("expected structured parity plan to be persisted")
+	}
+	if got := fields.Characterizations[0].ParityPlan.Window; got != "same 15m replay window" {
+		t.Fatalf("window = %q", got)
+	}
+}
+
+func TestHandleQuintSolution_CompareSurfacesMissingParityPlanWarning(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+	portfolio := mustExploreServeComparePortfolio(t, ctx, store, haftDir, "")
+
+	result, err := handleQuintSolution(ctx, store, haftDir, map[string]any{
+		"action":        "compare",
+		"portfolio_ref": portfolio.Meta.ID,
+		"dimensions":    []any{"latency"},
+		"scores": map[string]any{
+			"REST": map[string]any{"latency": "42ms"},
+			"gRPC": map[string]any{"latency": "18ms"},
+		},
+		"non_dominated_set": []any{"gRPC"},
+		"dominated_variants": []map[string]any{{
+			"variant":      "REST",
+			"dominated_by": []string{"gRPC"},
+			"summary":      "Higher latency with no compensating benefit in this comparison.",
+		}},
+		"pareto_tradeoffs": []map[string]any{{
+			"variant": "gRPC",
+			"summary": "Lowest latency result among the compared variants.",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "Comparison warnings:") {
+		t.Fatalf("expected compare response to surface warnings, got %s", result)
+	}
+	if !strings.Contains(result, "without a parity_plan") {
+		t.Fatalf("expected missing parity-plan warning, got %s", result)
+	}
+}
+
+func TestHandleQuintSolution_CompareSurfacesUnstructuredParityPlanWarning(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+	portfolio := mustExploreServeComparePortfolio(t, ctx, store, haftDir, "deep")
+
+	result, err := handleQuintSolution(ctx, store, haftDir, map[string]any{
+		"action":        "compare",
+		"portfolio_ref": portfolio.Meta.ID,
+		"dimensions":    []any{"latency"},
+		"scores": map[string]any{
+			"REST": map[string]any{"latency": "42ms"},
+			"gRPC": map[string]any{"latency": "18ms"},
+		},
+		"non_dominated_set": []any{"gRPC"},
+		"dominated_variants": []map[string]any{{
+			"variant":      "REST",
+			"dominated_by": []string{"gRPC"},
+			"summary":      "Higher latency with no compensating benefit in this comparison.",
+		}},
+		"pareto_tradeoffs": []map[string]any{{
+			"variant": "gRPC",
+			"summary": "Lowest latency result among the compared variants.",
+		}},
+		"parity_plan": `{"window":"same 15m replay window"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(result, "Comparison warnings:") {
+		t.Fatalf("expected compare response to surface warnings, got %s", result)
+	}
+	if !strings.Contains(result, "received an unstructured parity_plan") {
+		t.Fatalf("expected unstructured parity-plan warning, got %s", result)
+	}
+}
+
+func mustExploreServeComparePortfolio(
+	t *testing.T,
+	ctx context.Context,
+	store *artifact.Store,
+	haftDir string,
+	mode string,
+) *artifact.Artifact {
+	t.Helper()
+
+	portfolio, _, err := artifact.ExploreSolutions(ctx, store, haftDir, artifact.ExploreInput{
+		Mode: mode,
+		Variants: []artifact.Variant{
+			{
+				Title:         "REST",
+				WeakestLink:   "chatty serialization",
+				NoveltyMarker: "Keep the existing HTTP semantics",
+			},
+			{
+				Title:         "gRPC",
+				WeakestLink:   "tooling overhead",
+				NoveltyMarker: "Adopt binary RPC for lower-latency transport",
+			},
+		},
+		NoSteppingStoneRationale: "Both transports are direct architecture candidates.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return portfolio
+}

--- a/internal/fpf/server.go
+++ b/internal/fpf/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/m0n0x41d/haft/logger"
 )
@@ -49,7 +50,8 @@ type ContentItem struct {
 type V5ToolHandler func(ctx context.Context, toolName string, params json.RawMessage) (string, error)
 
 type Server struct {
-	v5Handler V5ToolHandler
+	v5Handler     V5ToolHandler
+	instructions string
 }
 
 func NewServer() *Server {
@@ -59,6 +61,10 @@ func NewServer() *Server {
 // SetV5Handler registers the handler for v5 tools (haft_note, haft_problem, etc).
 func (s *Server) SetV5Handler(h V5ToolHandler) {
 	s.v5Handler = h
+}
+
+func (s *Server) SetInstructions(instructions string) {
+	s.instructions = strings.TrimSpace(instructions)
 }
 
 func (s *Server) Start() {
@@ -148,7 +154,7 @@ func (s *Server) sendError(id interface{}, code int, message string) {
 }
 
 func (s *Server) handleInitialize(req JSONRPCRequest) {
-	s.sendResult(req.ID, map[string]interface{}{
+	result := map[string]interface{}{
 		"protocolVersion": "2024-11-05",
 		"capabilities": map[string]interface{}{
 			"tools": map[string]interface{}{},
@@ -157,7 +163,13 @@ func (s *Server) handleInitialize(req JSONRPCRequest) {
 			"name":    "haft",
 			"version": "5.0.0",
 		},
-	})
+	}
+
+	if s.instructions != "" {
+		result["instructions"] = s.instructions
+	}
+
+	s.sendResult(req.ID, result)
 }
 
 func (s *Server) handleToolsList(req JSONRPCRequest) {
@@ -215,6 +227,10 @@ func (s *Server) handleToolsList(req JSONRPCRequest) {
 						"title": map[string]string{
 							"type":        "string",
 							"description": "(frame) Problem title",
+						},
+						"problem_type": map[string]string{
+							"type":        "string",
+							"description": "(frame) Problem type: optimization, diagnosis, search, or synthesis",
 						},
 						"signal": map[string]string{
 							"type":        "string",

--- a/internal/fpf/server_test.go
+++ b/internal/fpf/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -146,6 +147,20 @@ func TestHandleToolsList_CompareSchemaIncludesNarrativeFields(t *testing.T) {
 	}
 }
 
+func TestHandleToolsList_ProblemSchemaIncludesProblemType(t *testing.T) {
+	problemSchema := mustListToolProperties(t, "haft_problem")
+
+	problemType, ok := problemSchema["problem_type"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("problem_type schema missing or wrong type: %#v", problemSchema["problem_type"])
+	}
+
+	description, _ := problemType["description"].(string)
+	if !strings.Contains(description, "optimization") {
+		t.Fatalf("unexpected problem_type description: %q", description)
+	}
+}
+
 func TestHandleToolsList_DecisionSchemaMarksValidUntilForEvidence(t *testing.T) {
 	decisionSchema := mustListToolProperties(t, "haft_decision")
 
@@ -215,6 +230,53 @@ func TestHandleToolsList_FPFQuerySchemaIncludesMode(t *testing.T) {
 	description, _ := mode["description"].(string)
 	if description != "(fpf) Experimental retrieval mode; currently supports tree" {
 		t.Fatalf("unexpected mode description: %q", description)
+	}
+}
+
+func TestHandleInitialize_IncludesWorkflowInstructionsWhenConfigured(t *testing.T) {
+	server := NewServer()
+	server.SetInstructions("## Project Workflow\nDefaults:\n- mode: standard")
+
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "initialize",
+		ID:      "req-init",
+	}
+
+	stdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.Stdout = stdout
+	}()
+
+	os.Stdout = writer
+	server.handleInitialize(request)
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	responseBytes, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := map[string]interface{}{}
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		t.Fatalf("unmarshal initialize response: %v\n%s", err, string(responseBytes))
+	}
+
+	result, ok := response["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("result missing or wrong type: %#v", response["result"])
+	}
+
+	instructions, _ := result["instructions"].(string)
+	if !strings.Contains(instructions, "Project Workflow") {
+		t.Fatalf("expected workflow instructions, got %#v", result["instructions"])
 	}
 }
 

--- a/internal/graph/impact_test.go
+++ b/internal/graph/impact_test.go
@@ -40,8 +40,8 @@ func TestComputeImpactSet_Transitive(t *testing.T) {
 	seedModule(t, db, "mod-core", "internal/core", "core")
 	seedModule(t, db, "mod-api", "internal/api", "api")
 
-	// core → api (api depends on core)
-	seedDep(t, db, "mod-core", "mod-api")
+	// api imports core
+	seedDep(t, db, "mod-api", "mod-core")
 
 	// Decision governs API module
 	seedDecision(t, db, "dec-api", "API design",
@@ -72,7 +72,7 @@ func TestComputeImpactForFile(t *testing.T) {
 
 	seedModule(t, db, "mod-core", "internal/core", "core")
 	seedModule(t, db, "mod-api", "internal/api", "api")
-	seedDep(t, db, "mod-core", "mod-api")
+	seedDep(t, db, "mod-api", "mod-core")
 
 	seedDecision(t, db, "dec-core", "Core invariants",
 		[]string{"Pure functions only"}, []string{"internal/core/calc.go"})

--- a/internal/graph/integration_test.go
+++ b/internal/graph/integration_test.go
@@ -1,0 +1,458 @@
+package graph
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/m0n0x41d/haft/db"
+	"github.com/m0n0x41d/haft/internal/artifact"
+)
+
+type projectGraphFixture struct {
+	db            *sql.DB
+	artifactStore *artifact.Store
+	graphStore    *Store
+}
+
+type seededDecision struct {
+	id         string
+	title      string
+	invariants []string
+	files      []string
+}
+
+func setupProjectGraphFixture(t *testing.T) *projectGraphFixture {
+	t.Helper()
+
+	projectRoot := fixtureProjectRoot(t)
+	dbPath := filepath.Join(t.TempDir(), "graph-integration.db")
+
+	database, err := db.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+
+	rawDB := database.GetRawDB()
+	artifactStore := artifact.NewStore(rawDB)
+	graphStore := NewStore(rawDB)
+	ctx := context.Background()
+
+	modules := []Node{
+		{ID: "mod-artifact", Path: "internal/artifact", Name: "artifact"},
+		{ID: "mod-graph", Path: "internal/graph", Name: "graph"},
+		{ID: "mod-codebase", Path: "internal/codebase", Name: "codebase"},
+		{ID: "mod-reff", Path: "internal/reff", Name: "reff"},
+		{ID: "mod-fpf", Path: "internal/fpf", Name: "fpf"},
+		{ID: "mod-present", Path: "internal/present", Name: "present"},
+		{ID: "mod-cli", Path: "internal/cli", Name: "cli"},
+		{ID: "mod-tools", Path: "internal/tools", Name: "tools"},
+		{ID: "mod-agentloop", Path: "internal/agentloop", Name: "agentloop"},
+		{ID: "mod-desktop", Path: "desktop", Name: "desktop"},
+		{ID: "mod-cmd-haft", Path: "cmd/haft", Name: "cmd-haft"},
+	}
+
+	for _, module := range modules {
+		requireProjectPathExists(t, projectRoot, module.Path)
+		seedIntegrationModule(t, rawDB, module.ID, module.Path, module.Name)
+	}
+
+	dependencies := [][2]string{
+		{"mod-present", "mod-artifact"},
+		{"mod-present", "mod-codebase"},
+		{"mod-cli", "mod-artifact"},
+		{"mod-cli", "mod-codebase"},
+		{"mod-cli", "mod-fpf"},
+		{"mod-cli", "mod-present"},
+		{"mod-tools", "mod-artifact"},
+		{"mod-tools", "mod-codebase"},
+		{"mod-tools", "mod-present"},
+		{"mod-agentloop", "mod-artifact"},
+		{"mod-agentloop", "mod-codebase"},
+		{"mod-desktop", "mod-artifact"},
+		{"mod-desktop", "mod-graph"},
+		{"mod-desktop", "mod-codebase"},
+		{"mod-cmd-haft", "mod-cli"},
+	}
+
+	for _, dep := range dependencies {
+		seedIntegrationDependency(t, rawDB, dep[0], dep[1])
+	}
+
+	decisions := []seededDecision{
+		{
+			id:    "dec-artifact-authority",
+			title: "SQLite runtime authority for artifacts",
+			invariants: []string{
+				"SQLite is the runtime source of truth for artifacts",
+				".haft projections are derived outputs, never edited directly",
+			},
+			files: []string{
+				"internal/artifact/store.go",
+				"internal/artifact/writer.go",
+			},
+		},
+		{
+			id:    "dec-artifact-decision-structure",
+			title: "Decision fields stay in structured_data",
+			invariants: []string{
+				"DecisionRecord invariants live in structured_data",
+			},
+			files: []string{
+				"internal/artifact/decision.go",
+				"internal/artifact/types.go",
+			},
+		},
+		{
+			id:    "dec-graph-query-layer",
+			title: "Knowledge graph query layer",
+			invariants: []string{
+				"Knowledge graph stays a query layer over existing tables",
+				"File-to-module ownership uses longest-prefix matching",
+			},
+			files: []string{
+				"internal/graph/query.go",
+				"internal/graph/types.go",
+			},
+		},
+		{
+			id:    "dec-graph-impact-propagation",
+			title: "Impact propagation follows dependents",
+			invariants: []string{
+				"Impact propagation follows transitive dependents of changed modules",
+			},
+			files: []string{
+				"internal/graph/impact.go",
+			},
+		},
+		{
+			id:    "dec-graph-invariant-verification",
+			title: "Invariant checks use live dependency data",
+			invariants: []string{
+				"Graph invariants are checked against the live dependency graph",
+			},
+			files: []string{
+				"internal/graph/verify.go",
+			},
+		},
+		{
+			id:    "dec-codebase-import-graph",
+			title: "Codebase scanner stores import edges",
+			invariants: []string{
+				"Module dependencies are stored as source imports target",
+			},
+			files: []string{
+				"internal/codebase/walker.go",
+				"internal/codebase/detector.go",
+			},
+		},
+		{
+			id:    "dec-reff-weakest-link",
+			title: "Weakest-link evidence scoring",
+			invariants: []string{
+				"Effective reliability uses weakest-link semantics",
+			},
+			files: []string{
+				"internal/reff/reff.go",
+			},
+		},
+		{
+			id:    "dec-cli-mcp-surface",
+			title: "CLI surfaces stay above Core",
+			invariants: []string{
+				"CLI surfaces operate through Core stores, not direct desktop calls",
+			},
+			files: []string{
+				"internal/cli/serve.go",
+				"internal/cli/sync.go",
+			},
+		},
+		{
+			id:    "dec-tools-thin-handlers",
+			title: "Tool handlers remain thin",
+			invariants: []string{
+				"Tool handlers stay thin over artifact and codebase services",
+			},
+			files: []string{
+				"internal/tools/haft.go",
+				"internal/tools/readfile.go",
+			},
+		},
+		{
+			id:    "dec-agentloop-core-orchestration",
+			title: "Agent loop uses Core stores",
+			invariants: []string{
+				"Agent loop orchestration depends on Core stores, not projections",
+			},
+			files: []string{
+				"internal/agentloop/coordinator.go",
+				"internal/agentloop/overseer.go",
+			},
+		},
+		{
+			id:    "dec-present-derived-views",
+			title: "Presentation reads derived Core state",
+			invariants: []string{
+				"Presentation models are derived from Core state only",
+			},
+			files: []string{
+				"internal/present/board.go",
+				"internal/present/projection.go",
+			},
+		},
+		{
+			id:    "dec-desktop-surface-boundary",
+			title: "Desktop remains a surface",
+			invariants: []string{
+				"Desktop is a surface and does not become a source of truth",
+			},
+			files: []string{
+				"desktop/app.go",
+				"desktop/governance.go",
+				"desktop/views.go",
+			},
+		},
+		{
+			id:    "dec-cmd-thin-entrypoint",
+			title: "cmd/haft stays a thin entrypoint",
+			invariants: []string{
+				"cmd/haft remains a thin entrypoint over internal/cli",
+			},
+			files: []string{
+				"cmd/haft/main.go",
+			},
+		},
+	}
+
+	if len(decisions) < 10 {
+		t.Fatalf("fixture must seed at least 10 decisions, got %d", len(decisions))
+	}
+
+	for _, decision := range decisions {
+		for _, file := range decision.files {
+			requireProjectPathExists(t, projectRoot, file)
+		}
+		seedIntegrationDecision(t, ctx, artifactStore, decision)
+	}
+
+	return &projectGraphFixture{
+		db:            rawDB,
+		artifactStore: artifactStore,
+		graphStore:    graphStore,
+	}
+}
+
+func fixtureProjectRoot(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func requireProjectPathExists(t *testing.T, projectRoot, relativePath string) {
+	t.Helper()
+
+	fullPath := filepath.Join(projectRoot, relativePath)
+	if _, err := os.Stat(fullPath); err != nil {
+		t.Fatalf("fixture path %s missing: %v", relativePath, err)
+	}
+}
+
+func seedIntegrationModule(t *testing.T, rawDB *sql.DB, moduleID, modulePath, moduleName string) {
+	t.Helper()
+
+	_, err := rawDB.Exec(
+		`INSERT INTO codebase_modules (module_id, path, name, lang, file_count, last_scanned) VALUES (?, ?, ?, 'go', 1, ?)`,
+		moduleID,
+		modulePath,
+		moduleName,
+		time.Now().UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		t.Fatalf("seed module %s: %v", moduleID, err)
+	}
+}
+
+func seedIntegrationDependency(t *testing.T, rawDB *sql.DB, sourceModule, targetModule string) {
+	t.Helper()
+
+	_, err := rawDB.Exec(
+		`INSERT INTO module_dependencies (source_module, target_module, dep_type, file_path, last_scanned) VALUES (?, ?, 'import', '', ?)`,
+		sourceModule,
+		targetModule,
+		time.Now().UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		t.Fatalf("seed dependency %s -> %s: %v", sourceModule, targetModule, err)
+	}
+}
+
+func seedIntegrationDecision(t *testing.T, ctx context.Context, artifactStore *artifact.Store, decision seededDecision) {
+	t.Helper()
+
+	structuredData, err := json.Marshal(artifact.DecisionFields{
+		SelectedTitle: decision.title,
+		WhySelected:   "Seeded integration fixture for knowledge graph queries.",
+		Invariants:    decision.invariants,
+	})
+	if err != nil {
+		t.Fatalf("marshal decision %s: %v", decision.id, err)
+	}
+
+	err = artifactStore.Create(ctx, &artifact.Artifact{
+		Meta: artifact.Meta{
+			ID:      decision.id,
+			Kind:    artifact.KindDecisionRecord,
+			Status:  artifact.StatusActive,
+			Mode:    artifact.ModeStandard,
+			Title:   decision.title,
+			Context: "graph-integration",
+		},
+		Body:           "Seeded integration fixture.",
+		StructuredData: string(structuredData),
+	})
+	if err != nil {
+		t.Fatalf("create decision %s: %v", decision.id, err)
+	}
+
+	files := make([]artifact.AffectedFile, 0, len(decision.files))
+	for _, file := range decision.files {
+		files = append(files, artifact.AffectedFile{Path: file})
+	}
+
+	err = artifactStore.SetAffectedFiles(ctx, decision.id, files)
+	if err != nil {
+		t.Fatalf("set affected files for %s: %v", decision.id, err)
+	}
+}
+
+func TestFindDecisionsForFile_SeededProjectData(t *testing.T) {
+	fixture := setupProjectGraphFixture(t)
+	ctx := context.Background()
+
+	decisions, err := fixture.graphStore.FindDecisionsForFile(ctx, "internal/graph/query.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decisionIDs := make([]string, 0, len(decisions))
+	for _, decision := range decisions {
+		decisionIDs = append(decisionIDs, decision.ID)
+	}
+
+	slices.Sort(decisionIDs)
+
+	expected := []string{
+		"dec-graph-impact-propagation",
+		"dec-graph-invariant-verification",
+		"dec-graph-query-layer",
+	}
+
+	if !slices.Equal(decisionIDs, expected) {
+		t.Fatalf("decision IDs = %v, want %v", decisionIDs, expected)
+	}
+}
+
+func TestFindInvariantsForFile_SeededProjectData(t *testing.T) {
+	fixture := setupProjectGraphFixture(t)
+	ctx := context.Background()
+
+	invariants, err := fixture.graphStore.FindInvariantsForFile(ctx, "internal/graph/query.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make([]string, 0, len(invariants))
+	for _, invariant := range invariants {
+		got = append(got, invariant.Text)
+	}
+
+	slices.Sort(got)
+
+	expected := []string{
+		"File-to-module ownership uses longest-prefix matching",
+		"Graph invariants are checked against the live dependency graph",
+		"Impact propagation follows transitive dependents of changed modules",
+		"Knowledge graph stays a query layer over existing tables",
+	}
+
+	if !slices.Equal(got, expected) {
+		t.Fatalf("invariants = %v, want %v", got, expected)
+	}
+}
+
+func TestComputeImpactSet_SeededProjectData(t *testing.T) {
+	fixture := setupProjectGraphFixture(t)
+	ctx := context.Background()
+
+	items, err := fixture.graphStore.ComputeImpactSet(ctx, "mod-artifact")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	impactByDecision := make(map[string]ImpactItem, len(items))
+	for _, item := range items {
+		impactByDecision[item.DecisionID] = item
+	}
+
+	expectedDecisionIDs := []string{
+		"dec-agentloop-core-orchestration",
+		"dec-artifact-authority",
+		"dec-artifact-decision-structure",
+		"dec-cli-mcp-surface",
+		"dec-cmd-thin-entrypoint",
+		"dec-desktop-surface-boundary",
+		"dec-present-derived-views",
+		"dec-tools-thin-handlers",
+	}
+
+	if len(impactByDecision) != len(expectedDecisionIDs) {
+		t.Fatalf("impact size = %d, want %d (%v)", len(impactByDecision), len(expectedDecisionIDs), mapsKeys(impactByDecision))
+	}
+
+	for _, decisionID := range expectedDecisionIDs {
+		item, ok := impactByDecision[decisionID]
+		if !ok {
+			t.Fatalf("missing impact item for %s in %v", decisionID, mapsKeys(impactByDecision))
+		}
+
+		if decisionID == "dec-artifact-authority" || decisionID == "dec-artifact-decision-structure" {
+			if !item.IsDirect {
+				t.Fatalf("%s should be direct impact", decisionID)
+			}
+			continue
+		}
+
+		if item.IsDirect {
+			t.Fatalf("%s should be indirect impact", decisionID)
+		}
+	}
+
+	cmdImpact := impactByDecision["dec-cmd-thin-entrypoint"]
+	if cmdImpact.ModuleID != "mod-cmd-haft" {
+		t.Fatalf("cmd impact module = %s, want mod-cmd-haft", cmdImpact.ModuleID)
+	}
+}
+
+func mapsKeys(values map[string]ImpactItem) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	slices.Sort(keys)
+	return keys
+}

--- a/internal/graph/query.go
+++ b/internal/graph/query.go
@@ -187,15 +187,15 @@ func (s *Store) FindModuleForFile(ctx context.Context, filePath string) (*Node, 
 func (s *Store) TransitiveDependents(ctx context.Context, moduleID string) ([]Node, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		WITH RECURSIVE deps(mid, depth, path) AS (
-			SELECT target_module, 1, source_module || '/' || target_module
+			SELECT source_module, 1, '|' || target_module || '|' || source_module || '|'
 			FROM module_dependencies
-			WHERE source_module = ?
+			WHERE target_module = ?
 			UNION
-			SELECT md.target_module, d.depth + 1, d.path || '/' || md.target_module
+			SELECT md.source_module, d.depth + 1, d.path || md.source_module || '|'
 			FROM deps d
-			JOIN module_dependencies md ON md.source_module = d.mid
+			JOIN module_dependencies md ON md.target_module = d.mid
 			WHERE d.depth < 10
-			  AND d.path NOT LIKE '%' || md.target_module || '%'
+			  AND d.path NOT LIKE '%|' || md.source_module || '|%'
 		)
 		SELECT DISTINCT m.module_id, m.path, m.name, d.depth
 		FROM deps d

--- a/internal/graph/query_test.go
+++ b/internal/graph/query_test.go
@@ -221,10 +221,10 @@ func TestTransitiveDependents(t *testing.T) {
 	seedModule(t, db, "mod-api", "internal/api", "api")
 	seedModule(t, db, "mod-web", "internal/web", "web")
 
-	// core → cache → api → web
-	seedDep(t, db, "mod-core", "mod-cache")
-	seedDep(t, db, "mod-cache", "mod-api")
-	seedDep(t, db, "mod-api", "mod-web")
+	// web imports api, api imports cache, cache imports core
+	seedDep(t, db, "mod-cache", "mod-core")
+	seedDep(t, db, "mod-api", "mod-cache")
+	seedDep(t, db, "mod-web", "mod-api")
 
 	deps, err := store.TransitiveDependents(ctx, "mod-core")
 	if err != nil {
@@ -255,7 +255,7 @@ func TestTransitiveDependents_CycleSafe(t *testing.T) {
 	seedModule(t, db, "mod-b", "pkg/b", "b")
 	seedModule(t, db, "mod-c", "pkg/c", "c")
 
-	// Circular: a → b → c → a
+	// Circular imports: a -> b -> c -> a
 	seedDep(t, db, "mod-a", "mod-b")
 	seedDep(t, db, "mod-b", "mod-c")
 	seedDep(t, db, "mod-c", "mod-a")
@@ -265,7 +265,7 @@ func TestTransitiveDependents_CycleSafe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Should terminate and return b + c (not infinite loop)
+	// Dependents of a are c directly and b transitively.
 	if len(deps) != 2 {
 		t.Fatalf("expected 2 deps in cycle, got %d", len(deps))
 	}

--- a/internal/present/format.go
+++ b/internal/present/format.go
@@ -561,15 +561,21 @@ func StatusResponse(data artifact.StatusData) string {
 		}
 	}
 
+	if len(data.HealthyDecisions) > 0 {
+		sb.WriteString(fmt.Sprintf("### Shipped / Healthy (%d)\n\n", len(data.HealthyDecisions)))
+		formatDecisionList(data.HealthyDecisions, 5)
+		sb.WriteString("\n")
+	}
+
 	if len(data.PendingDecisions) > 0 {
-		sb.WriteString(fmt.Sprintf("### Pending Implementation (%d)\n\n", len(data.PendingDecisions)))
+		sb.WriteString(fmt.Sprintf("### Pending (%d)\n\n", len(data.PendingDecisions)))
 		formatDecisionList(data.PendingDecisions, 5)
 		sb.WriteString("\n")
 	}
 
-	if len(data.ShippedDecisions) > 0 {
-		sb.WriteString(fmt.Sprintf("### Shipped (%d)\n\n", len(data.ShippedDecisions)))
-		formatDecisionList(data.ShippedDecisions, 5)
+	if len(data.UnassessedDecisions) > 0 {
+		sb.WriteString(fmt.Sprintf("### Unassessed (%d)\n\n", len(data.UnassessedDecisions)))
+		formatDecisionList(data.UnassessedDecisions, 5)
 		sb.WriteString("\n")
 	}
 
@@ -581,7 +587,12 @@ func StatusResponse(data artifact.StatusData) string {
 				sb.WriteString(fmt.Sprintf("- ... and %d more (use /h-refresh to see all)\n", len(data.StaleItems)-cap))
 				break
 			}
-			sb.WriteString(fmt.Sprintf("- **%s** `%s` — %s\n", s.Title, s.ID, s.Reason))
+			line := fmt.Sprintf("- **%s** `%s`", s.Title, s.ID)
+			if health, ok := data.DecisionHealth[s.ID]; ok {
+				line += fmt.Sprintf(" — %s", health.Label())
+			}
+			line += fmt.Sprintf(" — %s", s.Reason)
+			sb.WriteString(line + "\n")
 		}
 		sb.WriteString("\n")
 	}
@@ -633,8 +644,9 @@ func StatusResponse(data artifact.StatusData) string {
 		sb.WriteString("\n")
 	}
 
-	hasAny := len(data.PendingDecisions) > 0 ||
-		len(data.ShippedDecisions) > 0 ||
+	hasAny := len(data.HealthyDecisions) > 0 ||
+		len(data.PendingDecisions) > 0 ||
+		len(data.UnassessedDecisions) > 0 ||
 		len(data.StaleItems) > 0 ||
 		len(data.InProgressProblems) > 0 ||
 		len(data.BacklogProblems) > 0 ||

--- a/internal/present/format.go
+++ b/internal/present/format.go
@@ -158,6 +158,39 @@ func ScanResponse(items []artifact.StaleItem, navStrip string) string {
 	return sb.String()
 }
 
+func GovernanceAttentionResponse(attention artifact.GovernanceAttention) string {
+	if attention.BacklogCount == 0 &&
+		attention.InProgressCount == 0 &&
+		len(attention.AddressedWithoutDecision) == 0 &&
+		len(attention.InvariantViolations) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Governance State\n\n")
+	sb.WriteString(fmt.Sprintf("Problems: %d backlog, %d in progress\n", attention.BacklogCount, attention.InProgressCount))
+
+	if len(attention.AddressedWithoutDecision) > 0 {
+		sb.WriteString(fmt.Sprintf("\nAddressed without linked decision (%d)\n", len(attention.AddressedWithoutDecision)))
+		for _, gap := range attention.AddressedWithoutDecision {
+			sb.WriteString(fmt.Sprintf("- **%s** `%s`\n", gap.Title, gap.ProblemID))
+		}
+	}
+
+	if len(attention.InvariantViolations) > 0 {
+		sb.WriteString(fmt.Sprintf("\nInvariant violations (%d)\n", len(attention.InvariantViolations)))
+		for _, violation := range attention.InvariantViolations {
+			sb.WriteString(fmt.Sprintf("- **%s** `%s` — %s\n", violation.DecisionTitle, violation.DecisionID, violation.Invariant))
+			if strings.TrimSpace(violation.Reason) != "" {
+				sb.WriteString(fmt.Sprintf("  Reason: %s\n", strings.TrimSpace(violation.Reason)))
+			}
+		}
+	}
+
+	sb.WriteString("\n")
+	return sb.String()
+}
+
 // RefreshActionResponse formats the result of a refresh action.
 func RefreshActionResponse(action artifact.RefreshAction, dec *artifact.Artifact, newProb *artifact.Artifact, navStrip string) string {
 	var sb strings.Builder
@@ -481,6 +514,9 @@ func ProblemResponse(action string, a *artifact.Artifact, filePath string, navSt
 		sb.WriteString(fmt.Sprintf("Problem framed: %s\n", a.Meta.Title))
 		sb.WriteString(fmt.Sprintf("ID: %s\n", a.Meta.ID))
 		sb.WriteString(fmt.Sprintf("Mode: %s\n", a.Meta.Mode))
+		if problemType := artifact.ProblemTypeLabel(a); problemType != "" {
+			sb.WriteString(fmt.Sprintf("Type: %s\n", problemType))
+		}
 		if filePath != "" {
 			sb.WriteString(fmt.Sprintf("File: %s\n", filePath))
 		}
@@ -605,7 +641,7 @@ func StatusResponse(data artifact.StatusData) string {
 				sb.WriteString(fmt.Sprintf("- ... and %d more\n", len(data.InProgressProblems)-cap))
 				break
 			}
-			sb.WriteString(fmt.Sprintf("- **%s** `%s` → %s\n", p.Meta.Title, p.Meta.ID, data.InProgressBy[p.Meta.ID]))
+			sb.WriteString(fmt.Sprintf("- %s → %s\n", formatProblemListEntry(p), data.InProgressBy[p.Meta.ID]))
 		}
 		sb.WriteString("\n")
 	}
@@ -618,7 +654,7 @@ func StatusResponse(data artifact.StatusData) string {
 				sb.WriteString(fmt.Sprintf("- ... and %d more\n", len(data.BacklogProblems)-cap))
 				break
 			}
-			sb.WriteString(fmt.Sprintf("- **%s** `%s`\n", p.Meta.Title, p.Meta.ID))
+			sb.WriteString(fmt.Sprintf("- %s\n", formatProblemListEntry(p)))
 		}
 		sb.WriteString("\n")
 	}
@@ -631,7 +667,7 @@ func StatusResponse(data artifact.StatusData) string {
 				sb.WriteString(fmt.Sprintf("- ... and %d more\n", len(data.AddressedProblems)-cap))
 				break
 			}
-			sb.WriteString(fmt.Sprintf("- **%s** `%s` → %s\n", p.Meta.Title, p.Meta.ID, data.AddressedBy[p.Meta.ID]))
+			sb.WriteString(fmt.Sprintf("- %s → %s\n", formatProblemListEntry(p), data.AddressedBy[p.Meta.ID]))
 		}
 		sb.WriteString("\n")
 	}
@@ -733,7 +769,7 @@ func ProblemsListResponse(items []artifact.ProblemListItem, navStrip string) str
 
 	for i, item := range items {
 		p := item.Problem
-		sb.WriteString(fmt.Sprintf("### %d. %s [%s]\n", i+1, p.Meta.Title, p.Meta.ID))
+		sb.WriteString(fmt.Sprintf("### %d. %s [%s]\n", i+1, formatProblemTitleWithType(p), p.Meta.ID))
 		if p.Meta.Context != "" {
 			sb.WriteString(fmt.Sprintf("Context: %s | ", p.Meta.Context))
 		}
@@ -780,4 +816,21 @@ func ProblemsListResponse(items []artifact.ProblemListItem, navStrip string) str
 
 	sb.WriteString(navStrip)
 	return sb.String()
+}
+
+func formatProblemListEntry(problem *artifact.Artifact) string {
+	return fmt.Sprintf("**%s** `%s`", formatProblemTitleWithType(problem), problem.Meta.ID)
+}
+
+func formatProblemTitleWithType(problem *artifact.Artifact) string {
+	if problem == nil {
+		return ""
+	}
+
+	problemType := artifact.ProblemTypeLabel(problem)
+	if problemType == "" {
+		return problem.Meta.Title
+	}
+
+	return fmt.Sprintf("%s (%s)", problem.Meta.Title, problemType)
 }

--- a/internal/present/format_test.go
+++ b/internal/present/format_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/m0n0x41d/haft/internal/artifact"
 	"github.com/m0n0x41d/haft/internal/present"
@@ -140,6 +141,33 @@ func TestProblemResponse_NoRecallWhenAbsent(t *testing.T) {
 
 	if strings.Contains(response, "Related History") {
 		t.Error("frame response should NOT show Related History when not in body")
+	}
+}
+
+func TestProblemResponse_ShowsProblemType(t *testing.T) {
+	fields, err := json.Marshal(artifact.ProblemFields{
+		ProblemType: artifact.ProblemTypeDiagnosis,
+		Signal:      "signal",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := &artifact.Artifact{
+		Meta: artifact.Meta{
+			ID:    "prob-001",
+			Kind:  artifact.KindProblemCard,
+			Title: "Investigate webhook failures",
+			Mode:  artifact.ModeStandard,
+		},
+		Body:           "# Test\n\n## Signal\n\nSomething\n",
+		StructuredData: string(fields),
+	}
+
+	response := present.ProblemResponse("frame", a, "", "\n-- nav --\n")
+
+	if !strings.Contains(response, "Type: diagnosis") {
+		t.Fatalf("expected problem type in frame response, got:\n%s", response)
 	}
 }
 
@@ -281,6 +309,109 @@ func TestStatusResponse_ShowsDerivedDecisionHealth(t *testing.T) {
 			t.Fatalf("status output missing %q:\n%s", want, output)
 		}
 	}
+}
+
+func TestStatusResponse_ShowsProblemTypeInListings(t *testing.T) {
+	backlogFields, err := json.Marshal(artifact.ProblemFields{ProblemType: artifact.ProblemTypeSearch})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProgressFields, err := json.Marshal(artifact.ProblemFields{ProblemType: artifact.ProblemTypeDiagnosis})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := artifact.StatusData{
+		BacklogProblems: []*artifact.Artifact{
+			{
+				Meta:           artifact.Meta{ID: "prob-backlog", Title: "Backlog problem"},
+				StructuredData: string(backlogFields),
+			},
+		},
+		InProgressProblems: []*artifact.Artifact{
+			{
+				Meta:           artifact.Meta{ID: "prob-progress", Title: "In progress problem"},
+				StructuredData: string(inProgressFields),
+			},
+		},
+		InProgressBy: map[string]string{"prob-progress": "sol-001"},
+	}
+
+	output := present.StatusResponse(data)
+
+	for _, want := range []string{
+		"**In progress problem (diagnosis)** `prob-progress` → sol-001",
+		"**Backlog problem (search)** `prob-backlog`",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("status output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestProblemsListResponse_ShowsProblemTypeInHeading(t *testing.T) {
+	fields, err := json.Marshal(artifact.ProblemFields{ProblemType: artifact.ProblemTypeSynthesis})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := present.ProblemsListResponse([]artifact.ProblemListItem{
+		{
+			Problem: &artifact.Artifact{
+				Meta: artifact.Meta{
+					ID:        "prob-001",
+					Title:     "Design the deployment path",
+					CreatedAt: mustParseTime(t, "2026-04-14T00:00:00Z"),
+				},
+				StructuredData: string(fields),
+			},
+		},
+	}, "")
+
+	if !strings.Contains(output, "### 1. Design the deployment path (synthesis) [prob-001]") {
+		t.Fatalf("expected problem type in heading, got:\n%s", output)
+	}
+}
+
+func TestGovernanceAttentionResponse_ShowsOrphansAndInvariantViolations(t *testing.T) {
+	output := present.GovernanceAttentionResponse(artifact.GovernanceAttention{
+		BacklogCount:    2,
+		InProgressCount: 1,
+		AddressedWithoutDecision: []artifact.AddressedProblemGap{
+			{ProblemID: "prob-001", Title: "Orphan problem"},
+		},
+		InvariantViolations: []artifact.InvariantViolationFinding{
+			{
+				DecisionID:    "dec-001",
+				DecisionTitle: "Boundary decision",
+				Invariant:     "no dependency from api to database",
+				Reason:        "Forbidden dependency detected: internal/api → internal/database",
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"Problems: 2 backlog, 1 in progress",
+		"Addressed without linked decision (1)",
+		"**Orphan problem** `prob-001`",
+		"Invariant violations (1)",
+		"**Boundary decision** `dec-001` — no dependency from api to database",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("governance attention missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", value, err)
+	}
+
+	return parsed
 }
 
 func TestDecisionResponse_PreservesDecisionBodyVerbatim(t *testing.T) {

--- a/internal/present/format_test.go
+++ b/internal/present/format_test.go
@@ -433,7 +433,7 @@ func TestProjectionResponse_RendersAudienceViewsFromSameGraph(t *testing.T) {
 			wants: []string{
 				"## Manager/Status View",
 				"Problems: 0 backlog, 0 in progress, 1 addressed",
-				"Decisions: 0 pending follow-through, 1 measured/shipped, 0 refresh due",
+				"Decisions: 0 unassessed, 0 pending follow-through, 1 measured/shipped, 0 refresh due",
 			},
 		},
 		{
@@ -540,6 +540,54 @@ func TestProjectionResponse_ChangesWhenPredictionStatusChanges(t *testing.T) {
 	}
 	if auditBefore == auditAfter {
 		t.Fatalf("expected audit projection output to change after status update")
+	}
+}
+
+func TestProjectionResponse_ManagerStatusSeparatesUnassessedDecisions(t *testing.T) {
+	graph := artifact.ProjectionGraph{
+		Decisions: []artifact.DecisionProjection{
+			{
+				Meta: artifact.Meta{
+					ID:    "dec-unassessed",
+					Title: "Unassessed decision",
+				},
+				Health: artifact.DecisionHealth{
+					Maturity: artifact.DecisionMaturityUnassessed,
+				},
+			},
+			{
+				Meta: artifact.Meta{
+					ID:    "dec-pending",
+					Title: "Pending decision",
+				},
+				Health: artifact.DecisionHealth{
+					Maturity: artifact.DecisionMaturityPending,
+				},
+			},
+			{
+				Meta: artifact.Meta{
+					ID:    "dec-shipped",
+					Title: "Shipped decision",
+				},
+				NeedsRefresh: true,
+				Health: artifact.DecisionHealth{
+					Maturity: artifact.DecisionMaturityShipped,
+				},
+			},
+		},
+	}
+
+	output := present.ProjectionResponse(graph, artifact.ProjectionViewManager)
+
+	for _, want := range []string{
+		"Decisions: 1 unassessed, 1 pending follow-through, 1 measured/shipped, 1 refresh due",
+		"- **Unassessed decision** `dec-unassessed` — unassessed",
+		"- **Pending decision** `dec-pending` — waiting for measurement",
+		"- **Shipped decision** `dec-shipped` — measured, refresh due",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("manager projection missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/internal/present/format_test.go
+++ b/internal/present/format_test.go
@@ -228,6 +228,61 @@ func TestSearchResponse_PreservesQueryTitleAndBodyVerbatim(t *testing.T) {
 	}
 }
 
+func TestStatusResponse_ShowsDerivedDecisionHealth(t *testing.T) {
+	data := artifact.StatusData{
+		HealthyDecisions: []*artifact.Artifact{
+			{
+				Meta: artifact.Meta{
+					ID:    "dec-healthy",
+					Title: "Healthy decision",
+				},
+			},
+		},
+		PendingDecisions: []*artifact.Artifact{
+			{
+				Meta: artifact.Meta{
+					ID:    "dec-pending",
+					Title: "Pending decision",
+				},
+			},
+		},
+		UnassessedDecisions: []*artifact.Artifact{
+			{
+				Meta: artifact.Meta{
+					ID:    "dec-unassessed",
+					Title: "Unassessed decision",
+				},
+			},
+		},
+		DecisionHealth: map[string]artifact.DecisionHealth{
+			"dec-stale": {
+				Maturity:  artifact.DecisionMaturityShipped,
+				Freshness: artifact.DecisionFreshnessStale,
+			},
+		},
+		StaleItems: []artifact.StaleItem{
+			{
+				ID:     "dec-stale",
+				Title:  "Stale decision",
+				Reason: "evidence degraded (R_eff: 0.40)",
+			},
+		},
+	}
+
+	output := present.StatusResponse(data)
+
+	for _, want := range []string{
+		"### Shipped / Healthy (1)",
+		"### Pending (1)",
+		"### Unassessed (1)",
+		"**Stale decision** `dec-stale` — Shipped / Stale — evidence degraded (R_eff: 0.40)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("status output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestDecisionResponse_PreservesDecisionBodyVerbatim(t *testing.T) {
 	body := "# Decision\n\nFix DecisionRecord parser without changing DecisionRecord wording."
 	a := &artifact.Artifact{

--- a/internal/present/projection.go
+++ b/internal/present/projection.go
@@ -117,7 +117,7 @@ func managerProjectionResponse(graph artifact.ProjectionGraph) string {
 	}
 
 	backlog, inProgress, addressed := projectionProblemStages(graph.Problems)
-	pending, shipped, refreshDue := projectionDecisionStages(graph.Decisions)
+	unassessed, pending, shipped, refreshDue := projectionDecisionStages(graph.Decisions)
 	compared := 0
 	for _, portfolio := range graph.Portfolios {
 		if portfolio.Comparison != nil {
@@ -128,7 +128,15 @@ func managerProjectionResponse(graph artifact.ProjectionGraph) string {
 	var sb strings.Builder
 	sb.WriteString("## Manager/Status View\n\n")
 	sb.WriteString(fmt.Sprintf("Problems: %d backlog, %d in progress, %d addressed\n", backlog, inProgress, addressed))
-	sb.WriteString(fmt.Sprintf("Decisions: %d pending follow-through, %d measured/shipped, %d refresh due\n", pending, shipped, refreshDue))
+	sb.WriteString(
+		fmt.Sprintf(
+			"Decisions: %d unassessed, %d pending follow-through, %d measured/shipped, %d refresh due\n",
+			unassessed,
+			pending,
+			shipped,
+			refreshDue,
+		),
+	)
 	sb.WriteString(fmt.Sprintf("Compared portfolios: %d\n\n", compared))
 
 	if len(graph.Problems) > 0 {
@@ -150,12 +158,7 @@ func managerProjectionResponse(graph artifact.ProjectionGraph) string {
 	if len(graph.Decisions) > 0 {
 		sb.WriteString("### Decision Watchlist\n\n")
 		for _, decision := range graph.Decisions {
-			statusParts := []string{}
-			if decision.Measured {
-				statusParts = append(statusParts, "measured")
-			} else {
-				statusParts = append(statusParts, "waiting for measurement")
-			}
+			statusParts := []string{projectionDecisionWatchStatus(decision)}
 			if decision.NeedsRefresh {
 				statusParts = append(statusParts, "refresh due")
 			}
@@ -329,19 +332,52 @@ func projectionProblemStages(problems []artifact.ProblemProjection) (backlog int
 	return backlog, inProgress, addressed
 }
 
-func projectionDecisionStages(decisions []artifact.DecisionProjection) (pending int, shipped int, refreshDue int) {
+func projectionDecisionStages(decisions []artifact.DecisionProjection) (unassessed int, pending int, shipped int, refreshDue int) {
 	for _, decision := range decisions {
-		if decision.Measured {
+		health := projectionDecisionHealth(decision)
+
+		switch health.Maturity {
+		case artifact.DecisionMaturityUnassessed:
+			unassessed++
+		case artifact.DecisionMaturityPending:
+			pending++
+		case artifact.DecisionMaturityShipped:
 			shipped++
-		} else {
+		default:
 			pending++
 		}
+
 		if decision.NeedsRefresh {
 			refreshDue++
 		}
 	}
 
-	return pending, shipped, refreshDue
+	return unassessed, pending, shipped, refreshDue
+}
+
+func projectionDecisionHealth(decision artifact.DecisionProjection) artifact.DecisionHealth {
+	if decision.Health.Maturity != "" {
+		return decision.Health
+	}
+
+	if decision.Measured {
+		return artifact.DecisionHealth{Maturity: artifact.DecisionMaturityShipped}
+	}
+
+	return artifact.DecisionHealth{Maturity: artifact.DecisionMaturityPending}
+}
+
+func projectionDecisionWatchStatus(decision artifact.DecisionProjection) string {
+	health := projectionDecisionHealth(decision)
+
+	switch health.Maturity {
+	case artifact.DecisionMaturityUnassessed:
+		return "unassessed"
+	case artifact.DecisionMaturityShipped:
+		return "measured"
+	default:
+		return "waiting for measurement"
+	}
 }
 
 func projectionVariantTitles(variants []artifact.Variant) []string {

--- a/internal/project/workflow.go
+++ b/internal/project/workflow.go
@@ -1,0 +1,233 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const workflowFile = "workflow.md"
+
+type Workflow struct {
+	Intent       string
+	Defaults     WorkflowDefaults
+	PathPolicies []WorkflowPathPolicy
+	Exceptions   string
+}
+
+type WorkflowDefaults struct {
+	Mode            string `yaml:"mode"`
+	RequireDecision bool   `yaml:"require_decision"`
+	RequireVerify   bool   `yaml:"require_verify"`
+	AllowAutonomy   bool   `yaml:"allow_autonomy"`
+}
+
+type WorkflowPathPolicy struct {
+	Path            string `yaml:"path"`
+	Mode            string `yaml:"mode,omitempty"`
+	RequireDecision *bool  `yaml:"require_decision,omitempty"`
+	RequireVerify   *bool  `yaml:"require_verify,omitempty"`
+	AllowAutonomy   *bool  `yaml:"allow_autonomy,omitempty"`
+}
+
+func WorkflowPath(haftDir string) string {
+	return filepath.Join(haftDir, workflowFile)
+}
+
+func LoadWorkflow(projectRoot string) (*Workflow, error) {
+	path := WorkflowPath(filepath.Join(projectRoot, ".haft"))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read workflow: %w", err)
+	}
+
+	return ParseWorkflow(string(data))
+}
+
+func ParseWorkflow(content string) (*Workflow, error) {
+	sections := splitWorkflowSections(content)
+	workflow := &Workflow{
+		Intent:     strings.TrimSpace(sections["Intent"]),
+		Exceptions: strings.TrimSpace(sections["Exceptions"]),
+	}
+
+	defaultsBlock := firstFencedBlock(sections["Defaults"])
+	if defaultsBlock == "" {
+		return nil, fmt.Errorf("workflow defaults block is required")
+	}
+	if err := yaml.Unmarshal([]byte(defaultsBlock), &workflow.Defaults); err != nil {
+		return nil, fmt.Errorf("parse workflow defaults: %w", err)
+	}
+	if err := validateWorkflowDefaults(workflow.Defaults); err != nil {
+		return nil, err
+	}
+
+	pathPoliciesBlock := firstFencedBlock(sections["Path Policies"])
+	if pathPoliciesBlock != "" {
+		if err := yaml.Unmarshal([]byte(pathPoliciesBlock), &workflow.PathPolicies); err != nil {
+			return nil, fmt.Errorf("parse workflow path policies: %w", err)
+		}
+	}
+	if err := validateWorkflowPathPolicies(workflow.PathPolicies); err != nil {
+		return nil, err
+	}
+
+	return workflow, nil
+}
+
+func (w *Workflow) PromptPrefix() string {
+	if w == nil {
+		return ""
+	}
+
+	lines := []string{
+		"## Project Workflow",
+	}
+
+	if w.Intent != "" {
+		lines = append(lines, "")
+		lines = append(lines, "Intent:")
+		lines = append(lines, w.Intent)
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, "Defaults:")
+	lines = append(lines, fmt.Sprintf("- mode: %s", strings.TrimSpace(w.Defaults.Mode)))
+	lines = append(lines, fmt.Sprintf("- require_decision: %t", w.Defaults.RequireDecision))
+	lines = append(lines, fmt.Sprintf("- require_verify: %t", w.Defaults.RequireVerify))
+	lines = append(lines, fmt.Sprintf("- allow_autonomy: %t", w.Defaults.AllowAutonomy))
+
+	if len(w.PathPolicies) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Path policies: %d rule(s) declared in .haft/workflow.md. Apply them when touched files match.", len(w.PathPolicies)))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func ExampleWorkflowMarkdown() string {
+	return strings.Join([]string{
+		"# Workflow",
+		"",
+		"## Intent",
+		"",
+		"Haft should bias toward small reversible changes, require explicit decisions for core/domain edits,",
+		"and always verify behavior with tests or concrete runtime evidence before calling work complete.",
+		"",
+		"## Defaults",
+		"",
+		"```yaml",
+		"mode: standard",
+		"require_decision: true",
+		"require_verify: true",
+		"allow_autonomy: false",
+		"```",
+		"",
+		"## Path Policies",
+		"",
+		"```yaml",
+		"- path: \"internal/artifact/**\"",
+		"  mode: standard",
+		"  require_decision: true",
+		"  require_verify: true",
+		"- path: \"desktop/**\"",
+		"  mode: tactical",
+		"  require_decision: false",
+		"  require_verify: true",
+		"```",
+		"",
+		"## Exceptions",
+		"",
+		"Use tactical mode for narrow test-only fixes or low-risk docs updates. When a change touches a",
+		"policy-heavy path, keep the decision explicit even if the code delta is small.",
+		"",
+	}, "\n")
+}
+
+func splitWorkflowSections(content string) map[string]string {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	sections := make(map[string]*strings.Builder)
+	current := ""
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			current = strings.TrimSpace(strings.TrimPrefix(line, "## "))
+			sections[current] = &strings.Builder{}
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		sections[current].WriteString(line)
+		sections[current].WriteString("\n")
+	}
+
+	result := make(map[string]string, len(sections))
+	for key, value := range sections {
+		result[key] = value.String()
+	}
+	return result
+}
+
+func firstFencedBlock(section string) string {
+	if section == "" {
+		return ""
+	}
+
+	lines := strings.Split(strings.ReplaceAll(section, "\r\n", "\n"), "\n")
+	inBlock := false
+	var block strings.Builder
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			if !inBlock {
+				inBlock = true
+				continue
+			}
+			break
+		}
+		if !inBlock {
+			continue
+		}
+		block.WriteString(line)
+		block.WriteString("\n")
+	}
+
+	return strings.TrimSpace(block.String())
+}
+
+func validateWorkflowDefaults(defaults WorkflowDefaults) error {
+	if err := validateWorkflowMode(defaults.Mode, "defaults.mode"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWorkflowPathPolicies(policies []WorkflowPathPolicy) error {
+	for index, policy := range policies {
+		if strings.TrimSpace(policy.Path) == "" {
+			return fmt.Errorf("path_policies[%d].path is required", index)
+		}
+		if err := validateWorkflowMode(policy.Mode, fmt.Sprintf("path_policies[%d].mode", index)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWorkflowMode(mode string, field string) error {
+	mode = strings.TrimSpace(mode)
+	switch mode {
+	case "", "tactical", "standard", "deep":
+		return nil
+	default:
+		return fmt.Errorf("%s must be tactical, standard, or deep", field)
+	}
+}

--- a/internal/project/workflow_test.go
+++ b/internal/project/workflow_test.go
@@ -1,0 +1,88 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseWorkflow_Success(t *testing.T) {
+	workflow, err := ParseWorkflow(ExampleWorkflowMarkdown())
+	if err != nil {
+		t.Fatalf("ParseWorkflow returned error: %v", err)
+	}
+
+	if workflow.Intent == "" {
+		t.Fatal("expected intent section")
+	}
+	if workflow.Defaults.Mode != "standard" {
+		t.Fatalf("defaults.mode = %q", workflow.Defaults.Mode)
+	}
+	if !workflow.Defaults.RequireDecision {
+		t.Fatal("expected require_decision=true")
+	}
+	if len(workflow.PathPolicies) != 2 {
+		t.Fatalf("path policies = %d, want 2", len(workflow.PathPolicies))
+	}
+	if workflow.PathPolicies[0].Path != "internal/artifact/**" {
+		t.Fatalf("first policy path = %q", workflow.PathPolicies[0].Path)
+	}
+}
+
+func TestParseWorkflow_RejectsInvalidMode(t *testing.T) {
+	_, err := ParseWorkflow(strings.Replace(
+		ExampleWorkflowMarkdown(),
+		"mode: standard",
+		"mode: autopilot",
+		1,
+	))
+	if err == nil {
+		t.Fatal("expected invalid mode error")
+	}
+}
+
+func TestLoadWorkflow_ReadsProjectFile(t *testing.T) {
+	projectRoot := t.TempDir()
+	haftDir := filepath.Join(projectRoot, ".haft")
+	if err := os.MkdirAll(haftDir, 0o755); err != nil {
+		t.Fatalf("mkdir .haft: %v", err)
+	}
+
+	path := WorkflowPath(haftDir)
+	if err := os.WriteFile(path, []byte(ExampleWorkflowMarkdown()), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	workflow, err := LoadWorkflow(projectRoot)
+	if err != nil {
+		t.Fatalf("LoadWorkflow returned error: %v", err)
+	}
+	if workflow == nil {
+		t.Fatal("expected workflow")
+	}
+}
+
+func TestWorkflowPromptPrefix_UsesIntentAndDefaults(t *testing.T) {
+	workflow, err := ParseWorkflow(ExampleWorkflowMarkdown())
+	if err != nil {
+		t.Fatalf("ParseWorkflow returned error: %v", err)
+	}
+
+	prefix := workflow.PromptPrefix()
+	wantFragments := []string{
+		"## Project Workflow",
+		"Intent:",
+		"Defaults:",
+		"- mode: standard",
+		"- require_decision: true",
+		"- require_verify: true",
+		"- allow_autonomy: false",
+	}
+
+	for _, fragment := range wantFragments {
+		if !strings.Contains(prefix, fragment) {
+			t.Fatalf("prompt prefix missing %q\n%s", fragment, prefix)
+		}
+	}
+}

--- a/internal/reff/assurance.go
+++ b/internal/reff/assurance.go
@@ -1,0 +1,285 @@
+package reff
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrInadmissibleEvidence = errors.New("CL0 evidence cannot support")
+
+// Evidence is the minimal evidence shape needed for claim-scoped assurance
+// decomposition in the evidence engine.
+type Evidence struct {
+	ClaimRefs       []string
+	Type            string
+	Verdict         string
+	CongruenceLevel int
+	FormalityLevel  int
+	HasFormality    bool
+	ValidUntil      string
+}
+
+// ClaimAssurance is the per-claim F/G/R decomposition defined in the evidence
+// ontology.
+type ClaimAssurance struct {
+	ClaimRef      string
+	EvidenceCount int
+	HasEvidence   bool
+	FEff          int
+	GEff          int
+	REff          float64
+}
+
+// DecisionAssurance is the decision-level weakest-link aggregation over claims.
+type DecisionAssurance struct {
+	Claims      []ClaimAssurance
+	HasEvidence bool
+	FEff        int
+	GEff        int
+	REff        float64
+}
+
+// ComputeDecisionAssurance computes claim-scoped assurance and then applies the
+// weakest-link rule across claims. When claimRefs is empty, evidence is scored
+// directly as a backward-compatible pre-claim decision.
+func ComputeDecisionAssurance(claimRefs []string, items []Evidence, now time.Time) (DecisionAssurance, error) {
+	activeItems := filterActiveEvidence(items)
+	normalizedClaims := normalizeClaimRefs(claimRefs)
+
+	if len(normalizedClaims) == 0 {
+		claim, err := ComputeClaimAssurance("", activeItems, now)
+		if err != nil {
+			return DecisionAssurance{}, err
+		}
+
+		return DecisionAssurance{
+			HasEvidence: claim.HasEvidence,
+			FEff:        claim.FEff,
+			GEff:        claim.GEff,
+			REff:        claim.REff,
+		}, nil
+	}
+
+	result := DecisionAssurance{
+		Claims: make([]ClaimAssurance, 0, len(normalizedClaims)),
+		FEff:   3,
+		GEff:   3,
+		REff:   1.0,
+	}
+
+	for _, claimRef := range normalizedClaims {
+		claimItems := filterClaimEvidence(activeItems, claimRef)
+		claim, err := ComputeClaimAssurance(claimRef, claimItems, now)
+		if err != nil {
+			return DecisionAssurance{}, err
+		}
+
+		result.Claims = append(result.Claims, claim)
+		result.HasEvidence = result.HasEvidence || claim.HasEvidence
+		result.FEff = minInt(result.FEff, claim.FEff)
+		result.GEff = minInt(result.GEff, claim.GEff)
+		result.REff = minFloat(result.REff, claim.REff)
+	}
+
+	return result, nil
+}
+
+// ComputeClaimAssurance computes F/G/R for one claim by applying the
+// weakest-link rule to all active evidence that references it.
+func ComputeClaimAssurance(claimRef string, items []Evidence, now time.Time) (ClaimAssurance, error) {
+	result := ClaimAssurance{
+		ClaimRef: claimRef,
+	}
+
+	if len(items) == 0 {
+		return result, nil
+	}
+
+	result.EvidenceCount = len(items)
+	result.HasEvidence = true
+	result.FEff = 3
+	result.GEff = 3
+	result.REff = 1.0
+
+	for _, item := range items {
+		err := ValidateEvidence(item)
+		if err != nil {
+			return ClaimAssurance{}, err
+		}
+
+		formality := DeriveFormality(item)
+		groundedness := GroundednessFromCL(item.CongruenceLevel)
+		reliability := ScoreTypedEvidence(item.Type, item.Verdict, item.CongruenceLevel, item.ValidUntil, now)
+
+		result.FEff = minInt(result.FEff, formality)
+		result.GEff = minInt(result.GEff, groundedness)
+		result.REff = minFloat(result.REff, reliability)
+	}
+
+	return result, nil
+}
+
+// ValidateEvidence rejects evidence that the target-system contract marks as
+// inadmissible before it enters R_eff computation.
+func ValidateEvidence(item Evidence) error {
+	verdict := CanonicalVerdict(item.Verdict)
+	groundedness := GroundednessFromCL(item.CongruenceLevel)
+
+	if verdict != "supports" || groundedness != 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%w — re-evaluate or change verdict", ErrInadmissibleEvidence)
+}
+
+// CanonicalVerdict maps measurement aliases onto the canonical evidence
+// vocabulary used by the evidence engine.
+func CanonicalVerdict(verdict string) string {
+	normalized := strings.ToLower(strings.TrimSpace(verdict))
+
+	switch normalized {
+	case "supports", "accepted", "pass":
+		return "supports"
+	case "weakens", "partial", "degrade":
+		return "weakens"
+	case "refutes", "failed", "fail":
+		return "refutes"
+	case "superseded":
+		return "superseded"
+	default:
+		return "weakens"
+	}
+}
+
+// DeriveFormality returns the normalized explicit formality when present.
+// Otherwise it derives formality from evidence type.
+func DeriveFormality(item Evidence) int {
+	if item.HasFormality {
+		return NormalizeFormalityLevel(item.FormalityLevel)
+	}
+
+	return inferFormalityFromType(item.Type)
+}
+
+// NormalizeFormalityLevel preserves F0-F3 and folds legacy 0-9 values into the
+// same normalized formality scale used by the artifact layer.
+func NormalizeFormalityLevel(level int) int {
+	switch {
+	case level < 0:
+		return 0
+	case level <= 3:
+		return level
+	case level <= 5:
+		return 1
+	case level <= 8:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// GroundednessFromCL preserves CL semantics for view decomposition:
+// CL3=direct, CL2=similar, CL1=indirect, CL0=inadmissible.
+func GroundednessFromCL(cl int) int {
+	switch cl {
+	case 3, 2, 1, 0:
+		return cl
+	default:
+		return 0
+	}
+}
+
+func inferFormalityFromType(evidenceType string) int {
+	normalized := strings.ToLower(strings.TrimSpace(evidenceType))
+
+	switch normalized {
+	case "formal_proof", "proof", "proof_grade":
+		return 3
+	case "test_result", "test", "measurement", "explicit_measure", "partial_measure", "benchmark", "audit":
+		return 2
+	case "anecdote", "obs_no_verify":
+		return 0
+	case "documentation", "expert_opinion", "cross_project", "research", "code_review", "user_feedback", "attached", "observation", "obs_file_review", "obs_external":
+		return 1
+	case "obs_test_pass", "obs_lint_pass":
+		return 2
+	default:
+		return 1
+	}
+}
+
+func filterActiveEvidence(items []Evidence) []Evidence {
+	active := make([]Evidence, 0, len(items))
+
+	for _, item := range items {
+		if CanonicalVerdict(item.Verdict) == "superseded" {
+			continue
+		}
+
+		active = append(active, item)
+	}
+
+	return active
+}
+
+func filterClaimEvidence(items []Evidence, claimRef string) []Evidence {
+	filtered := make([]Evidence, 0, len(items))
+
+	for _, item := range items {
+		if !containsClaimRef(item.ClaimRefs, claimRef) {
+			continue
+		}
+
+		filtered = append(filtered, item)
+	}
+
+	return filtered
+}
+
+func normalizeClaimRefs(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+
+	return normalized
+}
+
+func containsClaimRef(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func minInt(left int, right int) int {
+	if left < right {
+		return left
+	}
+
+	return right
+}
+
+func minFloat(left float64, right float64) float64 {
+	if left < right {
+		return left
+	}
+
+	return right
+}

--- a/internal/reff/assurance_test.go
+++ b/internal/reff/assurance_test.go
@@ -1,0 +1,140 @@
+package reff
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestComputeDecisionAssurance_ComputesPerClaimDecomposition(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+
+	got, err := ComputeDecisionAssurance(
+		[]string{"claim-latency", "claim-correctness"},
+		[]Evidence{
+			{
+				ClaimRefs:       []string{"claim-latency"},
+				Type:            "benchmark",
+				Verdict:         "supports",
+				CongruenceLevel: 3,
+				ValidUntil:      "2026-05-01T00:00:00Z",
+			},
+			{
+				ClaimRefs:       []string{"claim-latency"},
+				Type:            "documentation",
+				Verdict:         "weakens",
+				CongruenceLevel: 2,
+				ValidUntil:      "2026-05-01T00:00:00Z",
+			},
+			{
+				ClaimRefs:       []string{"claim-correctness"},
+				Type:            "test_result",
+				Verdict:         "accepted",
+				CongruenceLevel: 3,
+				ValidUntil:      "2026-05-01T00:00:00Z",
+			},
+		},
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claims := claimAssuranceIndex(got.Claims)
+	latency := claims["claim-latency"]
+	correctness := claims["claim-correctness"]
+
+	if latency.REff != 0.4 {
+		t.Fatalf("latency R_eff = %.2f, want 0.40", latency.REff)
+	}
+	if latency.FEff != 1 {
+		t.Fatalf("latency F_eff = %d, want 1", latency.FEff)
+	}
+	if latency.GEff != 2 {
+		t.Fatalf("latency G_eff = %d, want 2", latency.GEff)
+	}
+	if correctness.REff != 1.0 {
+		t.Fatalf("correctness R_eff = %.2f, want 1.00", correctness.REff)
+	}
+	if correctness.FEff != 2 {
+		t.Fatalf("correctness F_eff = %d, want 2", correctness.FEff)
+	}
+	if correctness.GEff != 3 {
+		t.Fatalf("correctness G_eff = %d, want 3", correctness.GEff)
+	}
+	if got.REff != 0.4 {
+		t.Fatalf("decision R_eff = %.2f, want 0.40", got.REff)
+	}
+	if got.FEff != 1 {
+		t.Fatalf("decision F_eff = %d, want 1", got.FEff)
+	}
+	if got.GEff != 2 {
+		t.Fatalf("decision G_eff = %d, want 2", got.GEff)
+	}
+}
+
+func TestDeriveFormality_UsesExplicitLevelBeforeType(t *testing.T) {
+	got := DeriveFormality(Evidence{
+		Type:           "documentation",
+		FormalityLevel: 7,
+		HasFormality:   true,
+	})
+
+	if got != 2 {
+		t.Fatalf("DeriveFormality(explicit=7) = %d, want 2", got)
+	}
+}
+
+func TestGroundednessFromCL(t *testing.T) {
+	cases := []struct {
+		name string
+		cl   int
+		want int
+	}{
+		{name: "same context", cl: 3, want: 3},
+		{name: "similar context", cl: 2, want: 2},
+		{name: "indirect context", cl: 1, want: 1},
+		{name: "opposed context", cl: 0, want: 0},
+		{name: "invalid context", cl: -1, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GroundednessFromCL(tc.cl)
+			if got != tc.want {
+				t.Fatalf("GroundednessFromCL(%d) = %d, want %d", tc.cl, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeDecisionAssurance_RejectsCL0Supports(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+
+	_, err := ComputeDecisionAssurance(
+		[]string{"claim-latency"},
+		[]Evidence{
+			{
+				ClaimRefs:       []string{"claim-latency"},
+				Type:            "benchmark",
+				Verdict:         "supports",
+				CongruenceLevel: 0,
+				ValidUntil:      "2026-05-01T00:00:00Z",
+			},
+		},
+		now,
+	)
+	if !errors.Is(err, ErrInadmissibleEvidence) {
+		t.Fatalf("error = %v, want ErrInadmissibleEvidence", err)
+	}
+}
+
+func claimAssuranceIndex(values []ClaimAssurance) map[string]ClaimAssurance {
+	index := make(map[string]ClaimAssurance, len(values))
+
+	for _, value := range values {
+		index[value.ClaimRef] = value
+	}
+
+	return index
+}

--- a/internal/tools/haft.go
+++ b/internal/tools/haft.go
@@ -52,6 +52,7 @@ Actions:
 				"action":                 map[string]any{"type": "string", "enum": []string{"frame", "adopt", "select", "characterize", "close"}, "description": "frame | adopt | select | characterize | close"},
 				"ref":                    map[string]any{"type": "string", "description": "Existing problem ID to adopt (adopt)"},
 				"title":                  map[string]any{"type": "string", "description": "Problem title (frame)"},
+				"problem_type":           map[string]any{"type": "string", "description": "optimization | diagnosis | search | synthesis (frame)"},
 				"signal":                 map[string]any{"type": "string", "description": "What's anomalous or broken (frame)"},
 				"constraints":            map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Hard limits (frame)"},
 				"optimization_targets":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "What to improve, 1-3 max (frame)"},
@@ -97,6 +98,7 @@ func (t *HaftProblemTool) Execute(ctx context.Context, argsJSON string) (agent.T
 	case "frame":
 		input := artifact.ProblemFrameInput{
 			Title:                 jsonStr(args, "title"),
+			ProblemType:           jsonStr(args, "problem_type"),
 			Signal:                jsonStr(args, "signal"),
 			Acceptance:            jsonStr(args, "acceptance"),
 			BlastRadius:           jsonStr(args, "blast_radius"),
@@ -172,7 +174,11 @@ func (t *HaftProblemTool) Execute(ctx context.Context, argsJSON string) (agent.T
 		var b strings.Builder
 		items := artifact.EnrichProblemsForList(ctx, t.store, problems)
 		for _, item := range items {
-			fmt.Fprintf(&b, "- [%s] %s (%s) %s\n", item.Problem.Meta.ID, item.Problem.Meta.Title, item.Problem.Meta.Status, item.Signals)
+			title := item.Problem.Meta.Title
+			if problemType := artifact.ProblemTypeLabel(item.Problem); problemType != "" {
+				title += " (" + problemType + ")"
+			}
+			fmt.Fprintf(&b, "- [%s] %s (%s) %s\n", item.Problem.Meta.ID, title, item.Problem.Meta.Status, item.Signals)
 		}
 		return agent.PlainResult(b.String()), nil
 

--- a/internal/tools/haft_test.go
+++ b/internal/tools/haft_test.go
@@ -464,7 +464,7 @@ func TestHaftQueryTool_ProjectionChangeRationaleUsesCanonicalDecisionState(t *te
 		"Rejected alternatives:",
 		"- REST: Higher steady-state latency with no decisive cost advantage.",
 		"Rollback summary: Error budget exceeds 2% during canary",
-		"Latest measurement verdict: partial",
+		"Latest measurement verdict: weakens",
 	}
 
 	for _, want := range required {

--- a/internal/tools/haft_test.go
+++ b/internal/tools/haft_test.go
@@ -1382,9 +1382,40 @@ func TestHaftDecisionTool_MeasureRejectsForeignDecisionRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	foreignProblem, _, err := artifact.FrameProblem(fixture.ctx, fixture.store, fixture.haftDir, artifact.ProblemFrameInput{
+		Title:      "Streaming fallback transport",
+		Signal:     "Current transport cannot survive mobile reconnect churn.",
+		Acceptance: "Select a transport that keeps reconnect latency predictable.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foreignPortfolio, _, err := artifact.ExploreSolutions(fixture.ctx, fixture.store, fixture.haftDir, artifact.ExploreInput{
+		ProblemRef: foreignProblem.Meta.ID,
+		Variants: []artifact.Variant{
+			{
+				ID:            "Y1",
+				Title:         "WebSocket",
+				WeakestLink:   "connection lifecycle complexity",
+				NoveltyMarker: "Keep long-lived duplex sessions",
+			},
+			{
+				ID:            "Y2",
+				Title:         "SSE",
+				WeakestLink:   "server-to-client only",
+				NoveltyMarker: "Use unidirectional event streams",
+			},
+		},
+		NoSteppingStoneRationale: "Both variants are valid responses to the separate reconnect problem.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	foreignDecision, _, err := artifact.Decide(fixture.ctx, fixture.store, fixture.haftDir, artifact.DecideInput{
-		ProblemRef:      fixture.problem.Meta.ID,
-		PortfolioRef:    fixture.otherPortfolio.Meta.ID,
+		ProblemRef:      foreignProblem.Meta.ID,
+		PortfolioRef:    foreignPortfolio.Meta.ID,
 		SelectedTitle:   "WebSocket",
 		WhySelected:     "The foreign portfolio keeps duplex connections available.",
 		SelectionPolicy: "Prioritize persistent duplex transport.",

--- a/spec/WORKFLOW.md
+++ b/spec/WORKFLOW.md
@@ -1,0 +1,55 @@
+# `.haft/workflow.md`
+
+`workflow.md` is a small project policy file for how Haft should reason and execute inside this repo.
+
+It is a hybrid document:
+
+1. `Intent` is prose for human-readable direction.
+2. `Defaults` is YAML for project-wide policy.
+3. `Path Policies` is YAML for path-scoped overrides.
+4. `Exceptions` is prose for edge cases that do not fit the defaults.
+
+## Schema
+
+### Intent
+
+Plain markdown prose under `## Intent`.
+
+### Defaults
+
+The first fenced YAML block under `## Defaults` must match:
+
+```yaml
+mode: standard        # tactical | standard | deep
+require_decision: true
+require_verify: true
+allow_autonomy: false
+```
+
+### Path Policies
+
+The first fenced YAML block under `## Path Policies` is a list of path rules:
+
+```yaml
+- path: "internal/artifact/**"
+  mode: standard
+  require_decision: true
+  require_verify: true
+  allow_autonomy: false
+```
+
+Rules:
+
+- `path` is required.
+- `mode` is optional, but if present must be `tactical`, `standard`, or `deep`.
+- boolean flags are optional overrides for matching paths.
+
+### Exceptions
+
+Plain markdown prose under `## Exceptions`.
+
+## Runtime behavior
+
+- `haft agent` prepends `Intent` + `Defaults` to the agent system prompt at startup.
+- `haft serve` exposes the same prompt prefix through MCP initialize instructions.
+- `haft init` creates an example `.haft/workflow.md` when the file does not exist.

--- a/spec/target-system/ILLEGAL_STATES.md
+++ b/spec/target-system/ILLEGAL_STATES.md
@@ -14,7 +14,7 @@
 | 4 | Comparison without parity declaration | Comparison without same-conditions statement is invalid. | Skill instructions require parity. L2 enforcement planned. |
 | 5 | DecisionRecord with status `active` and no `selected_title` | A decision must have chosen something. | `Decide()` requires selected_title. |
 | 6 | EvidencePack with verdict `supports` and CL0 | Evidence from opposed context cannot support — inadmissible, not merely weak. | **Enforced:** reject at ingest or downgrade verdict to `weakens` before storage. CL0+supports must not enter R_eff computation. |
-| 7 | Two active DecisionRecords for the same ProblemCard | One problem → one active decision. Previous must be superseded. | Not currently enforced. **Gap: should be.** |
+| 7 | Two active DecisionRecords for the same ProblemCard | One problem → one active decision. Previous must be superseded. | **Enforced:** `Decide()` rejects a new live DecisionRecord when another live decision already governs the same problem. |
 | 8 | Note with >70% title word overlap with active DecisionRecord | Note duplicates an existing decision. | `haft_note` rejects at >70% overlap. Warns at 50-70%. |
 | 9 | Artifact with status `addressed` that is not a ProblemCard | Only problems can be "addressed." Other artifacts use superseded/deprecated. | `close` action only on ProblemCard kind. |
 
@@ -64,7 +64,6 @@
 
 | # | Gap | Impact | Priority |
 |---|-----|--------|----------|
-| G1 | #7: Multiple active decisions per problem | Poisons invariant injection, file-to-decision lookup, governance scans, and "what governs this file?" | **High** — must enforce before v7 execution loop |
 | G2 | #4: Parity declaration enforcement | Unfair comparisons pass without warning | **High** — planned for v6.x |
 | G3 | #10: Measurement fabrication detection | Trust inflation | Low — fundamentally LLM discipline issue |
 | G4 | #19: Subjective dimension enforcement | Entire Choose mode can look rigorous while being semantically hollow. Core value proposition corrupted. | **High** — L2 enforcement needed before v7 |

--- a/spec/target-system/SCOPE_FREEZE.md
+++ b/spec/target-system/SCOPE_FREEZE.md
@@ -65,15 +65,36 @@ Focus: trust and momentum for existing MCP/CLI users. No new surfaces.
   - [ ] G4: warn on subjective comparison dimensions (maintainable, simple, scalable)
 - [ ] Rename/install/docs polish for migration friction
 
-## v6.2 — Execution Primitives (days 31-60)
+## v6.2 — Execution Primitives + Dashboard (days 31-60)
 
 Focus: desktop starts proving the loop, not just visualizing.
 
-- [ ] Decision-anchored "Implement" from desktop (spawn agent in worktree with invariants + rationale)
-- [ ] Worktree/branch creation
+### Dashboard (single operator surface)
+- [ ] Unified dashboard page replacing separate Problems/Decisions pages
+- [ ] Active decisions section with **Implement** button → spawn agent in worktree with invariants + rationale
+- [ ] Governance findings section with **Adopt** / **Waive** / **Reopen** buttons on stale/drifted items
+- [ ] Adopt button → creates agent task/thread with decision context + drift report for interactive resolution
+- [ ] Automation section: **New Automation** → configure triggers (CI fail, dependency update, scheduled, manual) → auto-creates ProblemCard
+
+### Execution loop
+- [ ] Worktree/branch creation from Implement action
 - [ ] Automatic post-run invariant verification
 - [ ] Baseline refresh only on successful verification
 - [ ] Persisted verification/governance result linked to decision
+
+### DDR→Task Pipeline (Implement generates subtasks)
+- [ ] Implement on DecisionRecord generates subtask plan from invariants/claims/affected_files
+- [ ] Subtasks run sequentially via desktop governor (agent per task, worktree per task)
+- [ ] Auto-advance mode: next task starts when previous completes successfully
+- [ ] Manual mode (default): pause between tasks for review
+- [ ] Each subtask gets full decision context + previous subtask results
+
+### Deep onboard for legacy projects
+- [ ] `/h-onboard --deep` generates task plan from coverage gaps (blind modules)
+- [ ] Per-module deep analysis session: read code, identify responsibilities, record decisions/notes/baselines
+- [ ] Runs as automation trigger or via task pipeline
+
+**Terminology:** "problem" is reserved for ProblemCard artifacts only. The dashboard page is "Dashboard", not "Problem Board".
 
 ## v7.0 — Desktop Loop MVP (days 61-90)
 

--- a/spec/target-system/TERM_MAP.md
+++ b/spec/target-system/TERM_MAP.md
@@ -92,6 +92,15 @@
 | **F_eff (Formality)** | How structured is the evidence? F0 (anecdote) → F3 (formal proof). View concern for evidence decomposition. | Not a separate trust score. Decomposes R_eff inputs. |
 | **G_eff (Groundedness)** | How close is the evidence to the thing it verifies? Derived from CL. View concern. | Not a separate trust score. Decomposes R_eff inputs. |
 
+## Desktop Surfaces
+
+| Term | Definition | NOT this |
+|------|-----------|----------|
+| **Dashboard** | The single unified operator page in the desktop app. Shows active decisions, governance findings, automations, and recent activity. | Not "Problem Board." Problems appear as cards within the dashboard. |
+| **Implement** | Dashboard action on a DecisionRecord: spawns agent in worktree with invariants + rationale + workflow.md. | Not "run task." Implement is decision-anchored — the agent gets full reasoning context. |
+| **Adopt** | Dashboard action on a governance finding (stale/drifted): creates agent task/thread with decision context + drift report for interactive resolution. | Not auto-fix. Human resolves with agent assistance, then re-baselines, reopens, or waives. |
+| **Automation** | A configured trigger that auto-creates ProblemCards: CI fail, dependency update, scheduled, manual. The "problem factory." | Not a workflow engine. Creates problems, doesn't execute solutions. |
+
 ## Terms That Cause Confusion
 
 | Confusing term | Clarification |


### PR DESCRIPTION
## Summary

26 tasks completed. Decision quality enforcement before automating execution.

### Added
- `haft check` — local governance verification (exit 0/1)
- `/h-verify` surfaces full governance state (problems, invariants, drift)
- `.haft/workflow.md` — repo-level agent policy
- Problem typing on ProblemCard
- Derived decision health (Maturity + Freshness)
- Claim-scoped R_eff and evidence supersession
- Deep `/h-onboard` for legacy projects

### Enforced
- G1: one active decision per problem
- G2: parity plan warnings
- G4: subjective dimension detection
- CL0+supports rejection