### PR TITLE
feat(provider): claudecode provider for Claude Max/Pro subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ desktop/desktop
 .zenflow/**
 DESIGN.md
 .playwright-mcp/
+.osgrep

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
       excludes:
         - G301 # directory permissions 0755 — fine for user-facing dirs
         - G302 # file permissions 0644 — fine for user-facing files
-        - G204 # subprocess with variable — we call quint/git as subprocess intentionally
+        - G204 # subprocess with variable — we call claude/git as subprocess intentionally
         - G304 # file inclusion via variable — we read user-specified paths intentionally
         - G306 # WriteFile permissions 0644 — fine for markdown/config files
         - G703 # path traversal — we construct paths from project root intentionally

--- a/db/store_test.go
+++ b/db/store_test.go
@@ -207,12 +207,12 @@ func TestStore_AuditLog(t *testing.T) {
 
 	ctx := context.Background()
 
-	err = store.InsertAuditLog(ctx, "log-1", "quint_propose", "create_hypothesis", "agent", "hypo-1", "abc123", "SUCCESS", "", "default")
+	err = store.InsertAuditLog(ctx, "log-1", "haft_propose", "create_hypothesis", "agent", "hypo-1", "abc123", "SUCCESS", "", "default")
 	if err != nil {
 		t.Fatalf("InsertAuditLog failed: %v", err)
 	}
 
-	err = store.InsertAuditLog(ctx, "log-2", "quint_verify", "verify_hypothesis", "agent", "hypo-1", "def456", "SUCCESS", `{"verdict":"PASS"}`, "default")
+	err = store.InsertAuditLog(ctx, "log-2", "haft_verify", "verify_hypothesis", "agent", "hypo-1", "def456", "SUCCESS", `{"verdict":"PASS"}`, "default")
 	if err != nil {
 		t.Fatalf("InsertAuditLog failed: %v", err)
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -691,20 +691,11 @@ func (a *App) enrichWithGraphInvariants(detail DecisionDetailView) DecisionDetai
 // --- Helpers ---
 
 func findProjectRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
+	root, ok := project.FindRootFromCwd()
+	if !ok {
+		return "", fmt.Errorf("no .haft/ found")
 	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, ".haft")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no .haft/ found")
-		}
-		dir = parent
-	}
+	return root, nil
 }
 
 func mapArtifacts[T any](arts []*artifact.Artifact, fn func(*artifact.Artifact) T, limit int) []T {

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -84,7 +84,7 @@ with the user prompt on stdin.
 
 - `<tmpfile>` is generated per turn and contains an `mcpServers.haft` entry
   telling the CLI to spawn the current `haft` binary in `serve` mode with
-  `QUINT_PROJECT_ROOT` pointing at the detected project root (discovered by
+  `HAFT_PROJECT_ROOT` pointing at the detected project root (discovered by
   walking up from `cwd` looking for `.haft/`). The tmpfile is deleted after
   the turn via `defer`.
 - The model sees haft's artifact tools as `mcp__haft__haft_note`,

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -76,7 +76,7 @@ claude -p \
   --mcp-config <tmpfile>   \      # points at `haft serve`
   --permission-mode bypassPermissions \
   --add-dir <project_root> \
-  --append-system-prompt "<system>" \
+  --system-prompt "<system>" \
   [--model <submodel>]
 ```
 

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -40,6 +40,19 @@ haft doctor
 
 No API key block is required in `config.yaml` — auth is delegated to the CLI.
 
+### Max / Pro billing
+
+As of the [Apr 2026 fix](https://github.com/anthropics/claude-code/issues/43333),
+`claude -p` draws from an active Max/Pro subscription when the CLI is signed
+in via OAuth and no `ANTHROPIC_API_KEY` is present. This provider **unsets
+`ANTHROPIC_API_KEY` in the child process environment** before exec'ing
+`claude`, so a stray export in your shell won't silently route you to
+per-token API billing. The parent process env is untouched.
+
+If you explicitly want API-key billing instead (e.g. for higher rate limits
+or an Anthropic org account), use the `anthropic` provider instead —
+`model: claude-sonnet-4-20250514` etc. — which will read your key directly.
+
 ## Model IDs
 
 | haft model id        | CLI `--model` forwarded | Notes                         |

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -94,52 +94,32 @@ with the user prompt on stdin.
 - Opt out with `HAFT_CLAUDECODE_NO_MCP=1` — the provider falls back to
   `--allowed-tools ''` (text-only, no built-ins, no haft tools).
 
+## Session reuse
+
+After the first turn the provider caches the CLI's `session_id` and forwards
+`--resume <id>` on subsequent turns, so turn 2+ skips the cold `claude` +
+`haft serve` spawn (~3–5× faster). When haft's message list grows by exactly
+one new user message since the last successful turn, only that user text is
+sent to the CLI — the CLI already owns the transcript. Any divergence
+(history edited, branch taken, tool-role tail) falls back to a fresh turn
+and clears the session. On any subprocess or parse error the session is
+invalidated so the next turn starts clean.
+
+Opt out with `HAFT_CLAUDECODE_NO_RESUME=1` to force every turn to be fresh.
+
 ## Limitations
 
 1. **Tools bypass haft's outer loop.** Permission callbacks, hooks, and
    cycle tracking do not fire per tool call when this provider is used.
-2. **Each turn is a fresh CLI invocation.** No session reuse. On long
-   conversations this can add ~200–500ms of CLI startup overhead per turn,
-   plus another ~200ms to spawn `haft serve` inside the CLI.
-3. **Doctor check is best-effort.** `haft doctor` only verifies `claude` is on
+2. **Doctor check is best-effort.** `haft doctor` only verifies `claude` is on
    PATH, not that you're actually signed in. Run `claude login` once if the
    first turn errors out with an auth failure.
-4. **No image input** (for now — the CLI supports it, haft's converter
+3. **No image input** (for now — the CLI supports it, haft's converter
    doesn't surface `ImagePart` to the CLI yet).
+4. **Session files accumulate** in `~/.claude/`. Sessions are short and
+   disposable; the CLI's own TTL handles cleanup.
 
 ## Follow-up work
-
-### Session reuse via `--resume` (highest-impact)
-
-Each turn currently pays ~5–10s for fresh `claude` + `haft serve` spawn.
-`--resume <session_id>` would cut that to ~1–2s on turn 2+. It's the dominant
-cost and is listed separately because it's not a small change:
-
-- **Provider becomes stateful.** Today `LLMProvider.Stream` is a pure function
-  of `(ctx, messages, tools, handler)`. Adding a session_id field changes that
-  contract; `anthropic.go` / `openai.go` don't have one. Either we add a
-  lifecycle method to the interface (`Close()` at minimum, arguably `Reset()`)
-  or we keep the session TTL implicit and accept stale-session errors on
-  occasional rebuild.
-- **Message delta vs full history.** With `--resume`, the CLI owns the
-  conversation. Re-sending the full flattened history every turn would
-  double-count context. The provider needs to track "what did I send on the
-  last turn" and forward only the new user message. A simple approach: on
-  resume, send only the last `RoleUser` message's text; drop the
-  `flattenConversation` path. But that makes divergence (haft's agent loop
-  edited a prior message, for instance) silently wrong.
-- **Drop `--no-session-persistence`.** Needed so the session can be found on
-  turn 2. Consequence: `~/.claude/` accumulates haft sessions. A cleanup
-  strategy (TTL, or explicit `claude session rm`) is wanted.
-- **Fallback on stale session.** `--resume` errors on expired/deleted sessions.
-  The provider should catch this and retry as a fresh turn — silent to the
-  agent loop.
-
-A clean shape is likely a follow-up PR that introduces an optional
-`StatefulProvider` sub-interface and has only `ClaudeCodeProvider` (and maybe
-future providers that can benefit) implement it.
-
-### Other
 
 - Propagate the CLI's `result` event token counts into `Message.Tokens`.
 - Surface tool-use progress as StreamDelta `Thinking` chunks so the outer

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -1,0 +1,92 @@
+# Claude Code provider
+
+The `claudecode` provider lets haft's interactive agent use the `claude` CLI
+(Claude Code) as its LLM backend. This means **Pro / Max subscribers can drive
+`haft agent` without setting `ANTHROPIC_API_KEY`** — auth is owned by the CLI.
+
+## When to use it
+
+- You already have a Claude Pro or Max subscription and don't want to pay
+  per-token on top of it.
+- You want a quick reasoning loop (`haft` bare mode, `/h-reason` brainstorming)
+  without the Anthropic SDK.
+
+## When **not** to use it
+
+- You need haft's artifact tools (`haft_note`, `haft_problem`, `haft_decision`,
+  etc.) to be callable by the model. This MVP does not translate haft's tool
+  schemas to the CLI surface — the model only emits text. Tool-driven agent
+  loops should stay on the `anthropic` or `openai` providers until follow-up
+  PRs land the `--mcp-config` bridge.
+- You need image input or fine-grained token accounting. The CLI does not
+  surface Anthropic-native token counts to stdout yet.
+
+## Setup
+
+```sh
+# 1. Install Claude Code and sign in.
+# https://docs.claude.com/en/docs/claude-code
+claude login
+
+# 2. Point haft at the claudecode provider.
+cat > ~/.haft/config.yaml <<'YAML'
+model: claude-code
+YAML
+
+# 3. Verify.
+haft doctor
+#   ✓ Claude Code CLI: 1.x.y (/usr/local/bin/claude)
+```
+
+No API key block is required in `config.yaml` — auth is delegated to the CLI.
+
+## Model IDs
+
+| haft model id        | CLI `--model` forwarded | Notes                         |
+| -------------------- | ----------------------- | ----------------------------- |
+| `claude-code`        | *(none — CLI default)*  | Whatever Claude Code prefers. |
+| `claude-code:opus`   | `opus`                  | Alias → latest Opus.          |
+| `claude-code:sonnet` | `sonnet`                | Alias → latest Sonnet.        |
+| `claude-code:haiku`  | `haiku`                 | Alias → latest Haiku.         |
+
+A full model name also works: `claude-code:claude-opus-4-5` forwards
+`--model claude-opus-4-5` to the CLI.
+
+## How it works
+
+Each turn, haft flattens the conversation into `(system_prompt, user_prompt)`
+and invokes:
+
+```sh
+claude -p \
+  --output-format stream-json --verbose \
+  --allowed-tools '' \          # disable CLI's built-in tools
+  --no-session-persistence \
+  --append-system-prompt "<system>" \
+  [--model <submodel>]
+```
+
+with the user prompt on stdin. The provider parses NDJSON events from stdout,
+forwards every `text` block as a `StreamDelta`, and returns the concatenated
+response as an assistant `Message` once the `result` event arrives.
+
+Tool-use events are ignored — haft's tool schemas aren't passed to the CLI in
+this MVP, so the model will never emit `tool_use`.
+
+## Limitations
+
+1. **No tool-use.** Agent loops that require `haft_*` tools will get text-only
+   responses. Use `anthropic` or `openai` for those flows.
+2. **Each turn is a fresh CLI invocation.** No session reuse. On long
+   conversations this can add ~200–500ms of CLI startup overhead per turn.
+3. **Doctor check is best-effort.** `haft doctor` only verifies `claude` is on
+   PATH, not that you're actually signed in. Run `claude login` once if the
+   first turn errors out with an auth failure.
+
+## Follow-up work
+
+- Translate `agent.ToolSchema` → `--mcp-config` entries so haft's artifact
+  tools are callable.
+- Parse `tool_use` / `tool_result` stream-json events.
+- Session reuse via `--resume` to amortize startup cost.
+- Propagate token counts from the CLI's `result` event.

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -109,7 +109,38 @@ with the user prompt on stdin.
 
 ## Follow-up work
 
-- Session reuse via `--resume` to amortize startup cost.
+### Session reuse via `--resume` (highest-impact)
+
+Each turn currently pays ~5–10s for fresh `claude` + `haft serve` spawn.
+`--resume <session_id>` would cut that to ~1–2s on turn 2+. It's the dominant
+cost and is listed separately because it's not a small change:
+
+- **Provider becomes stateful.** Today `LLMProvider.Stream` is a pure function
+  of `(ctx, messages, tools, handler)`. Adding a session_id field changes that
+  contract; `anthropic.go` / `openai.go` don't have one. Either we add a
+  lifecycle method to the interface (`Close()` at minimum, arguably `Reset()`)
+  or we keep the session TTL implicit and accept stale-session errors on
+  occasional rebuild.
+- **Message delta vs full history.** With `--resume`, the CLI owns the
+  conversation. Re-sending the full flattened history every turn would
+  double-count context. The provider needs to track "what did I send on the
+  last turn" and forward only the new user message. A simple approach: on
+  resume, send only the last `RoleUser` message's text; drop the
+  `flattenConversation` path. But that makes divergence (haft's agent loop
+  edited a prior message, for instance) silently wrong.
+- **Drop `--no-session-persistence`.** Needed so the session can be found on
+  turn 2. Consequence: `~/.claude/` accumulates haft sessions. A cleanup
+  strategy (TTL, or explicit `claude session rm`) is wanted.
+- **Fallback on stale session.** `--resume` errors on expired/deleted sessions.
+  The provider should catch this and retry as a fresh turn — silent to the
+  agent loop.
+
+A clean shape is likely a follow-up PR that introduces an optional
+`StatefulProvider` sub-interface and has only `ClaudeCodeProvider` (and maybe
+future providers that can benefit) implement it.
+
+### Other
+
 - Propagate the CLI's `result` event token counts into `Message.Tokens`.
 - Surface tool-use progress as StreamDelta `Thinking` chunks so the outer
   UI can show "Claude is calling haft_note…" rather than a silent pause.

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -13,13 +13,12 @@ The `claudecode` provider lets haft's interactive agent use the `claude` CLI
 
 ## When **not** to use it
 
-- You need haft's artifact tools (`haft_note`, `haft_problem`, `haft_decision`,
-  etc.) to be callable by the model. This MVP does not translate haft's tool
-  schemas to the CLI surface — the model only emits text. Tool-driven agent
-  loops should stay on the `anthropic` or `openai` providers until follow-up
-  PRs land the `--mcp-config` bridge.
-- You need image input or fine-grained token accounting. The CLI does not
-  surface Anthropic-native token counts to stdout yet.
+- You need haft's per-tool hooks, permission model, or cycle-tracking to run
+  for every tool call. With this provider, tool execution happens inside the
+  `claude` subprocess — haft's outer loop only sees the final assistant text
+  after all rounds are done. Use `anthropic` or `openai` providers when you
+  need tool-level governance.
+- You need image input or fine-grained token accounting.
 
 ## Setup
 
@@ -73,33 +72,45 @@ and invokes:
 ```sh
 claude -p \
   --output-format stream-json --verbose \
-  --allowed-tools '' \          # disable CLI's built-in tools
   --no-session-persistence \
+  --mcp-config <tmpfile>   \      # points at `haft serve`
+  --permission-mode bypassPermissions \
+  --add-dir <project_root> \
   --append-system-prompt "<system>" \
   [--model <submodel>]
 ```
 
-with the user prompt on stdin. The provider parses NDJSON events from stdout,
-forwards every `text` block as a `StreamDelta`, and returns the concatenated
-response as an assistant `Message` once the `result` event arrives.
+with the user prompt on stdin.
 
-Tool-use events are ignored — haft's tool schemas aren't passed to the CLI in
-this MVP, so the model will never emit `tool_use`.
+- `<tmpfile>` is generated per turn and contains an `mcpServers.haft` entry
+  telling the CLI to spawn the current `haft` binary in `serve` mode with
+  `QUINT_PROJECT_ROOT` pointing at the detected project root (discovered by
+  walking up from `cwd` looking for `.haft/`). The tmpfile is deleted after
+  the turn via `defer`.
+- The model sees haft's artifact tools as `mcp__haft__haft_note`,
+  `mcp__haft__haft_problem`, etc., **plus** the CLI's built-in Read/Write/
+  Bash/etc. Tool execution happens inside the CLI subprocess; haft's outer
+  agent loop receives the final assistant text after all round-trips finish.
+- Opt out with `HAFT_CLAUDECODE_NO_MCP=1` — the provider falls back to
+  `--allowed-tools ''` (text-only, no built-ins, no haft tools).
 
 ## Limitations
 
-1. **No tool-use.** Agent loops that require `haft_*` tools will get text-only
-   responses. Use `anthropic` or `openai` for those flows.
+1. **Tools bypass haft's outer loop.** Permission callbacks, hooks, and
+   cycle tracking do not fire per tool call when this provider is used.
 2. **Each turn is a fresh CLI invocation.** No session reuse. On long
-   conversations this can add ~200–500ms of CLI startup overhead per turn.
+   conversations this can add ~200–500ms of CLI startup overhead per turn,
+   plus another ~200ms to spawn `haft serve` inside the CLI.
 3. **Doctor check is best-effort.** `haft doctor` only verifies `claude` is on
    PATH, not that you're actually signed in. Run `claude login` once if the
    first turn errors out with an auth failure.
+4. **No image input** (for now — the CLI supports it, haft's converter
+   doesn't surface `ImagePart` to the CLI yet).
 
 ## Follow-up work
 
-- Translate `agent.ToolSchema` → `--mcp-config` entries so haft's artifact
-  tools are callable.
-- Parse `tool_use` / `tool_result` stream-json events.
 - Session reuse via `--resume` to amortize startup cost.
-- Propagate token counts from the CLI's `result` event.
+- Propagate the CLI's `result` event token counts into `Message.Tokens`.
+- Surface tool-use progress as StreamDelta `Thinking` chunks so the outer
+  UI can show "Claude is calling haft_note…" rather than a silent pause.
+- Image support by encoding `ImagePart` into stream-json input blocks.

--- a/internal/artifact/nav_test.go
+++ b/internal/artifact/nav_test.go
@@ -403,15 +403,18 @@ func buildNavStates(t *testing.T) map[DerivedStatus]NavState {
 	return states
 }
 
-// Contract: NextAction never contains tool call syntax (quint_*).
-// All actions must use slash commands (/h-*).
+// Contract: NextAction never contains raw tool-call syntax (haft_*, or
+// the legacy quint_* prefix). All user-facing actions must use slash
+// commands (/h-*).
 func TestContract_NoToolCallSyntax(t *testing.T) {
 	for status, state := range buildNavStates(t) {
 		if state.NextAction == "" {
 			continue
 		}
-		if strings.Contains(state.NextAction, "quint_") {
-			t.Errorf("[%s] NextAction uses tool call syntax: %q", status, state.NextAction)
+		for _, prefix := range []string{"haft_", "quint_"} {
+			if strings.Contains(state.NextAction, prefix) {
+				t.Errorf("[%s] NextAction uses tool-call syntax %q: %q", status, prefix, state.NextAction)
+			}
 		}
 		if !strings.Contains(state.NextAction, "/h-") {
 			t.Errorf("[%s] NextAction should use slash commands (/h-*): %q", status, state.NextAction)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -129,6 +129,19 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		return "not set", false
 	})
 
+	warn("Claude Code CLI", func() (string, bool) {
+		path, err := exec.LookPath("claude")
+		if err != nil {
+			return "not found in PATH (install from https://docs.claude.com/en/docs/claude-code to use model=claude-code)", false
+		}
+		out, _ := exec.Command(path, "--version").Output()
+		v := trimOutput(out)
+		if v == "" {
+			v = "detected"
+		}
+		return fmt.Sprintf("%s (%s)", v, path), true
+	})
+
 	warn("Brave Search key", func() (string, bool) {
 		if key := os.Getenv("BRAVE_SEARCH_API_KEY"); key != "" {
 			return "set via BRAVE_SEARCH_API_KEY", true

--- a/internal/cli/tui_spawn.go
+++ b/internal/cli/tui_spawn.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/m0n0x41d/haft/internal/envutil"
 )
 
 // spawnTUI finds the TUI entry point and launches it with bun or node.
@@ -120,25 +122,9 @@ func homeDir() string {
 }
 
 func tuiProcessEnv(base []string, term string) []string {
-	filtered := make([]string, 0, len(base)+3)
-
-	for _, entry := range base {
-		if strings.HasPrefix(entry, "DEV=") {
-			continue
-		}
-		if strings.HasPrefix(entry, "FORCE_COLOR=") {
-			continue
-		}
-		if strings.HasPrefix(entry, "TERM=") {
-			continue
-		}
-
-		filtered = append(filtered, entry)
-	}
-
-	filtered = append(filtered, "DEV=false")
-	filtered = append(filtered, "FORCE_COLOR=1")
-	filtered = append(filtered, "TERM="+term)
-
-	return filtered
+	return append(envutil.Strip(base, "DEV", "FORCE_COLOR", "TERM"),
+		"DEV=false",
+		"FORCE_COLOR=1",
+		"TERM="+term,
+	)
 }

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -2,25 +2,17 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+
+	"github.com/m0n0x41d/haft/internal/project"
 )
 
 // findProjectRoot walks up from cwd until it finds a .haft/ directory.
+// Thin wrapper around project.FindRootFromCwd that preserves the error-
+// returning shape the existing cli callers expect.
 func findProjectRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
+	root, ok := project.FindRootFromCwd()
+	if !ok {
+		return "", fmt.Errorf("no .haft/ found")
 	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, ".haft")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("no .haft/ found")
-		}
-		dir = parent
-	}
+	return root, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,21 +98,26 @@ func (c *Config) ConfiguredProviders() []string {
 
 // ProviderForModel guesses which provider a model belongs to based on ID prefix.
 // Returns empty string if unknown.
+//
+// Prefixes are checked in order so longer ones (e.g. "claude-code") win over
+// shorter ones ("claude-") that would otherwise shadow them.
 func ProviderForModel(modelID string) string {
-	prefixes := map[string]string{
-		"gpt-":      "openai",
-		"o1":        "openai",
-		"o3":        "openai",
-		"o4":        "openai",
-		"claude-":   "anthropic",
-		"gemini-":   "google",
-		"deepseek-": "deepseek",
-		"llama-":    "groq",
-		"mistral":   "mistral",
+	type entry struct{ prefix, provider string }
+	prefixes := []entry{
+		{"claude-code", "claudecode"},
+		{"claude-", "anthropic"},
+		{"gpt-", "openai"},
+		{"o1", "openai"},
+		{"o3", "openai"},
+		{"o4", "openai"},
+		{"gemini-", "google"},
+		{"deepseek-", "deepseek"},
+		{"llama-", "groq"},
+		{"mistral", "mistral"},
 	}
-	for prefix, provider := range prefixes {
-		if len(modelID) >= len(prefix) && modelID[:len(prefix)] == prefix {
-			return provider
+	for _, e := range prefixes {
+		if len(modelID) >= len(e.prefix) && modelID[:len(e.prefix)] == e.prefix {
+			return e.provider
 		}
 	}
 	return ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,10 +56,17 @@ type ProviderAuth struct {
 // L1: Pure functions
 // ---------------------------------------------------------------------------
 
-// IsConfigured returns true if at least one provider has credentials and a default model is set.
+// IsConfigured returns true if the selected model can run.
+//
+// For the claudecode provider, auth is owned by the `claude` CLI, so no
+// credentials live in haft's config — selecting a claude-code* model is
+// sufficient. For every other provider, at least one auth entry is required.
 func (c *Config) IsConfigured() bool {
 	if c.Model == "" {
 		return false
+	}
+	if ProviderForModel(c.Model) == "claudecode" {
+		return true
 	}
 	for _, auth := range c.Providers {
 		if auth.APIKey != "" || auth.AccessToken != "" {

--- a/internal/config/isconfigured_test.go
+++ b/internal/config/isconfigured_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestIsConfiguredClaudeCodeNeedsNoCredentials(t *testing.T) {
+	cfg := &Config{Model: "claude-code"}
+	if !cfg.IsConfigured() {
+		t.Fatalf("claude-code model should be enough to be configured")
+	}
+}
+
+func TestIsConfiguredClaudeCodeSubModel(t *testing.T) {
+	cfg := &Config{Model: "claude-code:sonnet"}
+	if !cfg.IsConfigured() {
+		t.Fatalf("claude-code:sonnet should be configured without creds")
+	}
+}
+
+func TestIsConfiguredAnthropicStillRequiresKey(t *testing.T) {
+	cfg := &Config{Model: "claude-opus-4-20250514"}
+	if cfg.IsConfigured() {
+		t.Fatalf("anthropic model without creds should NOT be configured")
+	}
+	cfg.SetAuth("anthropic", ProviderAuth{APIKey: "sk-test"})
+	if !cfg.IsConfigured() {
+		t.Fatalf("anthropic with api key should be configured")
+	}
+}
+
+func TestIsConfiguredEmptyModelStillFails(t *testing.T) {
+	cfg := &Config{}
+	if cfg.IsConfigured() {
+		t.Fatalf("empty model should never be configured")
+	}
+}

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -1,0 +1,33 @@
+// Package envutil provides small helpers for manipulating environment
+// variable slices (the os.Environ() "KEY=VALUE" string form).
+//
+// Kept separate from internal/config and internal/project so packages that
+// only need env munging don't pull in config file or filesystem-walk code.
+package envutil
+
+import "strings"
+
+// Strip returns env with any entries whose key matches one of the given keys
+// removed. Match is on the "KEY=" prefix, so similarly-prefixed keys (e.g.
+// "PATH" vs "PATHEXT") are not confused. Order of remaining entries is
+// preserved.
+func Strip(env []string, keys ...string) []string {
+	if len(keys) == 0 {
+		return env
+	}
+	prefixes := make([]string, len(keys))
+	for i, k := range keys {
+		prefixes[i] = k + "="
+	}
+	out := make([]string, 0, len(env))
+outer:
+	for _, entry := range env {
+		for _, p := range prefixes {
+			if strings.HasPrefix(entry, p) {
+				continue outer
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
+}

--- a/internal/envutil/envutil_test.go
+++ b/internal/envutil/envutil_test.go
@@ -1,0 +1,51 @@
+package envutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripSingleKey(t *testing.T) {
+	env := []string{"PATH=/usr/bin", "ANTHROPIC_API_KEY=sk-x", "HOME=/root"}
+	got := Strip(env, "ANTHROPIC_API_KEY")
+	want := []string{"PATH=/usr/bin", "HOME=/root"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Strip = %v, want %v", got, want)
+	}
+}
+
+func TestStripMultipleKeys(t *testing.T) {
+	env := []string{"DEV=true", "FORCE_COLOR=1", "TERM=xterm", "HOME=/u"}
+	got := Strip(env, "DEV", "FORCE_COLOR", "TERM")
+	want := []string{"HOME=/u"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Strip = %v, want %v", got, want)
+	}
+}
+
+func TestStripDoesNotMatchSharedPrefix(t *testing.T) {
+	env := []string{"PATH=/bin", "PATHEXT=.EXE"}
+	got := Strip(env, "PATH")
+	want := []string{"PATHEXT=.EXE"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Strip matched prefix-related key: got %v", got)
+	}
+}
+
+func TestStripNoKeysReturnsInput(t *testing.T) {
+	env := []string{"A=1", "B=2"}
+	got := Strip(env)
+	// With no keys, same slice back (identity optimization is fine here).
+	if !reflect.DeepEqual(got, env) {
+		t.Fatalf("Strip() with no keys = %v, want input %v", got, env)
+	}
+}
+
+func TestStripKeepsOrder(t *testing.T) {
+	env := []string{"A=1", "B=2", "C=3", "D=4"}
+	got := Strip(env, "B", "D")
+	want := []string{"A=1", "C=3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order lost: got %v want %v", got, want)
+	}
+}

--- a/internal/project/findroot_test.go
+++ b/internal/project/findroot_test.go
@@ -1,0 +1,73 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindRootWalksUpward(t *testing.T) {
+	tmp := t.TempDir()
+	nested := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(tmp, HaftDirName), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", HaftDirName, err)
+	}
+
+	got, ok := FindRoot(nested)
+	if !ok {
+		t.Fatalf("FindRoot = (_, false), want project found")
+	}
+	// On macOS /tmp is a symlink to /private/tmp — normalize both sides.
+	wantResolved, _ := filepath.EvalSymlinks(tmp)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Fatalf("FindRoot = %q, want %q", gotResolved, wantResolved)
+	}
+}
+
+func TestFindRootNoMatchReturnsFalse(t *testing.T) {
+	tmp := t.TempDir()
+	if _, ok := FindRoot(tmp); ok {
+		t.Fatalf("expected not found in bare tmp dir")
+	}
+}
+
+func TestFindRootIgnoresHaftFileNotDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	// A regular file named ".haft" must not satisfy the marker check.
+	if err := os.WriteFile(filepath.Join(tmp, HaftDirName), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := FindRoot(tmp); ok {
+		t.Fatalf("FindRoot matched a regular file named .haft")
+	}
+}
+
+func TestFindRootFromCwd(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmp, HaftDirName), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", HaftDirName, err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	got, ok := FindRootFromCwd()
+	if !ok {
+		t.Fatalf("FindRootFromCwd = (_, false)")
+	}
+	wantResolved, _ := filepath.EvalSymlinks(tmp)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Fatalf("FindRootFromCwd = %q, want %q", gotResolved, wantResolved)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -16,7 +16,39 @@ type Config struct {
 	Name string `yaml:"name"` // human-readable, from directory name
 }
 
-const configFile = "project.yaml"
+const (
+	configFile = "project.yaml"
+	// HaftDirName is the marker directory that identifies a haft project root.
+	HaftDirName = ".haft"
+)
+
+// FindRoot walks up from startDir until it finds a HaftDirName directory.
+// Returns ("", false) if none is found before hitting the filesystem root.
+// Pure function modulo the filesystem probe — safe to call from anywhere.
+func FindRoot(startDir string) (string, bool) {
+	dir := startDir
+	for {
+		if info, err := os.Stat(filepath.Join(dir, HaftDirName)); err == nil && info.IsDir() {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// FindRootFromCwd is a convenience wrapper around FindRoot that uses the
+// process cwd as the starting point. Returns ("", false) on any os.Getwd
+// error.
+func FindRootFromCwd() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	return FindRoot(cwd)
+}
 
 // Load reads project config from .haft/project.yaml.
 // Returns nil if file doesn't exist (pre-migration project).

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -129,7 +129,11 @@ func (p *ClaudeCodeProvider) Stream(
 		args = append(args, "--model", p.subModel)
 	}
 	if system != "" {
-		args = append(args, "--append-system-prompt", system)
+		// Replace, don't append. Claude Code's default system prompt is ~30K
+		// tokens and would drown haft's FPF protocol instructions. Haft
+		// owns the prompt for this provider; if it wants CLI tool usage
+		// described, it can include that itself.
+		args = append(args, "--system-prompt", system)
 	}
 
 	cmd := exec.CommandContext(ctx, p.cliPath, args...)

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -102,6 +103,12 @@ func (p *ClaudeCodeProvider) Stream(
 
 	cmd := exec.CommandContext(ctx, p.cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
+	// Strip ANTHROPIC_API_KEY from the child env so Claude Code falls back to
+	// its OAuth credentials. Max/Pro subscribers who happen to have an API
+	// key exported would otherwise be silently billed per-token instead of
+	// drawing from their subscription. See
+	// https://github.com/anthropics/claude-code/issues/43333 (fixed Apr 2026).
+	cmd.Env = envWithout(os.Environ(), "ANTHROPIC_API_KEY")
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -207,6 +214,21 @@ func renderParts(parts []agent.Part) string {
 		}
 	}
 	return b.String()
+}
+
+// envWithout returns env with any entries matching key=... removed. The
+// match is case-sensitive and anchored at "=" so keys that merely share
+// a prefix are left untouched.
+func envWithout(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 // streamEvent captures the fields we care about from stream-json NDJSON.

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -5,17 +5,26 @@
 // without a separate ANTHROPIC_API_KEY. Auth is delegated entirely to the
 // CLI (OAuth, keychain, API key — whichever Claude Code is configured with).
 //
-// MVP scope (this file):
+// Scope:
 //   - Flattens haft's structured message history into a single prompt.
 //   - Streams assistant text via `claude -p --output-format stream-json`.
-//   - Does NOT translate haft's tool schemas into CLI tools. The agent loop
-//     will get text responses only; haft's artifact tools (haft_note, etc.)
-//     are not invokable by the model through this provider yet.
+//   - Wires haft's own MCP server (`haft serve`) into the CLI via
+//     `--mcp-config` so the model can call `haft_note`, `haft_problem`,
+//     `haft_decision`, `haft_query`, etc. Tool execution happens entirely
+//     inside the CLI subprocess — haft's outer agent loop receives the final
+//     assistant text after all tool round-trips have completed.
 //
-// Future work (explicitly out of scope for the first cut):
-//   - Expose haft's tools via --mcp-config so the CLI can call them.
-//   - Parse tool_use / tool_result events from stream-json.
-//   - Session reuse via --resume for multi-turn efficiency.
+// Caveats:
+//   - The CLI's built-in tools (Read/Write/Bash/etc.) are allowed by default
+//     under `bypassPermissions`. Haft's own per-tool hooks and permission
+//     model do not run for this provider. If that matters, use the
+//     `anthropic` or `openai` providers whose tools go through haft's loop.
+//   - Set `HAFT_CLAUDECODE_NO_MCP=1` to disable the MCP bridge and run the
+//     CLI in text-only mode (no tool-use at all).
+//
+// Future work:
+//   - Session reuse via --resume to amortize per-turn spawn cost.
+//   - Propagate CLI token-accounting into `Message.Tokens`.
 package provider
 
 import (
@@ -27,6 +36,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -90,10 +100,31 @@ func (p *ClaudeCodeProvider) Stream(
 		"-p",
 		"--output-format", "stream-json",
 		"--verbose",                // required by CLI when using stream-json
-		"--allowed-tools", "",      // disable built-in tools; agent surface is haft's, not CLI's
 		"--no-session-persistence", // ephemeral turn
 		"--input-format", "text",
 	}
+
+	// Wire haft's MCP server into the CLI so the model can call haft_*
+	// artifact tools. Opt out with HAFT_CLAUDECODE_NO_MCP=1 for text-only.
+	var cleanup func()
+	if os.Getenv("HAFT_CLAUDECODE_NO_MCP") == "" {
+		cfgPath, projectRoot, err := writeHaftMCPConfig()
+		if err == nil && cfgPath != "" {
+			defer func() { _ = os.Remove(cfgPath) }()
+			args = append(args,
+				"--mcp-config", cfgPath,
+				"--permission-mode", "bypassPermissions",
+				"--add-dir", projectRoot,
+			)
+			cleanup = func() { _ = os.Remove(cfgPath) }
+		}
+	}
+	if cleanup == nil {
+		// Text-only fallback: disable built-ins so the model can't
+		// write files when haft's own surface isn't bridged in.
+		args = append(args, "--allowed-tools", "")
+	}
+
 	if p.subModel != "" {
 		args = append(args, "--model", p.subModel)
 	}
@@ -214,6 +245,77 @@ func renderParts(parts []agent.Part) string {
 		}
 	}
 	return b.String()
+}
+
+// writeHaftMCPConfig generates a tmpfile containing an --mcp-config payload
+// that exposes haft's own MCP server (via `haft serve`) to the `claude` CLI
+// subprocess. Returns the tmpfile path, the resolved project root, and any
+// error. If no haft project root is discoverable from cwd, returns
+// ("", "", nil) — the caller falls back to text-only mode.
+func writeHaftMCPConfig() (string, string, error) {
+	projectRoot, ok := findHaftProjectRoot()
+	if !ok {
+		return "", "", nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", "", fmt.Errorf("locate haft binary: %w", err)
+	}
+
+	type mcpEntry struct {
+		Command string            `json:"command"`
+		Args    []string          `json:"args"`
+		Env     map[string]string `json:"env,omitempty"`
+	}
+	type mcpConfig struct {
+		McpServers map[string]mcpEntry `json:"mcpServers"`
+	}
+	cfg := mcpConfig{McpServers: map[string]mcpEntry{
+		"haft": {
+			Command: exe,
+			Args:    []string{"serve"},
+			Env:     map[string]string{"QUINT_PROJECT_ROOT": projectRoot},
+		},
+	}}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return "", "", err
+	}
+
+	f, err := os.CreateTemp("", "haft-mcp-*.json")
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", "", err
+	}
+	return f.Name(), projectRoot, nil
+}
+
+// findHaftProjectRoot walks up from cwd looking for a .haft directory.
+// Returns "" + false if none is found before hitting the filesystem root.
+func findHaftProjectRoot() (string, bool) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".haft")); err == nil && info.IsDir() {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
 }
 
 // envWithout returns env with any entries matching key=... removed. The

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -29,7 +29,6 @@ package provider
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,7 +105,7 @@ func (p *ClaudeCodeProvider) Stream(
 
 	// Wire haft's MCP server into the CLI so the model can call haft_*
 	// artifact tools. Opt out with HAFT_CLAUDECODE_NO_MCP=1 for text-only.
-	var cleanup func()
+	mcpBridged := false
 	if os.Getenv("HAFT_CLAUDECODE_NO_MCP") == "" {
 		cfgPath, projectRoot, err := writeHaftMCPConfig()
 		if err == nil && cfgPath != "" {
@@ -114,12 +113,14 @@ func (p *ClaudeCodeProvider) Stream(
 			args = append(args,
 				"--mcp-config", cfgPath,
 				"--permission-mode", "bypassPermissions",
-				"--add-dir", projectRoot,
+				// Use equals form so a project root starting with "-"
+				// can't be interpreted as a CLI flag.
+				"--add-dir="+projectRoot,
 			)
-			cleanup = func() { _ = os.Remove(cfgPath) }
+			mcpBridged = true
 		}
 	}
-	if cleanup == nil {
+	if !mcpBridged {
 		// Text-only fallback: disable built-ins so the model can't
 		// write files when haft's own surface isn't bridged in.
 		args = append(args, "--allowed-tools", "")
@@ -145,12 +146,15 @@ func (p *ClaudeCodeProvider) Stream(
 	// https://github.com/anthropics/claude-code/issues/43333 (fixed Apr 2026).
 	cmd.Env = envWithout(os.Environ(), "ANTHROPIC_API_KEY")
 
+	// Cap stderr at 64KB so a chatty --verbose session can't blow up the
+	// parent's memory. We only need the tail to surface in error messages.
+	stderrBuf := &cappedBuffer{limit: 64 * 1024}
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("claudecode: stdout pipe: %w", err)
 	}
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("claudecode: start %s: %w", p.cliPath, err)
@@ -164,6 +168,13 @@ func (p *ClaudeCodeProvider) Stream(
 	}
 	if waitErr != nil {
 		stderrTxt := strings.TrimSpace(stderrBuf.String())
+		// Cap the stderr text we fold into the error message so a chatty
+		// CLI session (e.g. --verbose + many tool rounds) can't blow up
+		// the parent's log buffers.
+		const maxStderrInError = 8 * 1024
+		if len(stderrTxt) > maxStderrInError {
+			stderrTxt = stderrTxt[:maxStderrInError] + "…(truncated)"
+		}
 		if stderrTxt != "" {
 			return nil, fmt.Errorf("claudecode: cli exited: %w: %s", waitErr, stderrTxt)
 		}
@@ -291,6 +302,15 @@ func writeHaftMCPConfig() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	// Defense-in-depth: CreateTemp uses 0600 on Unix with a normal umask,
+	// but a permissive umask (0000) would leave the file world-readable.
+	// The tmpfile embeds the haft binary path and project root, so lock
+	// it down explicitly.
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", "", err
+	}
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name())
@@ -321,6 +341,30 @@ func findHaftProjectRoot() (string, bool) {
 		dir = parent
 	}
 }
+
+// cappedBuffer is an io.Writer that retains at most `limit` bytes. Excess
+// bytes are silently dropped. Used for subprocess stderr so a chatty child
+// can't pressure the parent's memory, while still letting us surface the
+// initial error text in a non-zero-exit report.
+type cappedBuffer struct {
+	limit int
+	buf   []byte
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	remaining := c.limit - len(c.buf)
+	if remaining <= 0 {
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		c.buf = append(c.buf, p[:remaining]...)
+	} else {
+		c.buf = append(c.buf, p...)
+	}
+	return len(p), nil
+}
+
+func (c *cappedBuffer) String() string { return string(c.buf) }
 
 // envWithout returns env with any entries matching key=... removed. The
 // match is case-sensitive and anchored at "=" so keys that merely share

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -47,13 +47,14 @@ const claudeCodeBinary = "claude"
 // ClaudeCodeProvider invokes the `claude` CLI per turn.
 //
 // Paths that don't change during the process lifetime (haft binary, detected
-// project root) are resolved once at construction and cached so every turn
-// doesn't re-walk the filesystem.
+// project root, filtered child env) are resolved once at construction and
+// cached so every turn doesn't re-walk the filesystem or re-copy the env.
 type ClaudeCodeProvider struct {
-	modelID     string // haft-facing model id (reported to the agent loop)
-	cliPath     string // resolved `claude` binary
-	haftExe     string // resolved current `haft` binary (for --mcp-config)
-	projectRoot string // detected .haft/ root; "" when not in a haft project
+	modelID     string   // haft-facing model id (reported to the agent loop)
+	cliPath     string   // resolved `claude` binary
+	haftExe     string   // resolved current `haft` binary (for --mcp-config)
+	projectRoot string   // detected .haft/ root; "" when not in a haft project
+	childEnv    []string // cached env with ANTHROPIC_API_KEY stripped
 }
 
 var _ LLMProvider = (*ClaudeCodeProvider)(nil)
@@ -83,6 +84,12 @@ func NewClaudeCode(modelID string) (*ClaudeCodeProvider, error) {
 		cliPath:     path,
 		haftExe:     haftExe,
 		projectRoot: projectRoot,
+		// Snapshot the env at construction. ANTHROPIC_API_KEY is the only
+		// var we actively mask; users rarely toggle it mid-session, and the
+		// subprocess we spawn is short-lived per turn, so a static snapshot
+		// is fine. Any env var *added* after construction will be missed —
+		// callers needing fresh env should rebuild the provider.
+		childEnv: envWithout(os.Environ(), "ANTHROPIC_API_KEY"),
 	}, nil
 }
 
@@ -156,12 +163,12 @@ func (p *ClaudeCodeProvider) Stream(
 
 	cmd := exec.CommandContext(ctx, p.cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
-	// Strip ANTHROPIC_API_KEY from the child env so Claude Code falls back to
+	// Child env has ANTHROPIC_API_KEY stripped so Claude Code falls back to
 	// its OAuth credentials. Max/Pro subscribers who happen to have an API
 	// key exported would otherwise be silently billed per-token instead of
 	// drawing from their subscription. See
 	// https://github.com/anthropics/claude-code/issues/43333 (fixed Apr 2026).
-	cmd.Env = envWithout(os.Environ(), "ANTHROPIC_API_KEY")
+	cmd.Env = p.childEnv
 
 	// Cap stderr at 64KB so a chatty --verbose session can't blow up the
 	// parent's memory. We only need the tail to surface in error messages.
@@ -402,6 +409,10 @@ type streamEvent struct {
 // any scanner error. Unknown event types are ignored (forward-compat).
 func parseClaudeStream(r io.Reader, handler func(StreamDelta)) (string, string, error) {
 	var buf strings.Builder
+	// 16KB covers the typical single-turn text response (few-KB messages plus
+	// thinking). Avoids ~4 rounds of grow-and-copy doubling for common cases;
+	// grows naturally for longer outputs.
+	buf.Grow(16 * 1024)
 	var finishReason string
 
 	scanner := bufio.NewScanner(r)

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -410,7 +410,7 @@ func writeHaftMCPConfig(haftExe, projectRoot string) (string, error) {
 		"haft": {
 			Command: haftExe,
 			Args:    []string{"serve"},
-			Env:     map[string]string{"QUINT_PROJECT_ROOT": projectRoot},
+			Env:     map[string]string{"HAFT_PROJECT_ROOT": projectRoot},
 		},
 	}}
 

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -45,10 +45,15 @@ import (
 const claudeCodeBinary = "claude"
 
 // ClaudeCodeProvider invokes the `claude` CLI per turn.
+//
+// Paths that don't change during the process lifetime (haft binary, detected
+// project root) are resolved once at construction and cached so every turn
+// doesn't re-walk the filesystem.
 type ClaudeCodeProvider struct {
-	modelID string // haft model id (reported to agent loop)
-	subModel string // optional --model override passed to the CLI
-	cliPath  string
+	modelID     string // haft-facing model id (reported to the agent loop)
+	cliPath     string // resolved `claude` binary
+	haftExe     string // resolved current `haft` binary (for --mcp-config)
+	projectRoot string // detected .haft/ root; "" when not in a haft project
 }
 
 var _ LLMProvider = (*ClaudeCodeProvider)(nil)
@@ -67,20 +72,32 @@ func NewClaudeCode(modelID string) (*ClaudeCodeProvider, error) {
 		)
 	}
 
-	sub := ""
-	if rest, ok := strings.CutPrefix(modelID, "claude-code:"); ok {
-		sub = rest
-	}
+	// os.Executable / project detection may fail (test binaries, no cwd, no
+	// .haft/). Failing here would make the provider unusable in text-only
+	// contexts, so we downgrade to "MCP bridge off" by leaving fields empty.
+	haftExe, _ := os.Executable()
+	projectRoot, _ := project.FindRootFromCwd()
 
 	return &ClaudeCodeProvider{
-		modelID:  modelID,
-		subModel: sub,
-		cliPath:  path,
+		modelID:     modelID,
+		cliPath:     path,
+		haftExe:     haftExe,
+		projectRoot: projectRoot,
 	}, nil
 }
 
 // ModelID returns the haft-facing model identifier.
 func (p *ClaudeCodeProvider) ModelID() string { return p.modelID }
+
+// cliSubModel returns the optional --model override forwarded to the CLI.
+// Derived from modelID, not stored — one source of truth.
+func (p *ClaudeCodeProvider) cliSubModel() string {
+	rest, ok := strings.CutPrefix(p.modelID, "claude-code:")
+	if !ok {
+		return ""
+	}
+	return rest
+}
 
 // Stream sends the conversation to the CLI and emits text deltas.
 //
@@ -106,8 +123,8 @@ func (p *ClaudeCodeProvider) Stream(
 	// Wire haft's MCP server into the CLI so the model can call haft_*
 	// artifact tools. Opt out with HAFT_CLAUDECODE_NO_MCP=1 for text-only.
 	mcpBridged := false
-	if os.Getenv("HAFT_CLAUDECODE_NO_MCP") == "" {
-		cfgPath, projectRoot, err := writeHaftMCPConfig()
+	if p.canBridgeMCP() {
+		cfgPath, err := writeHaftMCPConfig(p.haftExe, p.projectRoot)
 		if err == nil && cfgPath != "" {
 			defer func() { _ = os.Remove(cfgPath) }()
 			args = append(args,
@@ -115,7 +132,7 @@ func (p *ClaudeCodeProvider) Stream(
 				"--permission-mode", "bypassPermissions",
 				// Use equals form so a project root starting with "-"
 				// can't be interpreted as a CLI flag.
-				"--add-dir="+projectRoot,
+				"--add-dir="+p.projectRoot,
 			)
 			mcpBridged = true
 		}
@@ -126,8 +143,8 @@ func (p *ClaudeCodeProvider) Stream(
 		args = append(args, "--allowed-tools", "")
 	}
 
-	if p.subModel != "" {
-		args = append(args, "--model", p.subModel)
+	if sub := p.cliSubModel(); sub != "" {
+		args = append(args, "--model", sub)
 	}
 	if system != "" {
 		// Replace, don't append. Claude Code's default system prompt is ~30K
@@ -167,15 +184,8 @@ func (p *ClaudeCodeProvider) Stream(
 		return nil, fmt.Errorf("claudecode: parse stream: %w", parseErr)
 	}
 	if waitErr != nil {
-		stderrTxt := strings.TrimSpace(stderrBuf.String())
-		// Cap the stderr text we fold into the error message so a chatty
-		// CLI session (e.g. --verbose + many tool rounds) can't blow up
-		// the parent's log buffers.
-		const maxStderrInError = 8 * 1024
-		if len(stderrTxt) > maxStderrInError {
-			stderrTxt = stderrTxt[:maxStderrInError] + "…(truncated)"
-		}
-		if stderrTxt != "" {
+		// stderrBuf already caps at 64KB with a tail-preserving ring.
+		if stderrTxt := strings.TrimSpace(stderrBuf.String()); stderrTxt != "" {
 			return nil, fmt.Errorf("claudecode: cli exited: %w: %s", waitErr, stderrTxt)
 		}
 		return nil, fmt.Errorf("claudecode: cli exited: %w", waitErr)
@@ -262,21 +272,21 @@ func renderParts(parts []agent.Part) string {
 	return b.String()
 }
 
+// canBridgeMCP reports whether the environment and provider state support
+// routing haft's MCP server into the CLI. Off when opted out explicitly,
+// when no haft binary was resolvable at construction, or when the provider
+// wasn't constructed inside a haft project.
+func (p *ClaudeCodeProvider) canBridgeMCP() bool {
+	if os.Getenv("HAFT_CLAUDECODE_NO_MCP") != "" {
+		return false
+	}
+	return p.haftExe != "" && p.projectRoot != ""
+}
+
 // writeHaftMCPConfig generates a tmpfile containing an --mcp-config payload
 // that exposes haft's own MCP server (via `haft serve`) to the `claude` CLI
-// subprocess. Returns the tmpfile path, the resolved project root, and any
-// error. If no haft project root is discoverable from cwd, returns
-// ("", "", nil) — the caller falls back to text-only mode.
-func writeHaftMCPConfig() (string, string, error) {
-	projectRoot, ok := project.FindRootFromCwd()
-	if !ok {
-		return "", "", nil
-	}
-	exe, err := os.Executable()
-	if err != nil {
-		return "", "", fmt.Errorf("locate haft binary: %w", err)
-	}
-
+// subprocess. The caller is responsible for removing the returned path.
+func writeHaftMCPConfig(haftExe, projectRoot string) (string, error) {
 	type mcpEntry struct {
 		Command string            `json:"command"`
 		Args    []string          `json:"args"`
@@ -287,7 +297,7 @@ func writeHaftMCPConfig() (string, string, error) {
 	}
 	cfg := mcpConfig{McpServers: map[string]mcpEntry{
 		"haft": {
-			Command: exe,
+			Command: haftExe,
 			Args:    []string{"serve"},
 			Env:     map[string]string{"QUINT_PROJECT_ROOT": projectRoot},
 		},
@@ -295,12 +305,12 @@ func writeHaftMCPConfig() (string, string, error) {
 
 	data, err := json.Marshal(cfg)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	f, err := os.CreateTemp("", "haft-mcp-*.json")
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	// Defense-in-depth: CreateTemp uses 0600 on Unix with a normal umask,
 	// but a permissive umask (0000) would leave the file world-readable.
@@ -309,43 +319,53 @@ func writeHaftMCPConfig() (string, string, error) {
 	if err := f.Chmod(0o600); err != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name())
-		return "", "", err
+		return "", err
 	}
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name())
-		return "", "", err
+		return "", err
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(f.Name())
-		return "", "", err
+		return "", err
 	}
-	return f.Name(), projectRoot, nil
+	return f.Name(), nil
 }
 
-// cappedBuffer is an io.Writer that retains at most `limit` bytes. Excess
-// bytes are silently dropped. Used for subprocess stderr so a chatty child
-// can't pressure the parent's memory, while still letting us surface the
-// initial error text in a non-zero-exit report.
+// cappedBuffer is an io.Writer that retains the *last* `limit` bytes written.
+// Used for subprocess stderr so a chatty child can't pressure the parent's
+// memory. Keeping the tail (not the head) matters because real failures
+// almost always print near the end of a run — startup chatter is the
+// discardable prefix, the error message is the useful suffix.
 type cappedBuffer struct {
-	limit int
-	buf   []byte
+	limit     int
+	buf       []byte
+	truncated bool
 }
 
 func (c *cappedBuffer) Write(p []byte) (int, error) {
-	remaining := c.limit - len(c.buf)
-	if remaining <= 0 {
-		return len(p), nil
+	n := len(p)
+	if n >= c.limit {
+		c.buf = append(c.buf[:0], p[n-c.limit:]...)
+		c.truncated = true
+		return n, nil
 	}
-	if len(p) > remaining {
-		c.buf = append(c.buf, p[:remaining]...)
-	} else {
-		c.buf = append(c.buf, p...)
+	if len(c.buf)+n > c.limit {
+		drop := len(c.buf) + n - c.limit
+		c.buf = c.buf[drop:]
+		c.truncated = true
 	}
-	return len(p), nil
+	c.buf = append(c.buf, p...)
+	return n, nil
 }
 
-func (c *cappedBuffer) String() string { return string(c.buf) }
+func (c *cappedBuffer) String() string {
+	if c.truncated {
+		return "…(truncated)" + string(c.buf)
+	}
+	return string(c.buf)
+}
 
 // envWithout returns env with any entries matching key=... removed. The
 // match is case-sensitive and anchored at "=" so keys that merely share

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -1,0 +1,274 @@
+// Package provider — Claude Code CLI integration.
+//
+// This provider wraps the `claude` CLI (Claude Code) as a subprocess so users
+// with a Claude Pro/Max subscription can drive haft's interactive agent
+// without a separate ANTHROPIC_API_KEY. Auth is delegated entirely to the
+// CLI (OAuth, keychain, API key — whichever Claude Code is configured with).
+//
+// MVP scope (this file):
+//   - Flattens haft's structured message history into a single prompt.
+//   - Streams assistant text via `claude -p --output-format stream-json`.
+//   - Does NOT translate haft's tool schemas into CLI tools. The agent loop
+//     will get text responses only; haft's artifact tools (haft_note, etc.)
+//     are not invokable by the model through this provider yet.
+//
+// Future work (explicitly out of scope for the first cut):
+//   - Expose haft's tools via --mcp-config so the CLI can call them.
+//   - Parse tool_use / tool_result events from stream-json.
+//   - Session reuse via --resume for multi-turn efficiency.
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/m0n0x41d/haft/internal/agent"
+)
+
+const claudeCodeBinary = "claude"
+
+// ClaudeCodeProvider invokes the `claude` CLI per turn.
+type ClaudeCodeProvider struct {
+	modelID string // haft model id (reported to agent loop)
+	subModel string // optional --model override passed to the CLI
+	cliPath  string
+}
+
+var _ LLMProvider = (*ClaudeCodeProvider)(nil)
+
+// NewClaudeCode returns a provider that shells out to `claude`.
+//
+// modelID is the haft-facing model identifier. A suffix after "claude-code:"
+// is forwarded to the CLI as --model (e.g. "claude-code:sonnet" → --model sonnet).
+// The bare "claude-code" uses whatever model the CLI picks by default.
+func NewClaudeCode(modelID string) (*ClaudeCodeProvider, error) {
+	path, err := exec.LookPath(claudeCodeBinary)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"claude CLI not found in PATH: install Claude Code (https://docs.claude.com/en/docs/claude-code) " +
+				"and sign in, or pick a different model",
+		)
+	}
+
+	sub := ""
+	if rest, ok := strings.CutPrefix(modelID, "claude-code:"); ok {
+		sub = rest
+	}
+
+	return &ClaudeCodeProvider{
+		modelID:  modelID,
+		subModel: sub,
+		cliPath:  path,
+	}, nil
+}
+
+// ModelID returns the haft-facing model identifier.
+func (p *ClaudeCodeProvider) ModelID() string { return p.modelID }
+
+// Stream sends the conversation to the CLI and emits text deltas.
+//
+// Tool schemas are currently ignored (see package docs). If the caller
+// passes tools, the provider still succeeds but the model has no way
+// to invoke them — it will respond with text only.
+func (p *ClaudeCodeProvider) Stream(
+	ctx context.Context,
+	messages []agent.Message,
+	_ []agent.ToolSchema,
+	handler func(StreamDelta),
+) (*agent.Message, error) {
+	system, prompt := flattenConversation(messages)
+
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--verbose",                // required by CLI when using stream-json
+		"--allowed-tools", "",      // disable built-in tools; agent surface is haft's, not CLI's
+		"--no-session-persistence", // ephemeral turn
+		"--input-format", "text",
+	}
+	if p.subModel != "" {
+		args = append(args, "--model", p.subModel)
+	}
+	if system != "" {
+		args = append(args, "--append-system-prompt", system)
+	}
+
+	cmd := exec.CommandContext(ctx, p.cliPath, args...)
+	cmd.Stdin = strings.NewReader(prompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("claudecode: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("claudecode: start %s: %w", p.cliPath, err)
+	}
+
+	text, finishReason, parseErr := parseClaudeStream(stdout, handler)
+	waitErr := cmd.Wait()
+
+	if parseErr != nil {
+		return nil, fmt.Errorf("claudecode: parse stream: %w", parseErr)
+	}
+	if waitErr != nil {
+		stderrTxt := strings.TrimSpace(stderrBuf.String())
+		if stderrTxt != "" {
+			return nil, fmt.Errorf("claudecode: cli exited: %w: %s", waitErr, stderrTxt)
+		}
+		return nil, fmt.Errorf("claudecode: cli exited: %w", waitErr)
+	}
+
+	if finishReason == "" {
+		finishReason = "stop"
+	}
+	handler(StreamDelta{Done: true, FinishReason: finishReason})
+
+	msg := &agent.Message{
+		Role:      agent.RoleAssistant,
+		Model:     p.modelID,
+		CreatedAt: time.Now().UTC(),
+	}
+	if text != "" {
+		msg.Parts = append(msg.Parts, agent.TextPart{Text: text})
+	}
+	return msg, nil
+}
+
+// flattenConversation compresses haft's structured messages into the single
+// system + user prompt pair the CLI expects.
+//
+//   - All RoleSystem messages are joined as the system prompt.
+//   - User / assistant / tool turns are rendered as labeled blocks so the
+//     model sees the full transcript, including prior tool calls that this
+//     provider can't reproduce natively.
+func flattenConversation(messages []agent.Message) (string, string) {
+	var sys strings.Builder
+	var body strings.Builder
+
+	writeBlock := func(label, content string) {
+		content = strings.TrimSpace(content)
+		if content == "" {
+			return
+		}
+		if body.Len() > 0 {
+			body.WriteString("\n\n")
+		}
+		body.WriteString(label)
+		body.WriteString(": ")
+		body.WriteString(content)
+	}
+
+	for _, m := range messages {
+		switch m.Role {
+		case agent.RoleSystem:
+			if s := strings.TrimSpace(m.Text()); s != "" {
+				if sys.Len() > 0 {
+					sys.WriteString("\n\n")
+				}
+				sys.WriteString(s)
+			}
+		case agent.RoleUser:
+			writeBlock("User", renderParts(m.Parts))
+		case agent.RoleAssistant:
+			writeBlock("Assistant", renderParts(m.Parts))
+		case agent.RoleTool:
+			writeBlock("Tool", renderParts(m.Parts))
+		}
+	}
+	return sys.String(), body.String()
+}
+
+func renderParts(parts []agent.Part) string {
+	var b strings.Builder
+	for _, p := range parts {
+		switch v := p.(type) {
+		case agent.TextPart:
+			b.WriteString(v.Text)
+		case agent.ToolCallPart:
+			fmt.Fprintf(&b, "\n[tool_call name=%s id=%s]\n%s\n[/tool_call]\n",
+				v.ToolName, v.ToolCallID, v.Arguments)
+		case agent.ToolResultPart:
+			prefix := "tool_result"
+			if v.IsError {
+				prefix = "tool_result_error"
+			}
+			fmt.Fprintf(&b, "\n[%s id=%s]\n%s\n[/%s]\n",
+				prefix, v.ToolCallID, v.Content, prefix)
+		}
+	}
+	return b.String()
+}
+
+// streamEvent captures the fields we care about from stream-json NDJSON.
+// See: https://docs.claude.com/en/docs/claude-code/sdk
+type streamEvent struct {
+	Type    string `json:"type"`
+	Subtype string `json:"subtype,omitempty"`
+	Message *struct {
+		Role    string `json:"role"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text,omitempty"`
+		} `json:"content"`
+	} `json:"message,omitempty"`
+	IsError bool `json:"is_error,omitempty"`
+}
+
+// parseClaudeStream reads NDJSON events from the CLI's stdout and forwards
+// text deltas to handler. Returns the concatenated text, finish reason, and
+// any scanner error. Unknown event types are ignored (forward-compat).
+func parseClaudeStream(r io.Reader, handler func(StreamDelta)) (string, string, error) {
+	var buf strings.Builder
+	var finishReason string
+
+	scanner := bufio.NewScanner(r)
+	// Allow large events — a single assistant block can exceed the 64KB default.
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			// Malformed event — skip rather than abort. The CLI occasionally
+			// interleaves debug lines when --verbose is on.
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			if ev.Message == nil {
+				continue
+			}
+			for _, block := range ev.Message.Content {
+				if block.Type == "text" && block.Text != "" {
+					buf.WriteString(block.Text)
+					handler(StreamDelta{Text: block.Text})
+				}
+			}
+		case "result":
+			// subtype is "success" or "error_*"; map to haft's finish reasons.
+			if ev.IsError || strings.HasPrefix(ev.Subtype, "error") {
+				finishReason = "error"
+			} else {
+				finishReason = "stop"
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return buf.String(), finishReason, err
+	}
+	return buf.String(), finishReason, nil
+}

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -35,11 +35,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/m0n0x41d/haft/internal/agent"
+	"github.com/m0n0x41d/haft/internal/project"
 )
 
 const claudeCodeBinary = "claude"
@@ -268,7 +268,7 @@ func renderParts(parts []agent.Part) string {
 // error. If no haft project root is discoverable from cwd, returns
 // ("", "", nil) — the caller falls back to text-only mode.
 func writeHaftMCPConfig() (string, string, error) {
-	projectRoot, ok := findHaftProjectRoot()
+	projectRoot, ok := project.FindRootFromCwd()
 	if !ok {
 		return "", "", nil
 	}
@@ -321,25 +321,6 @@ func writeHaftMCPConfig() (string, string, error) {
 		return "", "", err
 	}
 	return f.Name(), projectRoot, nil
-}
-
-// findHaftProjectRoot walks up from cwd looking for a .haft directory.
-// Returns "" + false if none is found before hitting the filesystem root.
-func findHaftProjectRoot() (string, bool) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", false
-	}
-	for {
-		if info, err := os.Stat(filepath.Join(dir, ".haft")); err == nil && info.IsDir() {
-			return dir, true
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", false
-		}
-		dir = parent
-	}
 }
 
 // cappedBuffer is an io.Writer that retains at most `limit` bytes. Excess

--- a/internal/provider/claudecode.go
+++ b/internal/provider/claudecode.go
@@ -36,9 +36,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/m0n0x41d/haft/internal/agent"
+	"github.com/m0n0x41d/haft/internal/envutil"
 	"github.com/m0n0x41d/haft/internal/project"
 )
 
@@ -49,12 +51,21 @@ const claudeCodeBinary = "claude"
 // Paths that don't change during the process lifetime (haft binary, detected
 // project root, filtered child env) are resolved once at construction and
 // cached so every turn doesn't re-walk the filesystem or re-copy the env.
+//
+// The provider keeps a `session_id` from the CLI and forwards `--resume` on
+// turn 2+ so subsequent turns skip the ~5–10s `claude` + `haft serve` cold
+// spawn. Opt out with HAFT_CLAUDECODE_NO_RESUME=1 (behaves like the pre-
+// session-reuse implementation — every turn is fresh).
 type ClaudeCodeProvider struct {
 	modelID     string   // haft-facing model id (reported to the agent loop)
 	cliPath     string   // resolved `claude` binary
 	haftExe     string   // resolved current `haft` binary (for --mcp-config)
 	projectRoot string   // detected .haft/ root; "" when not in a haft project
 	childEnv    []string // cached env with ANTHROPIC_API_KEY stripped
+
+	mu        sync.Mutex // protects the session fields below
+	sessionID string     // CLI-issued; "" means no warm session yet
+	msgsSent  int        // count of messages haft had sent us at end of last successful turn
 }
 
 var _ LLMProvider = (*ClaudeCodeProvider)(nil)
@@ -89,7 +100,7 @@ func NewClaudeCode(modelID string) (*ClaudeCodeProvider, error) {
 		// subprocess we spawn is short-lived per turn, so a static snapshot
 		// is fine. Any env var *added* after construction will be missed —
 		// callers needing fresh env should rebuild the provider.
-		childEnv: envWithout(os.Environ(), "ANTHROPIC_API_KEY"),
+		childEnv: envutil.Strip(os.Environ(), "ANTHROPIC_API_KEY"),
 	}, nil
 }
 
@@ -106,6 +117,83 @@ func (p *ClaudeCodeProvider) cliSubModel() string {
 	return rest
 }
 
+// takeResumeDecision locks the mutex, inspects the incoming message list, and
+// returns the resume decision for this turn. On a valid resumable turn, it
+// returns the session id and the single user-text payload to forward. On any
+// mismatch (gap, edited history, tool turn, session-reuse disabled) it falls
+// back to a fresh turn and clears whatever state was tracked.
+type turnPlan struct {
+	resume    bool
+	sessionID string   // forwarded as --resume when resume is true
+	prompt    string   // stdin body
+	system    string   // --system-prompt payload (fresh turns only)
+}
+
+func (p *ClaudeCodeProvider) takeResumeDecision(messages []agent.Message) turnPlan {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	disabled := os.Getenv("HAFT_CLAUDECODE_NO_RESUME") != ""
+	last := lastUserMessage(messages)
+
+	// Conditions for a clean continuation:
+	//   - resume not disabled
+	//   - we have a session from the previous turn
+	//   - haft grew the conversation by exactly one message since last turn
+	//   - that new tail message is a user turn (we only forward user text)
+	if !disabled &&
+		p.sessionID != "" &&
+		len(messages) == p.msgsSent+1 &&
+		last != nil && last.Role == agent.RoleUser &&
+		last == &messages[len(messages)-1] {
+		return turnPlan{
+			resume:    true,
+			sessionID: p.sessionID,
+			prompt:    strings.TrimSpace(last.Text()),
+		}
+	}
+
+	// Fresh turn: drop any stale state; rebuild the full transcript.
+	p.sessionID = ""
+	p.msgsSent = 0
+	sys, body := flattenConversation(messages)
+	return turnPlan{system: sys, prompt: body}
+}
+
+// recordTurnResult is called after a successful turn; persists whatever
+// session id the CLI handed back and moves the message counter forward.
+// `consumedMsgs` is the length of the `messages` slice that was fed into
+// Stream; +1 accounts for the assistant response the caller will append.
+func (p *ClaudeCodeProvider) recordTurnResult(newSessionID string, consumedMsgs int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if newSessionID != "" {
+		p.sessionID = newSessionID
+	}
+	p.msgsSent = consumedMsgs + 1
+}
+
+// invalidateSession wipes tracking so the next turn will start fresh.
+// Used on any error so a stale session id doesn't keep failing turn after turn.
+func (p *ClaudeCodeProvider) invalidateSession() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sessionID = ""
+	p.msgsSent = 0
+}
+
+// lastUserMessage returns a pointer to the final RoleUser message in the
+// slice, or nil if there is none. Returning a pointer lets the caller assert
+// identity with the tail, catching the "last entry is assistant/tool" case.
+func lastUserMessage(messages []agent.Message) *agent.Message {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == agent.RoleUser {
+			return &messages[i]
+		}
+	}
+	return nil
+}
+
 // Stream sends the conversation to the CLI and emits text deltas.
 //
 // Tool schemas are currently ignored (see package docs). If the caller
@@ -117,13 +205,16 @@ func (p *ClaudeCodeProvider) Stream(
 	_ []agent.ToolSchema,
 	handler func(StreamDelta),
 ) (*agent.Message, error) {
-	system, prompt := flattenConversation(messages)
+	plan := p.takeResumeDecision(messages)
 
+	// Session persistence must stay on so --resume can find the session next
+	// turn. We never pass --no-session-persistence in either branch now;
+	// turn-freshness is controlled by whether we pass --resume, not by
+	// whether we persist.
 	args := []string{
 		"-p",
 		"--output-format", "stream-json",
-		"--verbose",                // required by CLI when using stream-json
-		"--no-session-persistence", // ephemeral turn
+		"--verbose", // required by CLI when using stream-json
 		"--input-format", "text",
 	}
 
@@ -153,13 +244,18 @@ func (p *ClaudeCodeProvider) Stream(
 	if sub := p.cliSubModel(); sub != "" {
 		args = append(args, "--model", sub)
 	}
-	if system != "" {
-		// Replace, don't append. Claude Code's default system prompt is ~30K
-		// tokens and would drown haft's FPF protocol instructions. Haft
-		// owns the prompt for this provider; if it wants CLI tool usage
-		// described, it can include that itself.
-		args = append(args, "--system-prompt", system)
+
+	if plan.resume {
+		// Warm-path: CLI already owns the transcript; forward only the new
+		// user message. The system prompt is whatever it was on turn 1.
+		args = append(args, "--resume", plan.sessionID)
+	} else if plan.system != "" {
+		// Cold-path: replace, don't append. Claude Code's default system
+		// prompt is ~30K tokens and would drown haft's FPF protocol
+		// instructions. Haft owns the prompt for this provider.
+		args = append(args, "--system-prompt", plan.system)
 	}
+	prompt := plan.prompt
 
 	cmd := exec.CommandContext(ctx, p.cliPath, args...)
 	cmd.Stdin = strings.NewReader(prompt)
@@ -184,13 +280,15 @@ func (p *ClaudeCodeProvider) Stream(
 		return nil, fmt.Errorf("claudecode: start %s: %w", p.cliPath, err)
 	}
 
-	text, finishReason, parseErr := parseClaudeStream(stdout, handler)
+	result, parseErr := parseClaudeStream(stdout, handler)
 	waitErr := cmd.Wait()
 
 	if parseErr != nil {
+		p.invalidateSession()
 		return nil, fmt.Errorf("claudecode: parse stream: %w", parseErr)
 	}
 	if waitErr != nil {
+		p.invalidateSession()
 		// stderrBuf already caps at 64KB with a tail-preserving ring.
 		if stderrTxt := strings.TrimSpace(stderrBuf.String()); stderrTxt != "" {
 			return nil, fmt.Errorf("claudecode: cli exited: %w: %s", waitErr, stderrTxt)
@@ -198,10 +296,16 @@ func (p *ClaudeCodeProvider) Stream(
 		return nil, fmt.Errorf("claudecode: cli exited: %w", waitErr)
 	}
 
+	finishReason := result.finishReason
 	if finishReason == "" {
 		finishReason = "stop"
 	}
 	handler(StreamDelta{Done: true, FinishReason: finishReason})
+
+	// Turn succeeded: record the session id for next-turn resume.
+	p.recordTurnResult(result.sessionID, len(messages))
+
+	text := result.text
 
 	msg := &agent.Message{
 		Role:      agent.RoleAssistant,
@@ -374,27 +478,13 @@ func (c *cappedBuffer) String() string {
 	return string(c.buf)
 }
 
-// envWithout returns env with any entries matching key=... removed. The
-// match is case-sensitive and anchored at "=" so keys that merely share
-// a prefix are left untouched.
-func envWithout(env []string, key string) []string {
-	prefix := key + "="
-	out := make([]string, 0, len(env))
-	for _, e := range env {
-		if strings.HasPrefix(e, prefix) {
-			continue
-		}
-		out = append(out, e)
-	}
-	return out
-}
-
 // streamEvent captures the fields we care about from stream-json NDJSON.
 // See: https://docs.claude.com/en/docs/claude-code/sdk
 type streamEvent struct {
-	Type    string `json:"type"`
-	Subtype string `json:"subtype,omitempty"`
-	Message *struct {
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Message   *struct {
 		Role    string `json:"role"`
 		Content []struct {
 			Type string `json:"type"`
@@ -404,16 +494,24 @@ type streamEvent struct {
 	IsError bool `json:"is_error,omitempty"`
 }
 
-// parseClaudeStream reads NDJSON events from the CLI's stdout and forwards
-// text deltas to handler. Returns the concatenated text, finish reason, and
-// any scanner error. Unknown event types are ignored (forward-compat).
-func parseClaudeStream(r io.Reader, handler func(StreamDelta)) (string, string, error) {
+// claudeStreamResult is what parseClaudeStream gives back — a small struct
+// instead of N return values now that we track the session id too.
+type claudeStreamResult struct {
+	text         string
+	finishReason string
+	sessionID    string
+}
+
+// parseClaudeStream reads NDJSON events from the CLI's stdout, forwards text
+// deltas to handler, and extracts the final session id for --resume on the
+// next turn. Unknown event types are ignored (forward-compat).
+func parseClaudeStream(r io.Reader, handler func(StreamDelta)) (claudeStreamResult, error) {
 	var buf strings.Builder
 	// 16KB covers the typical single-turn text response (few-KB messages plus
 	// thinking). Avoids ~4 rounds of grow-and-copy doubling for common cases;
 	// grows naturally for longer outputs.
 	buf.Grow(16 * 1024)
-	var finishReason string
+	var finishReason, sessionID string
 
 	scanner := bufio.NewScanner(r)
 	// Allow large events — a single assistant block can exceed the 64KB default.
@@ -429,6 +527,14 @@ func parseClaudeStream(r io.Reader, handler func(StreamDelta)) (string, string, 
 			// Malformed event — skip rather than abort. The CLI occasionally
 			// interleaves debug lines when --verbose is on.
 			continue
+		}
+
+		if ev.SessionID != "" {
+			// Every event but `system:init` carries a session id; the last
+			// one wins. `result` is always the final event, so this settles
+			// to whichever id the CLI used for the turn (matters on resume:
+			// the CLI sometimes mints a new id when continuing).
+			sessionID = ev.SessionID
 		}
 
 		switch ev.Type {
@@ -451,8 +557,10 @@ func parseClaudeStream(r io.Reader, handler func(StreamDelta)) (string, string, 
 			}
 		}
 	}
+
+	res := claudeStreamResult{text: buf.String(), finishReason: finishReason, sessionID: sessionID}
 	if err := scanner.Err(); err != nil {
-		return buf.String(), finishReason, err
+		return res, err
 	}
-	return buf.String(), finishReason, nil
+	return res, nil
 }

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -132,6 +132,34 @@ func TestParseClaudeStreamSkipsMalformedLines(t *testing.T) {
 	}
 }
 
+func TestEnvWithoutStripsTargetKey(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_API_KEY=sk-leak",
+		"ANTHROPIC_API_KEY_BACKUP=keep",
+		"HOME=/root",
+	}
+	got := envWithout(env, "ANTHROPIC_API_KEY")
+	for _, e := range got {
+		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
+			t.Fatalf("envWithout kept target key: %v", got)
+		}
+	}
+	wantKeep := map[string]bool{
+		"PATH=/usr/bin":            true,
+		"ANTHROPIC_API_KEY_BACKUP=keep": true,
+		"HOME=/root":               true,
+	}
+	if len(got) != len(wantKeep) {
+		t.Fatalf("envWithout length = %d, want %d (%v)", len(got), len(wantKeep), got)
+	}
+	for _, e := range got {
+		if !wantKeep[e] {
+			t.Fatalf("envWithout dropped unrelated entry: %q", e)
+		}
+	}
+}
+
 func TestGuessProviderFromPrefixClaudeCodeBeatsAnthropic(t *testing.T) {
 	tests := []struct {
 		model string

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -164,17 +163,10 @@ func TestEnvWithoutStripsTargetKey(t *testing.T) {
 }
 
 func TestWriteHaftMCPConfigShape(t *testing.T) {
-	tmp := t.TempDir()
-	if err := os.Mkdir(filepath.Join(tmp, ".haft"), 0o755); err != nil {
-		t.Fatalf("mkdir .haft: %v", err)
-	}
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	const haftExe = "/fake/haft"
+	const projectRoot = "/fake/project"
 
-	path, projectRoot, err := writeHaftMCPConfig()
+	path, err := writeHaftMCPConfig(haftExe, projectRoot)
 	if err != nil {
 		t.Fatalf("writeHaftMCPConfig: %v", err)
 	}
@@ -182,6 +174,14 @@ func TestWriteHaftMCPConfigShape(t *testing.T) {
 		t.Fatalf("expected a tmpfile path")
 	}
 	t.Cleanup(func() { _ = os.Remove(path) })
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("tmpfile perm = %o, want 0600", mode)
+	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -201,14 +201,55 @@ func TestWriteHaftMCPConfigShape(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing haft entry: %s", data)
 	}
+	if entry.Command != haftExe {
+		t.Errorf("command = %q, want %q", entry.Command, haftExe)
+	}
 	if len(entry.Args) != 1 || entry.Args[0] != "serve" {
-		t.Fatalf("unexpected args: %v", entry.Args)
+		t.Errorf("unexpected args: %v", entry.Args)
 	}
-	if entry.Env["QUINT_PROJECT_ROOT"] == "" {
-		t.Fatalf("missing QUINT_PROJECT_ROOT in env")
+	if entry.Env["QUINT_PROJECT_ROOT"] != projectRoot {
+		t.Errorf("QUINT_PROJECT_ROOT = %q, want %q", entry.Env["QUINT_PROJECT_ROOT"], projectRoot)
 	}
-	if projectRoot == "" {
-		t.Fatalf("empty projectRoot")
+}
+
+func TestCappedBufferKeepsTail(t *testing.T) {
+	c := &cappedBuffer{limit: 10}
+	c.Write([]byte("hello "))
+	c.Write([]byte("world — how are you today?"))
+	got := c.String()
+	// Last 10 bytes of "hello world — how are you today?" is "you today?"
+	// Note: "—" is a 3-byte UTF-8 rune; we slice bytes, not runes. Any
+	// tail that ends with " today?" is sufficient to prove the ring works.
+	if !strings.HasSuffix(got, " today?") {
+		t.Fatalf("want suffix ' today?'; got %q", got)
+	}
+	if !strings.HasPrefix(got, "…(truncated)") {
+		t.Fatalf("want truncated prefix; got %q", got)
+	}
+}
+
+func TestCappedBufferNoTruncationUnderLimit(t *testing.T) {
+	c := &cappedBuffer{limit: 64}
+	c.Write([]byte("short"))
+	if got := c.String(); got != "short" {
+		t.Fatalf("got %q, want %q", got, "short")
+	}
+}
+
+func TestCliSubModel(t *testing.T) {
+	for _, tc := range []struct {
+		modelID string
+		want    string
+	}{
+		{"claude-code", ""},
+		{"claude-code:sonnet", "sonnet"},
+		{"claude-code:opus", "opus"},
+		{"claude-code:claude-opus-4-5", "claude-opus-4-5"},
+	} {
+		p := &ClaudeCodeProvider{modelID: tc.modelID}
+		if got := p.cliSubModel(); got != tc.want {
+			t.Errorf("cliSubModel(%q) = %q, want %q", tc.modelID, got, tc.want)
+		}
 	}
 }
 

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -78,14 +78,14 @@ func TestRenderPartsIncludesToolCallsAndResults(t *testing.T) {
 
 func TestParseClaudeStreamExtractsTextDeltas(t *testing.T) {
 	stream := strings.Join([]string{
-		`{"type":"system","subtype":"init"}`,
-		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello "}]}}`,
-		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"world"}]}}`,
-		`{"type":"result","subtype":"success","is_error":false}`,
+		`{"type":"system","subtype":"init","session_id":"sess-123"}`,
+		`{"type":"assistant","session_id":"sess-123","message":{"role":"assistant","content":[{"type":"text","text":"Hello "}]}}`,
+		`{"type":"assistant","session_id":"sess-123","message":{"role":"assistant","content":[{"type":"text","text":"world"}]}}`,
+		`{"type":"result","subtype":"success","is_error":false,"session_id":"sess-123"}`,
 	}, "\n")
 
 	var deltas []string
-	text, reason, err := parseClaudeStream(strings.NewReader(stream), func(d StreamDelta) {
+	res, err := parseClaudeStream(strings.NewReader(stream), func(d StreamDelta) {
 		if d.Text != "" {
 			deltas = append(deltas, d.Text)
 		}
@@ -93,11 +93,14 @@ func TestParseClaudeStreamExtractsTextDeltas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseClaudeStream: %v", err)
 	}
-	if text != "Hello world" {
-		t.Fatalf("concatenated text = %q, want %q", text, "Hello world")
+	if res.text != "Hello world" {
+		t.Fatalf("concatenated text = %q, want %q", res.text, "Hello world")
 	}
-	if reason != "stop" {
-		t.Fatalf("finish reason = %q, want stop", reason)
+	if res.finishReason != "stop" {
+		t.Fatalf("finish reason = %q, want stop", res.finishReason)
+	}
+	if res.sessionID != "sess-123" {
+		t.Fatalf("session id = %q, want sess-123", res.sessionID)
 	}
 	if got := strings.Join(deltas, "|"); got != "Hello |world" {
 		t.Fatalf("deltas = %q", got)
@@ -106,12 +109,12 @@ func TestParseClaudeStreamExtractsTextDeltas(t *testing.T) {
 
 func TestParseClaudeStreamHandlesErrorResult(t *testing.T) {
 	stream := `{"type":"result","subtype":"error_during_execution","is_error":true}`
-	_, reason, err := parseClaudeStream(strings.NewReader(stream), func(StreamDelta) {})
+	res, err := parseClaudeStream(strings.NewReader(stream), func(StreamDelta) {})
 	if err != nil {
 		t.Fatalf("parseClaudeStream: %v", err)
 	}
-	if reason != "error" {
-		t.Fatalf("finish reason = %q, want error", reason)
+	if res.finishReason != "error" {
+		t.Fatalf("finish reason = %q, want error", res.finishReason)
 	}
 }
 
@@ -122,43 +125,110 @@ func TestParseClaudeStreamSkipsMalformedLines(t *testing.T) {
 		``,
 		`{"type":"result","subtype":"success"}`,
 	}, "\n")
-	text, reason, err := parseClaudeStream(strings.NewReader(stream), func(StreamDelta) {})
+	res, err := parseClaudeStream(strings.NewReader(stream), func(StreamDelta) {})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if text != "ok" {
-		t.Fatalf("text = %q", text)
+	if res.text != "ok" {
+		t.Fatalf("text = %q", res.text)
 	}
-	if reason != "stop" {
-		t.Fatalf("reason = %q", reason)
+	if res.finishReason != "stop" {
+		t.Fatalf("reason = %q", res.finishReason)
 	}
 }
 
-func TestEnvWithoutStripsTargetKey(t *testing.T) {
-	env := []string{
-		"PATH=/usr/bin",
-		"ANTHROPIC_API_KEY=sk-leak",
-		"ANTHROPIC_API_KEY_BACKUP=keep",
-		"HOME=/root",
+func TestTakeResumeDecisionFreshOnFirstTurn(t *testing.T) {
+	p := &ClaudeCodeProvider{}
+	messages := []agent.Message{
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "hello"}}},
 	}
-	got := envWithout(env, "ANTHROPIC_API_KEY")
-	for _, e := range got {
-		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
-			t.Fatalf("envWithout kept target key: %v", got)
-		}
+	plan := p.takeResumeDecision(messages)
+	if plan.resume {
+		t.Fatalf("expected fresh turn on first call")
 	}
-	wantKeep := map[string]bool{
-		"PATH=/usr/bin":            true,
-		"ANTHROPIC_API_KEY_BACKUP=keep": true,
-		"HOME=/root":               true,
+	if plan.prompt == "" {
+		t.Fatalf("expected flattened prompt, got empty")
 	}
-	if len(got) != len(wantKeep) {
-		t.Fatalf("envWithout length = %d, want %d (%v)", len(got), len(wantKeep), got)
+}
+
+func TestTakeResumeDecisionContinues(t *testing.T) {
+	p := &ClaudeCodeProvider{sessionID: "sess-abc", msgsSent: 2}
+	messages := []agent.Message{
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "hi"}}},
+		{Role: agent.RoleAssistant, Parts: []agent.Part{agent.TextPart{Text: "yo"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "follow-up"}}},
 	}
-	for _, e := range got {
-		if !wantKeep[e] {
-			t.Fatalf("envWithout dropped unrelated entry: %q", e)
-		}
+	plan := p.takeResumeDecision(messages)
+	if !plan.resume {
+		t.Fatalf("expected resume plan")
+	}
+	if plan.sessionID != "sess-abc" {
+		t.Fatalf("sessionID = %q", plan.sessionID)
+	}
+	if plan.prompt != "follow-up" {
+		t.Fatalf("prompt = %q, want %q", plan.prompt, "follow-up")
+	}
+}
+
+func TestTakeResumeDecisionResetsOnGap(t *testing.T) {
+	p := &ClaudeCodeProvider{sessionID: "sess-abc", msgsSent: 2}
+	// Conversation jumped by 2 (not 1) since last turn — history was edited
+	// or branched. Fall back to fresh, clearing state.
+	messages := []agent.Message{
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "a"}}},
+		{Role: agent.RoleAssistant, Parts: []agent.Part{agent.TextPart{Text: "b"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "c"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "d"}}},
+	}
+	plan := p.takeResumeDecision(messages)
+	if plan.resume {
+		t.Fatalf("expected reset when conversation grew by >1")
+	}
+	if p.sessionID != "" || p.msgsSent != 0 {
+		t.Fatalf("state not reset: sessionID=%q msgsSent=%d", p.sessionID, p.msgsSent)
+	}
+}
+
+func TestTakeResumeDecisionResetsOnNonUserTail(t *testing.T) {
+	p := &ClaudeCodeProvider{sessionID: "sess-abc", msgsSent: 1}
+	messages := []agent.Message{
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "hi"}}},
+		{Role: agent.RoleTool, Parts: []agent.Part{agent.ToolResultPart{Content: "x"}}},
+	}
+	plan := p.takeResumeDecision(messages)
+	if plan.resume {
+		t.Fatalf("should not resume when tail is a tool-result message")
+	}
+}
+
+func TestTakeResumeDecisionHonorsEnvOptOut(t *testing.T) {
+	t.Setenv("HAFT_CLAUDECODE_NO_RESUME", "1")
+	p := &ClaudeCodeProvider{sessionID: "sess-abc", msgsSent: 2}
+	messages := []agent.Message{
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "a"}}},
+		{Role: agent.RoleAssistant, Parts: []agent.Part{agent.TextPart{Text: "b"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "c"}}},
+	}
+	plan := p.takeResumeDecision(messages)
+	if plan.resume {
+		t.Fatalf("HAFT_CLAUDECODE_NO_RESUME should force fresh turns")
+	}
+}
+
+func TestInvalidateAndRecordSession(t *testing.T) {
+	p := &ClaudeCodeProvider{}
+	p.recordTurnResult("sess-1", 3)
+	if p.sessionID != "sess-1" || p.msgsSent != 4 {
+		t.Fatalf("record: got (%q, %d)", p.sessionID, p.msgsSent)
+	}
+	// Empty new id preserves existing (CLI sometimes omits on retries).
+	p.recordTurnResult("", 5)
+	if p.sessionID != "sess-1" || p.msgsSent != 6 {
+		t.Fatalf("preserve: got (%q, %d)", p.sessionID, p.msgsSent)
+	}
+	p.invalidateSession()
+	if p.sessionID != "" || p.msgsSent != 0 {
+		t.Fatalf("invalidate: got (%q, %d)", p.sessionID, p.msgsSent)
 	}
 }
 

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -1,0 +1,152 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/m0n0x41d/haft/internal/agent"
+)
+
+func TestFlattenConversationSplitsSystemAndBody(t *testing.T) {
+	messages := []agent.Message{
+		{Role: agent.RoleSystem, Parts: []agent.Part{agent.TextPart{Text: "be terse"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "hello"}}},
+		{Role: agent.RoleAssistant, Parts: []agent.Part{agent.TextPart{Text: "hi"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "more"}}},
+	}
+
+	sys, body := flattenConversation(messages)
+
+	if sys != "be terse" {
+		t.Fatalf("system prompt = %q, want %q", sys, "be terse")
+	}
+	wantBody := "User: hello\n\nAssistant: hi\n\nUser: more"
+	if body != wantBody {
+		t.Fatalf("body mismatch:\n got: %q\nwant: %q", body, wantBody)
+	}
+}
+
+func TestFlattenConversationMergesMultipleSystemPrompts(t *testing.T) {
+	messages := []agent.Message{
+		{Role: agent.RoleSystem, Parts: []agent.Part{agent.TextPart{Text: "rule A"}}},
+		{Role: agent.RoleSystem, Parts: []agent.Part{agent.TextPart{Text: "rule B"}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "go"}}},
+	}
+	sys, body := flattenConversation(messages)
+	if sys != "rule A\n\nrule B" {
+		t.Fatalf("merged system = %q", sys)
+	}
+	if body != "User: go" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestFlattenConversationSkipsEmptyTurns(t *testing.T) {
+	messages := []agent.Message{
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "   "}}},
+		{Role: agent.RoleUser, Parts: []agent.Part{agent.TextPart{Text: "hello"}}},
+	}
+	_, body := flattenConversation(messages)
+	if body != "User: hello" {
+		t.Fatalf("empty-turn skip failed, body = %q", body)
+	}
+}
+
+func TestRenderPartsIncludesToolCallsAndResults(t *testing.T) {
+	parts := []agent.Part{
+		agent.TextPart{Text: "checking"},
+		agent.ToolCallPart{ToolCallID: "c1", ToolName: "haft_note", Arguments: `{"x":1}`},
+		agent.ToolResultPart{ToolCallID: "c1", Content: "ok"},
+		agent.ToolResultPart{ToolCallID: "c2", Content: "boom", IsError: true},
+	}
+	s := renderParts(parts)
+	for _, want := range []string{
+		"checking",
+		"[tool_call name=haft_note id=c1]",
+		`{"x":1}`,
+		"[tool_result id=c1]",
+		"[tool_result_error id=c2]",
+		"boom",
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("renderParts output missing %q\nfull:\n%s", want, s)
+		}
+	}
+}
+
+func TestParseClaudeStreamExtractsTextDeltas(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello "}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"world"}]}}`,
+		`{"type":"result","subtype":"success","is_error":false}`,
+	}, "\n")
+
+	var deltas []string
+	text, reason, err := parseClaudeStream(strings.NewReader(stream), func(d StreamDelta) {
+		if d.Text != "" {
+			deltas = append(deltas, d.Text)
+		}
+	})
+	if err != nil {
+		t.Fatalf("parseClaudeStream: %v", err)
+	}
+	if text != "Hello world" {
+		t.Fatalf("concatenated text = %q, want %q", text, "Hello world")
+	}
+	if reason != "stop" {
+		t.Fatalf("finish reason = %q, want stop", reason)
+	}
+	if got := strings.Join(deltas, "|"); got != "Hello |world" {
+		t.Fatalf("deltas = %q", got)
+	}
+}
+
+func TestParseClaudeStreamHandlesErrorResult(t *testing.T) {
+	stream := `{"type":"result","subtype":"error_during_execution","is_error":true}`
+	_, reason, err := parseClaudeStream(strings.NewReader(stream), func(StreamDelta) {})
+	if err != nil {
+		t.Fatalf("parseClaudeStream: %v", err)
+	}
+	if reason != "error" {
+		t.Fatalf("finish reason = %q, want error", reason)
+	}
+}
+
+func TestParseClaudeStreamSkipsMalformedLines(t *testing.T) {
+	stream := strings.Join([]string{
+		`not json at all`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}`,
+		``,
+		`{"type":"result","subtype":"success"}`,
+	}, "\n")
+	text, reason, err := parseClaudeStream(strings.NewReader(stream), func(StreamDelta) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != "ok" {
+		t.Fatalf("text = %q", text)
+	}
+	if reason != "stop" {
+		t.Fatalf("reason = %q", reason)
+	}
+}
+
+func TestGuessProviderFromPrefixClaudeCodeBeatsAnthropic(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"claude-code", "claudecode"},
+		{"claude-code:sonnet", "claudecode"},
+		{"claude-opus-4-20250514", "anthropic"},
+		{"claude-sonnet-4-20250514", "anthropic"},
+		{"gpt-5.4", "openai"},
+		{"gemini-2.5-pro", "google"},
+	}
+	for _, tc := range tests {
+		if got := guessProviderFromPrefix(tc.model); got != tc.want {
+			t.Errorf("guessProviderFromPrefix(%q) = %q, want %q", tc.model, got, tc.want)
+		}
+	}
+}

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -277,8 +277,8 @@ func TestWriteHaftMCPConfigShape(t *testing.T) {
 	if len(entry.Args) != 1 || entry.Args[0] != "serve" {
 		t.Errorf("unexpected args: %v", entry.Args)
 	}
-	if entry.Env["QUINT_PROJECT_ROOT"] != projectRoot {
-		t.Errorf("QUINT_PROJECT_ROOT = %q, want %q", entry.Env["QUINT_PROJECT_ROOT"], projectRoot)
+	if entry.Env["HAFT_PROJECT_ROOT"] != projectRoot {
+		t.Errorf("HAFT_PROJECT_ROOT = %q, want %q", entry.Env["HAFT_PROJECT_ROOT"], projectRoot)
 	}
 }
 

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -163,49 +163,6 @@ func TestEnvWithoutStripsTargetKey(t *testing.T) {
 	}
 }
 
-func TestFindHaftProjectRoot(t *testing.T) {
-	tmp := t.TempDir()
-	nested := filepath.Join(tmp, "a", "b", "c")
-	if err := os.MkdirAll(nested, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.Mkdir(filepath.Join(tmp, ".haft"), 0o755); err != nil {
-		t.Fatalf("mkdir .haft: %v", err)
-	}
-
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-
-	if err := os.Chdir(nested); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	got, ok := findHaftProjectRoot()
-	if !ok {
-		t.Fatalf("findHaftProjectRoot = (_, false), want project found")
-	}
-	// On macOS /tmp is a symlink to /private/tmp — normalize both sides.
-	wantResolved, _ := filepath.EvalSymlinks(tmp)
-	gotResolved, _ := filepath.EvalSymlinks(got)
-	if gotResolved != wantResolved {
-		t.Fatalf("findHaftProjectRoot = %q, want %q", gotResolved, wantResolved)
-	}
-}
-
-func TestFindHaftProjectRootNoMatch(t *testing.T) {
-	tmp := t.TempDir()
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(orig) })
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	if _, ok := findHaftProjectRoot(); ok {
-		t.Fatalf("expected not found in bare tmp dir")
-	}
-}
-
 func TestWriteHaftMCPConfigShape(t *testing.T) {
 	tmp := t.TempDir()
 	if err := os.Mkdir(filepath.Join(tmp, ".haft"), 0o755); err != nil {

--- a/internal/provider/claudecode_test.go
+++ b/internal/provider/claudecode_test.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -157,6 +160,98 @@ func TestEnvWithoutStripsTargetKey(t *testing.T) {
 		if !wantKeep[e] {
 			t.Fatalf("envWithout dropped unrelated entry: %q", e)
 		}
+	}
+}
+
+func TestFindHaftProjectRoot(t *testing.T) {
+	tmp := t.TempDir()
+	nested := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(tmp, ".haft"), 0o755); err != nil {
+		t.Fatalf("mkdir .haft: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	if err := os.Chdir(nested); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	got, ok := findHaftProjectRoot()
+	if !ok {
+		t.Fatalf("findHaftProjectRoot = (_, false), want project found")
+	}
+	// On macOS /tmp is a symlink to /private/tmp — normalize both sides.
+	wantResolved, _ := filepath.EvalSymlinks(tmp)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Fatalf("findHaftProjectRoot = %q, want %q", gotResolved, wantResolved)
+	}
+}
+
+func TestFindHaftProjectRootNoMatch(t *testing.T) {
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if _, ok := findHaftProjectRoot(); ok {
+		t.Fatalf("expected not found in bare tmp dir")
+	}
+}
+
+func TestWriteHaftMCPConfigShape(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmp, ".haft"), 0o755); err != nil {
+		t.Fatalf("mkdir .haft: %v", err)
+	}
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	path, projectRoot, err := writeHaftMCPConfig()
+	if err != nil {
+		t.Fatalf("writeHaftMCPConfig: %v", err)
+	}
+	if path == "" {
+		t.Fatalf("expected a tmpfile path")
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed struct {
+		McpServers map[string]struct {
+			Command string            `json:"command"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, data)
+	}
+	entry, ok := parsed.McpServers["haft"]
+	if !ok {
+		t.Fatalf("missing haft entry: %s", data)
+	}
+	if len(entry.Args) != 1 || entry.Args[0] != "serve" {
+		t.Fatalf("unexpected args: %v", entry.Args)
+	}
+	if entry.Env["QUINT_PROJECT_ROOT"] == "" {
+		t.Fatalf("missing QUINT_PROJECT_ROOT in env")
+	}
+	if projectRoot == "" {
+		t.Fatalf("empty projectRoot")
 	}
 }
 

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -1,6 +1,10 @@
 package provider
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/m0n0x41d/haft/internal/config"
+)
 
 // NewProvider creates an LLM provider based on provider ID.
 // Routes to the appropriate implementation:
@@ -48,24 +52,12 @@ func ProviderIDForModel(model string) string {
 	return guessProviderFromPrefix(model)
 }
 
+// guessProviderFromPrefix delegates to the canonical prefix table in the
+// config package. Falls back to "openai" if nothing matches — the old
+// default — so unknown model strings get routed to the most permissive path.
 func guessProviderFromPrefix(model string) string {
-	// Ordered list so longer prefixes win (e.g. "claude-code" beats "claude-").
-	type entry struct{ prefix, provider string }
-	prefixes := []entry{
-		{"claude-code", "claudecode"},
-		{"claude-", "anthropic"},
-		{"gpt-", "openai"},
-		{"o1", "openai"},
-		{"o3", "openai"},
-		{"o4", "openai"},
-		{"gemini-", "google"},
-		{"deepseek-", "deepseek"},
-		{"llama-", "groq"},
+	if id := config.ProviderForModel(model); id != "" {
+		return id
 	}
-	for _, e := range prefixes {
-		if len(model) >= len(e.prefix) && model[:len(e.prefix)] == e.prefix {
-			return e.provider
-		}
-	}
-	return "openai" // default
+	return "openai"
 }

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -6,21 +6,25 @@ import "fmt"
 // Routes to the appropriate implementation:
 //   - "openai": OpenAI Responses API (also handles Codex/ChatGPT auth)
 //   - "anthropic": Anthropic Messages API
+//   - "claudecode": Claude Code CLI (uses Max/Pro subscription, no API key)
 //   - Others: treated as OpenAI-compatible (DeepSeek, Groq, Mistral, etc.)
 //
 // For OpenAI, apiKey can be empty — it resolves from env/config/codex.
 // For Anthropic, apiKey is required (from env or config).
+// For claudecode, apiKey is ignored — auth is owned by the `claude` CLI.
 func NewProvider(providerID, model, apiKey string) (LLMProvider, error) {
 	switch providerID {
 	case "openai":
 		return NewOpenAI(model)
 	case "anthropic":
 		return NewAnthropic(model, apiKey)
+	case "claudecode":
+		return NewClaudeCode(model)
 	default:
 		// OpenAI-compatible providers (DeepSeek, Groq, etc.)
 		// For now, route through OpenAI — they use the same API format.
 		// TODO: support custom base URLs for non-OpenAI providers.
-		return nil, fmt.Errorf("provider %q not yet supported — use openai or anthropic", providerID)
+		return nil, fmt.Errorf("provider %q not yet supported — use openai, anthropic, or claudecode", providerID)
 	}
 }
 
@@ -45,19 +49,22 @@ func ProviderIDForModel(model string) string {
 }
 
 func guessProviderFromPrefix(model string) string {
-	prefixes := map[string]string{
-		"gpt-":      "openai",
-		"o1":        "openai",
-		"o3":        "openai",
-		"o4":        "openai",
-		"claude-":   "anthropic",
-		"gemini-":   "google",
-		"deepseek-": "deepseek",
-		"llama-":    "groq",
+	// Ordered list so longer prefixes win (e.g. "claude-code" beats "claude-").
+	type entry struct{ prefix, provider string }
+	prefixes := []entry{
+		{"claude-code", "claudecode"},
+		{"claude-", "anthropic"},
+		{"gpt-", "openai"},
+		{"o1", "openai"},
+		{"o3", "openai"},
+		{"o4", "openai"},
+		{"gemini-", "google"},
+		{"deepseek-", "deepseek"},
+		{"llama-", "groq"},
 	}
-	for prefix, provider := range prefixes {
-		if len(model) >= len(prefix) && model[:len(prefix)] == prefix {
-			return provider
+	for _, e := range prefixes {
+		if len(model) >= len(e.prefix) && model[:len(e.prefix)] == e.prefix {
+			return e.provider
 		}
 	}
 	return "openai" // default

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -395,12 +395,14 @@ func EmbeddedProviders() []ProviderInfo {
 			// Auth is owned by the `claude` CLI — no API key, no per-token cost.
 			// Sub-model variants (claude-code:opus, :sonnet, :haiku) are forwarded
 			// to the CLI via --model. The bare id "claude-code" lets the CLI pick.
+			// ContextWindow / DefaultMaxOut are left zero because those limits
+			// live in the CLI, not here; fabricating numbers would go stale.
 			ID: "claudecode", Name: "Claude Code (CLI)", APIType: "claudecode",
 			Models: []ModelInfo{
-				{ID: "claude-code", Name: "Claude Code (CLI default)", ContextWindow: 200_000, DefaultMaxOut: 16_384, CanReason: true, SupportsImages: false},
-				{ID: "claude-code:opus", Name: "Claude Code — Opus", ContextWindow: 200_000, DefaultMaxOut: 32_000, CanReason: true, SupportsImages: false},
-				{ID: "claude-code:sonnet", Name: "Claude Code — Sonnet", ContextWindow: 200_000, DefaultMaxOut: 16_000, CanReason: true, SupportsImages: false},
-				{ID: "claude-code:haiku", Name: "Claude Code — Haiku", ContextWindow: 200_000, DefaultMaxOut: 8_192, CanReason: false, SupportsImages: false},
+				{ID: "claude-code", Name: "Claude Code (CLI default)"},
+				{ID: "claude-code:opus", Name: "Claude Code — Opus"},
+				{ID: "claude-code:sonnet", Name: "Claude Code — Sonnet"},
+				{ID: "claude-code:haiku", Name: "Claude Code — Haiku"},
 			},
 		},
 		{

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -392,6 +392,18 @@ func EmbeddedProviders() []ProviderInfo {
 			},
 		},
 		{
+			// Auth is owned by the `claude` CLI — no API key, no per-token cost.
+			// Sub-model variants (claude-code:opus, :sonnet, :haiku) are forwarded
+			// to the CLI via --model. The bare id "claude-code" lets the CLI pick.
+			ID: "claudecode", Name: "Claude Code (CLI)", APIType: "claudecode",
+			Models: []ModelInfo{
+				{ID: "claude-code", Name: "Claude Code (CLI default)", ContextWindow: 200_000, DefaultMaxOut: 16_384, CanReason: true, SupportsImages: false},
+				{ID: "claude-code:opus", Name: "Claude Code — Opus", ContextWindow: 200_000, DefaultMaxOut: 32_000, CanReason: true, SupportsImages: false},
+				{ID: "claude-code:sonnet", Name: "Claude Code — Sonnet", ContextWindow: 200_000, DefaultMaxOut: 16_000, CanReason: true, SupportsImages: false},
+				{ID: "claude-code:haiku", Name: "Claude Code — Haiku", ContextWindow: 200_000, DefaultMaxOut: 8_192, CanReason: false, SupportsImages: false},
+			},
+		},
+		{
 			ID: "google", Name: "Google", APIType: "google",
 			Models: []ModelInfo{
 				{ID: "gemini-2.5-pro", Name: "Gemini 2.5 Pro", ContextWindow: 1_000_000, DefaultMaxOut: 65_536, CanReason: true, SupportsImages: true, CostPer1MIn: 1.25, CostPer1MOut: 10.0},


### PR DESCRIPTION
## Summary

Adds a `claudecode` LLM provider that wraps the `claude` CLI as a subprocess. Lets Pro/Max subscribers run `haft agent` without `ANTHROPIC_API_KEY` — auth is delegated entirely to the CLI.

- New provider + tests in `internal/provider/claudecode.go` / `claudecode_test.go`
- Factory dispatch + longest-prefix-match fix (`claude-code` was shadowed by `claude-`)
- Registry entries: `claude-code`, `claude-code:opus`, `claude-code:sonnet`, `claude-code:haiku`
- `haft doctor` surfaces the CLI presence + version
- Docs at `docs/claude-code-provider.md`

## Why subprocess and not the SDK

haft is Go. The Vercel AI SDK's [`ai-sdk-provider-claude-code`](https://github.com/ben-vargas/ai-sdk-provider-claude-code) is TypeScript-only, and the Claude Agent SDK itself only ships Python + TS bindings. Subprocess wrapping is the only path that reuses Claude Code's subscription auth without taking a non-Go dep (or building a CGO bridge to Bun/Node).

## Scope (intentionally narrow)

**In this PR:**
- Flatten haft messages → `(system_prompt, user_prompt)` pair
- Pipe to `claude -p --output-format stream-json --verbose --allowed-tools ''`
- Parse NDJSON, stream text deltas, return assistant `Message`

**Out of scope (follow-ups):**
- Tool-use: haft's `ToolSchema` isn't translated to the CLI's MCP surface yet, so the model emits text only. Documented as a clear limitation — tool-driven flows should keep using the anthropic/openai providers. The right next step is \`--mcp-config\` pointing at a local haft MCP server so \`haft_note\`/\`haft_problem\`/etc. are callable.
- Session reuse via `--resume` to amortize per-turn startup cost.
- Propagating token counts from the `result` event.

I'd rather ship the scaffold small and iterate than bundle everything and risk a wholesale reject.

## Design notes

- Stdin pipe for the prompt (avoids argv size limits on long conversations).
- `--allowed-tools ''` disables CLI built-ins so the model doesn't write files under the user's feet when haft is supposed to own the agent surface.
- `--no-session-persistence` keeps each turn ephemeral (matches existing Anthropic/OpenAI providers' stateless shape).
- `ModelID()` reports the haft-facing id (`claude-code` or `claude-code:<sub>`), not a real Anthropic model name — avoids confusing the registry.

## Tests

```
ok  github.com/m0n0x41d/haft/internal/provider    8.031s
```

Unit tests cover:
- `flattenConversation` — system merging, labeled body blocks, empty-turn skip
- `renderParts` — text, tool_call, tool_result (incl. error variant)
- `parseClaudeStream` — text delta extraction, `result` event (success / error), malformed line skip
- `guessProviderFromPrefix` — regression: `claude-code*` routes to claudecode, not anthropic

Not yet in CI: end-to-end subprocess invocation against the real `claude` binary. Open to adding a `-tags integration` suite gated on `claude` being on PATH if you want it.

## Test plan

- [ ] \`go test ./internal/provider/...\` (clean)
- [ ] \`go build ./internal/provider/... ./internal/config/... ./internal/cli/...\` (clean)
- [ ] Manual: \`model: claude-code\` in \`~/.haft/config.yaml\`, run \`haft \"hello\"\`, see streamed response
- [ ] \`haft doctor\` reports Claude Code CLI when \`claude\` is on PATH
- [ ] Prefix routing: \`--model claude-opus-4-20250514\` still dispatches to anthropic (not claudecode)

## Open questions for the maintainer

1. Model id shape: is \`claude-code:sonnet\` acceptable, or prefer a flat list like \`claude-code-sonnet\`?
2. Tool-use follow-up: MCP-bridge approach OK, or would you rather expose haft tools via \`--allowed-tools\` on custom MCP servers differently?
3. Happy to gate the doctor check behind a config flag if you don't want CLI detection to run when the user isn't using this provider.