### PR TITLE
fix(release): TS strict cast for unknown-status fixture (v7.0.0 hotfix)

### DIFF
--- a/desktop/frontend/src/lib/readinessContract.test.ts
+++ b/desktop/frontend/src/lib/readinessContract.test.ts
@@ -47,7 +47,7 @@ test("readiness contract canonical statuses match the TypeScript union", () => {
 for (const unknown of fixture.unknown_status_examples) {
   test(`unknown status ${JSON.stringify(unknown)} cannot fake-ready an unready project`, () => {
     const readiness = projectReadiness({
-      status: unknown,
+      status: unknown as ProjectReadiness,
       exists: true,
       has_haft: true,
       has_specs: false,
@@ -62,7 +62,7 @@ for (const unknown of fixture.unknown_status_examples) {
 
   test(`unknown status ${JSON.stringify(unknown)} cannot fake-ready a missing project`, () => {
     const readiness = projectReadiness({
-      status: unknown,
+      status: unknown as ProjectReadiness,
       exists: false,
       has_haft: false,
       has_specs: false,


### PR DESCRIPTION
## Summary

- Cast `fixture.unknown_status_examples` entries to `ProjectReadiness` at the test call site
- Unblocks `desktop/frontend` `tsc -b` strict mode in the release workflow's `Build CLI` matrix
- Caught by `Build CLI linux-arm64` failing first → fail-fast cancelled the rest of the matrix on the original v7.0.0 tag run

## Test plan

- [x] `npm --prefix desktop/frontend run build` green locally
- [x] `go test ./...` green via lefthook pre-push
- [ ] Re-tag v7.0.0 → release matrix builds green

🤖 Generated with [Claude Code](https://claude.com/claude-code)