### PR TITLE
Add CLI command to complete external WorkCommissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ haft commission list --selector stale
 haft commission show wc-...
 haft commission requeue wc-... --reason stale_operator_recovery
 haft commission cancel wc-... --reason no_longer_relevant
+haft commission complete-external wc-... --runner external-runner --reason external_runtime_succeeded --payload-file runtime-evidence.json
 haft commission list-runnable
 haft commission claim wc-...
 ```

--- a/internal/cli/commission.go
+++ b/internal/cli/commission.go
@@ -36,6 +36,11 @@ var (
 	commissionFromDecisionValidFor         string
 	commissionFromDecisionValidUntil       string
 	commissionFromDecisionSliceDescription string
+	commissionLifecycleEvent               string
+	commissionLifecycleVerdict             string
+	commissionLifecycleReason              string
+	commissionLifecyclePayload             string
+	commissionLifecyclePayloadFile         string
 )
 
 var commissionCmd = &cobra.Command{
@@ -115,6 +120,19 @@ var commissionCancelCmd = &cobra.Command{
 	RunE:  runCommissionCancel,
 }
 
+var commissionCompleteExternalCmd = &cobra.Command{
+	Use:   "complete-external <commission-id>",
+	Short: "Record terminal success/failure for an externally-run WorkCommission",
+	Long: `Record terminal success/failure for an externally-run WorkCommission.
+
+This is the operator path for external runners that already wrote local runtime
+evidence outside Haft Harness. If the commission is still preflighting, this
+command first records a passed preflight/start event, then records the terminal
+complete_or_block event. It does not apply, merge, or publish any workspace diff.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCommissionCompleteExternal,
+}
+
 func init() {
 	commissionCreateCmd.Flags().StringVar(&commissionJSONPath, "json", "", "JSON payload path, or '-' for stdin")
 	registerCommissionFromDecisionFlags(commissionCreateFromDecisionCmd)
@@ -128,6 +146,12 @@ func init() {
 	commissionRequeueCmd.Flags().String("reason", "operator_requested_requeue", "reason recorded on the recovery event")
 	commissionCancelCmd.Flags().StringVar(&commissionRunnerID, "runner", "haft-cli", "runner id for the cancellation event")
 	commissionCancelCmd.Flags().String("reason", "operator_cancelled", "reason recorded on the cancellation event")
+	commissionCompleteExternalCmd.Flags().StringVar(&commissionRunnerID, "runner", "haft-cli", "runner id for the lifecycle events")
+	commissionCompleteExternalCmd.Flags().StringVar(&commissionLifecycleVerdict, "verdict", "completed", "terminal verdict: completed, pass, failed, or blocked")
+	commissionCompleteExternalCmd.Flags().StringVar(&commissionLifecycleReason, "reason", "external_runtime_completed", "reason recorded on lifecycle events")
+	commissionCompleteExternalCmd.Flags().StringVar(&commissionLifecycleEvent, "event", "external_runtime_terminal", "terminal event name recorded on completion")
+	commissionCompleteExternalCmd.Flags().StringVar(&commissionLifecyclePayload, "payload", "", "JSON object payload, or @path to read JSON from a file")
+	commissionCompleteExternalCmd.Flags().StringVar(&commissionLifecyclePayloadFile, "payload-file", "", "JSON object payload file")
 
 	commissionCmd.AddCommand(commissionCreateCmd)
 	commissionCmd.AddCommand(commissionCreateFromDecisionCmd)
@@ -139,6 +163,7 @@ func init() {
 	commissionCmd.AddCommand(commissionClaimCmd)
 	commissionCmd.AddCommand(commissionRequeueCmd)
 	commissionCmd.AddCommand(commissionCancelCmd)
+	commissionCmd.AddCommand(commissionCompleteExternalCmd)
 	rootCmd.AddCommand(commissionCmd)
 }
 
@@ -318,6 +343,120 @@ func runCommissionCancel(cmd *cobra.Command, args []string) error {
 		result, err := handleHaftCommission(ctx, store, params)
 		return writeCommissionResult(cmd, result, err)
 	})
+}
+
+func runCommissionCompleteExternal(cmd *cobra.Command, args []string) error {
+	payload, err := commissionLifecyclePayloadFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	params := map[string]any{
+		"commission_id": args[0],
+		"runner_id":     commissionRunnerID,
+		"event":         commissionLifecycleEvent,
+		"verdict":       commissionLifecycleVerdict,
+		"reason":        commissionLifecycleReason,
+	}
+	if payload != nil {
+		params["payload"] = payload
+	}
+
+	return withCommissionStore(func(ctx context.Context, store *artifact.Store) error {
+		result, err := completeExternalWorkCommission(ctx, store, params)
+		return writeCommissionResult(cmd, result, err)
+	})
+}
+
+func completeExternalWorkCommission(ctx context.Context, store *artifact.Store, params map[string]any) (string, error) {
+	commissionID := strings.TrimSpace(stringArg(params, "commission_id"))
+	if commissionID == "" {
+		return "", fmt.Errorf("commission_id is required")
+	}
+
+	shown, err := handleHaftCommission(ctx, store, map[string]any{
+		"action":        "show",
+		"commission_id": commissionID,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var decoded map[string]map[string]any
+	if err := json.Unmarshal([]byte(shown), &decoded); err != nil {
+		return "", fmt.Errorf("decode WorkCommission %s: %w", commissionID, err)
+	}
+	commission := decoded["commission"]
+	state := strings.TrimSpace(stringField(commission, "state"))
+
+	switch state {
+	case "preflighting":
+		_, err := handleHaftCommission(ctx, store, map[string]any{
+			"action":        "start_after_preflight",
+			"commission_id": commissionID,
+			"runner_id":     stringArg(params, "runner_id"),
+			"event":         "external_preflight_passed",
+			"verdict":       "pass",
+			"reason":        stringArg(params, "reason"),
+		})
+		if err != nil {
+			return "", err
+		}
+	case "running":
+		// Already started; record only the terminal lifecycle event below.
+	case "completed", "completed_with_projection_debt", "failed", "blocked_policy", "blocked_stale", "blocked_conflict":
+		if externalCompletionVerdictMatchesState(state, stringArg(params, "verdict")) {
+			return shown, nil
+		}
+		return "", fmt.Errorf("commission_complete_external_already_terminal: state=%s verdict=%s", state, stringArg(params, "verdict"))
+	default:
+		return "", fmt.Errorf("commission_complete_external_not_allowed: state=%s allowed_states=preflighting,running", state)
+	}
+
+	completeArgs := copyStringAnyMap(params)
+	completeArgs["action"] = "complete_or_block"
+	return handleHaftCommission(ctx, store, completeArgs)
+}
+
+func externalCompletionVerdictMatchesState(state string, verdict string) bool {
+	switch strings.TrimSpace(verdict) {
+	case "pass", "completed":
+		return state == "completed" || state == "completed_with_projection_debt"
+	case "failed":
+		return state == "failed"
+	case "blocked":
+		return strings.HasPrefix(state, "blocked_")
+	default:
+		return false
+	}
+}
+
+func commissionLifecyclePayloadFromFlags(cmd *cobra.Command) (map[string]any, error) {
+	payload := strings.TrimSpace(commissionLifecyclePayload)
+	payloadFile := strings.TrimSpace(commissionLifecyclePayloadFile)
+	if payload != "" && payloadFile != "" {
+		return nil, fmt.Errorf("use either --payload or --payload-file, not both")
+	}
+	if strings.HasPrefix(payload, "@") {
+		payloadFile = strings.TrimSpace(strings.TrimPrefix(payload, "@"))
+		payload = ""
+	}
+	if payloadFile != "" {
+		data, err := os.ReadFile(payloadFile)
+		if err != nil {
+			return nil, fmt.Errorf("read payload file %s: %w", payloadFile, err)
+		}
+		payload = string(data)
+	}
+	if payload == "" {
+		return nil, nil
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		return nil, fmt.Errorf("parse lifecycle payload JSON: %w", err)
+	}
+	return decoded, nil
 }
 
 func withCommissionStore(fn func(context.Context, *artifact.Store) error) error {

--- a/internal/cli/serve_commission_test.go
+++ b/internal/cli/serve_commission_test.go
@@ -623,6 +623,143 @@ func TestHandleHaftCommission_CompleteOrBlockRecordsProjectionDebtForExternalReq
 	}
 }
 
+func TestCompleteExternalWorkCommission_CompletesPreflightingCommission(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	decision := createCommissionDecisionFixture(t, ctx, store, haftDir, "External lifecycle", "internal/cli/commission.go")
+	createdResult, err := handleHaftCommission(ctx, store, map[string]any{
+		"action":        "create_from_decision",
+		"decision_ref":  decision.Meta.ID,
+		"repo_ref":      "local:haft",
+		"base_sha":      "base-r1",
+		"target_branch": "dev",
+		"valid_until":   "2099-01-01T00:00:00Z",
+		"spec_readiness_override": map[string]any{
+			"kind":              "tactical",
+			"out_of_spec":       true,
+			"project_readiness": "needs_onboard",
+			"reason":            "unit test fixture without project spec carriers",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := map[string]map[string]any{}
+	if err := json.Unmarshal([]byte(createdResult), &created); err != nil {
+		t.Fatal(err)
+	}
+	commissionID := created["commission"]["id"].(string)
+
+	_, err = handleHaftCommission(ctx, store, map[string]any{
+		"action":        "claim_for_preflight",
+		"commission_id": commissionID,
+		"runner_id":     "external:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := completeExternalWorkCommission(ctx, store, map[string]any{
+		"commission_id": commissionID,
+		"runner_id":     "external:test",
+		"event":         "external_runtime_terminal",
+		"verdict":       "completed",
+		"reason":        "external_runtime_succeeded_diff_pending_reviewer",
+		"payload": map[string]any{
+			"final_message_path": "logs/wc.last-message.txt",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	completed := map[string]map[string]any{}
+	if err := json.Unmarshal([]byte(result), &completed); err != nil {
+		t.Fatal(err)
+	}
+	commission := completed["commission"]
+	if commission["state"] != "completed" {
+		t.Fatalf("state = %#v, want completed", commission["state"])
+	}
+
+	events, ok := commission["events"].([]any)
+	if !ok || len(events) != 2 {
+		t.Fatalf("events = %#v, want start and terminal events", commission["events"])
+	}
+	first, _ := events[0].(map[string]any)
+	last, _ := events[1].(map[string]any)
+	if first["action"] != "start_after_preflight" || first["verdict"] != "pass" {
+		t.Fatalf("first event = %#v, want start_after_preflight/pass", first)
+	}
+	if last["action"] != "complete_or_block" || last["verdict"] != "completed" {
+		t.Fatalf("last event = %#v, want complete_or_block/completed", last)
+	}
+	if last["event"] != "external_runtime_terminal" {
+		t.Fatalf("terminal event = %#v", last["event"])
+	}
+}
+
+func TestCompleteExternalWorkCommissionIsIdempotentForMatchingTerminalState(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+
+	_, err := handleHaftCommission(ctx, store, map[string]any{
+		"action":     "create",
+		"commission": workCommissionFixture("wc-external-cli-already-complete", "completed", "2099-01-01T00:00:00Z"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := completeExternalWorkCommission(ctx, store, map[string]any{
+		"commission_id": "wc-external-cli-already-complete",
+		"runner_id":     "external:test",
+		"event":         "external_runtime_terminal",
+		"verdict":       "completed",
+		"reason":        "external_runtime_succeeded",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shown := map[string]map[string]any{}
+	if err := json.Unmarshal([]byte(result), &shown); err != nil {
+		t.Fatal(err)
+	}
+	if shown["commission"]["state"] != "completed" {
+		t.Fatalf("state = %#v, want completed", shown["commission"]["state"])
+	}
+}
+
+func TestCompleteExternalWorkCommissionRejectsQueuedCommission(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+
+	_, err := handleHaftCommission(ctx, store, map[string]any{
+		"action":     "create",
+		"commission": workCommissionFixture("wc-external-cli-queued", "queued", "2099-01-01T00:00:00Z"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = completeExternalWorkCommission(ctx, store, map[string]any{
+		"commission_id": "wc-external-cli-queued",
+		"runner_id":     "external:test",
+		"event":         "external_runtime_terminal",
+		"verdict":       "completed",
+		"reason":        "external_runtime_succeeded",
+	})
+	if err == nil {
+		t.Fatal("expected queued commission completion to fail")
+	}
+	if !strings.Contains(err.Error(), "commission_complete_external_not_allowed") {
+		t.Fatalf("err = %v, want commission_complete_external_not_allowed", err)
+	}
+}
+
 func TestHandleHaftCommission_CompleteOrBlockKeepsLocalOnlyCompletionUnaffected(t *testing.T) {
 	store := setupCLIArtifactStore(t)
 	ctx := context.Background()
@@ -2489,7 +2626,6 @@ func workCommissionFixture(id, state, validUntil string) map[string]any {
 	}
 }
 
-
 func TestHandleHaftCommission_CreateFromDecisionRequiresSliceDescriptionOnSecondCommission(t *testing.T) {
 	store := setupCLIArtifactStore(t)
 	ctx := context.Background()
@@ -2633,4 +2769,3 @@ func TestHandleHaftCommission_CreateFromDecisionAcceptsExplicitSliceDescription(
 		t.Fatalf("second commission slice_description = %#v, want slice-B: MCP schema additions only", got)
 	}
 }
-


### PR DESCRIPTION
## Summary

Adds `haft commission complete-external <wc-id>` so a human operator can close a WorkCommission lifecycle after an external runner has produced local runtime evidence.

The command:

- records `start_after_preflight` automatically when the WC is still `preflighting`
- records the terminal `complete_or_block` lifecycle event
- supports terminal `--verdict completed|pass|failed|blocked`
- accepts inline JSON payloads with `--payload '{...}'` or file payloads with `--payload-file evidence.json` / `--payload @evidence.json`
- refuses queued/terminal/non-running states instead of abusing `cancel`
- does not apply, merge, or publish workspace diffs

This addresses #78.

## Why

External runners can successfully finish and write evidence outside Haft Harness, while the WorkCommission remains `preflighting`/`running`. Without a CLI completion command, downstream `depends_on` WCs stay blocked unless an operator has access to hidden MCP/tool-only lifecycle calls.

## Test plan

```bash
go test ./internal/workcommission ./internal/cli
go test ./...
go run ./cmd/haft commission --help
go run ./cmd/haft commission complete-external --help
```
