### PR TITLE
fix(install): pick CLI archive, not desktop tarball

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -256,7 +256,14 @@ main() {
     # Try downloading release
     local api_url="https://api.github.com/repos/${REPO}/releases/latest"
     local download_url
-    download_url=$(curl -s "$api_url" | grep "browser_download_url.*${os_arch}.tar.gz" | sed -E 's/.*"([^"]+)".*/\1/' | head -1)
+    # Anchor on `/haft-${os_arch}.tar.gz` (leading slash) so the CLI archive
+    # is picked, not `haft-desktop-${os_arch}.tar.gz` which sorts first in
+    # the GitHub API response and contains the Tauri shell binary, not
+    # the CLI `haft` binary.
+    download_url=$(curl -s "$api_url" \
+        | grep -E "\"browser_download_url\":[[:space:]]*\".*/haft-${os_arch}\.tar\.gz\"" \
+        | sed -E 's/.*"([^"]+)".*/\1/' \
+        | head -1)
 
     if [[ -n "$download_url" ]]; then
         (


### PR DESCRIPTION
## Summary

`install.sh` regex matched both `haft-${arch}.tar.gz` and `haft-desktop-${arch}.tar.gz` and `head -1` picked the desktop one (alphabetically first). Users hit \"Binary not found in archive\" because the desktop tarball ships `haft-desktop` / `Haft.app`, not the CLI \`haft\`.

## Test plan

- [x] Verified all three CLI arches (linux-amd64, linux-arm64, darwin-arm64) resolve to the correct tarball URL after the fix
- [x] No retag of v7.0.0 needed — install.sh is fetched from raw.githubusercontent.com/main/install.sh, fix lands live for all `curl ... | bash` users on merge