### PR TITLE
Fix Open-Sleigh terminalization and lifecycle authority

### DIFF
--- a/internal/scopeauth/scope_authorization.go
+++ b/internal/scopeauth/scope_authorization.go
@@ -269,11 +269,18 @@ func pathMatches(pattern string, changedPath string) bool {
 	case strings.HasSuffix(normalizedPattern, "/**"):
 		prefix := strings.TrimSuffix(normalizedPattern, "/**")
 		return changedPath == prefix || strings.HasPrefix(changedPath, prefix+"/")
+	case scopePatternIsDirectory(pattern):
+		return changedPath == normalizedPattern || strings.HasPrefix(changedPath, normalizedPattern+"/")
 	case strings.Contains(normalizedPattern, "*"):
 		return globRegex(normalizedPattern).MatchString(changedPath)
 	default:
 		return changedPath == normalizedPattern
 	}
+}
+
+func scopePatternIsDirectory(pattern string) bool {
+	trimmedPattern := strings.TrimSpace(filepath.ToSlash(pattern))
+	return strings.HasSuffix(trimmedPattern, "/")
 }
 
 func globRegex(pattern string) *regexp.Regexp {

--- a/internal/scopeauth/scope_authorization_test.go
+++ b/internal/scopeauth/scope_authorization_test.go
@@ -28,6 +28,26 @@ func TestAuthorizeWorkspaceDiffAllowsAllowedPath(t *testing.T) {
 	}
 }
 
+func TestAuthorizeWorkspaceDiffAllowsDirectoryCarrierWithTrailingSlash(t *testing.T) {
+	facts := testPathFacts()
+	scope := CommissionScope{
+		AllowedPaths: []string{"docs/", "test/"},
+	}
+
+	summary := AuthorizeWorkspaceDiff(
+		scope,
+		[]string{"docs/readiness.md", "test/smoke_test.go"},
+		facts,
+	)
+
+	if summary.Verdict != Allowed {
+		t.Fatalf("verdict = %s, want %s; out_of_scope=%#v", summary.Verdict, Allowed, summary.OutOfScope)
+	}
+	if !slices.Equal(summary.Allowed, []string{"docs/readiness.md", "test/smoke_test.go"}) {
+		t.Fatalf("allowed = %#v", summary.Allowed)
+	}
+}
+
 func TestAuthorizeWorkspaceDiffForbiddenOverridesBroadAllowedPath(t *testing.T) {
 	facts := testPathFacts()
 	scope := CommissionScope{

--- a/open-sleigh/lib/open_sleigh/agent/tool_runtime.ex
+++ b/open-sleigh/lib/open_sleigh/agent/tool_runtime.ex
@@ -488,15 +488,42 @@ defmodule OpenSleigh.Agent.ToolRuntime do
   @spec run_bash(String.t(), Path.t(), pos_integer()) ::
           {:ok, String.t()} | {:error, EffectError.t()}
   defp run_bash(command, workspace_path, timeout_ms) do
-    task =
-      Task.async(fn ->
-        System.cmd("bash", ["-lc", command], cd: workspace_path, stderr_to_stdout: true)
-      end)
+    with :ok <- reject_commission_lifecycle_mutation(command) do
+      task =
+        Task.async(fn ->
+          System.cmd("bash", ["-lc", command], cd: workspace_path, stderr_to_stdout: true)
+        end)
 
-    task
-    |> bash_task_result(timeout_ms)
+      task
+      |> bash_task_result(timeout_ms)
+    end
   rescue
     _ -> {:error, :tool_execution_failed}
+  end
+
+  @spec reject_commission_lifecycle_mutation(String.t()) :: :ok | {:error, EffectError.t()}
+  defp reject_commission_lifecycle_mutation(command) do
+    if commission_lifecycle_mutation_command?(command) do
+      {:error, :no_commission_mutation}
+    else
+      :ok
+    end
+  end
+
+  @spec commission_lifecycle_mutation_command?(String.t()) :: boolean()
+  defp commission_lifecycle_mutation_command?(command) do
+    normalized = String.downcase(command)
+
+    Enum.any?(commission_lifecycle_mutation_patterns(), &Regex.match?(&1, normalized))
+  end
+
+  @spec commission_lifecycle_mutation_patterns() :: [Regex.t()]
+  defp commission_lifecycle_mutation_patterns do
+    [
+      ~r/\bhaft\s+commission\s+(cancel|claim|complete-external|create|create-batch|create-from-decision|create-from-plan|requeue)\b/,
+      ~r/\bhaft_commission\b/,
+      ~r/["']action["']\s*:\s*["'](claim_for_preflight|complete_or_block|record_preflight|record_run_event|requeue|start_after_preflight)["']/
+    ]
   end
 
   @spec bash_task_result(Task.t(), pos_integer()) :: {:ok, String.t()} | {:error, EffectError.t()}

--- a/open-sleigh/lib/open_sleigh/runtime_log_writer.ex
+++ b/open-sleigh/lib/open_sleigh/runtime_log_writer.ex
@@ -208,6 +208,7 @@ defmodule OpenSleigh.RuntimeLogWriter do
   defp serialise(boolean) when is_boolean(boolean), do: boolean
   defp serialise(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp serialise(%MapSet{} = set), do: set |> MapSet.to_list() |> serialise()
+  defp serialise(%_{} = struct), do: struct |> Map.from_struct() |> serialise()
 
   defp serialise(%{} = map) do
     map

--- a/open-sleigh/lib/open_sleigh/runtime_status_writer.ex
+++ b/open-sleigh/lib/open_sleigh/runtime_status_writer.ex
@@ -277,6 +277,7 @@ defmodule OpenSleigh.RuntimeStatusWriter do
   defp serialise(boolean) when is_boolean(boolean), do: boolean
   defp serialise(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp serialise(%MapSet{} = set), do: set |> MapSet.to_list() |> serialise()
+  defp serialise(%_{} = struct), do: struct |> Map.from_struct() |> serialise()
 
   defp serialise(%{} = map) do
     map

--- a/open-sleigh/test/open_sleigh/agent/tool_runtime_test.exs
+++ b/open-sleigh/test/open_sleigh/agent/tool_runtime_test.exs
@@ -151,6 +151,30 @@ defmodule OpenSleigh.Agent.ToolRuntimeTest do
     refute File.exists?(target)
   end
 
+  test "bash rejects commission lifecycle mutation before command execution", ctx do
+    commission =
+      ["**/*"]
+      |> scoped_commission!([], MapSet.new([:run_tests]))
+
+    session =
+      ctx.workspace
+      |> adapter_session(commission, MapSet.new([:bash]))
+
+    target = Path.join(ctx.workspace, "should-not-exist.txt")
+
+    assert {:error, :no_commission_mutation} =
+             ToolRuntime.execute(
+               "bash",
+               %{
+                 "command" =>
+                   "haft commission complete-external wc-tool-runtime --runner codex; touch should-not-exist.txt"
+               },
+               session
+             )
+
+    refute File.exists?(target)
+  end
+
   test "bash path mutation is terminal-diff checked because shell text is opaque", ctx do
     commission =
       ["allowed.txt"]

--- a/open-sleigh/test/open_sleigh/runtime_log_writer_test.exs
+++ b/open-sleigh/test/open_sleigh/runtime_log_writer_test.exs
@@ -1,7 +1,7 @@
 defmodule OpenSleigh.RuntimeLogWriterTest do
   use ExUnit.Case, async: true
 
-  alias OpenSleigh.RuntimeLogWriter
+  alias OpenSleigh.{PhaseConfig, RuntimeLogWriter}
 
   setup do
     root =
@@ -37,6 +37,43 @@ defmodule OpenSleigh.RuntimeLogWriterTest do
     assert Enum.all?(events, &(&1["commission_id"] == "wc/local-1"))
     assert Enum.all?(events, &(&1["legacy_ticket_id"] == "OCT-1"))
     assert Enum.any?(events, &(&1["event"] == "phase_completed"))
+  end
+
+  test "event payloads can include non-enumerable structs", ctx do
+    log_root = Path.join(ctx.root, "wal")
+
+    phase_config = %PhaseConfig{
+      phase: :execute,
+      agent_role: :executor,
+      tools: [:read, :edit],
+      gates: %{
+        structural: [:design_runtime_split_ok],
+        semantic: [],
+        human: [:commission_approved]
+      },
+      prompt_template_key: :execute,
+      max_turns: 20,
+      default_valid_until_days: 30
+    }
+
+    {:ok, writer} =
+      RuntimeLogWriter.start_link(
+        path: log_root,
+        metadata: %{commission_id: "wc/struct-1"}
+      )
+
+    :ok =
+      RuntimeLogWriter.event(writer, :session_waiting_human, %{phase_config: phase_config})
+
+    :ok = RuntimeLogWriter.stop(writer)
+
+    log_path = Path.join(log_root, "wc_struct-1.jsonl")
+    events = log_events(log_path)
+    event = Enum.find(events, &(&1["event"] == "session_waiting_human"))
+
+    assert get_in(event, ["data", "phase_config", "phase"]) == "execute"
+    assert get_in(event, ["data", "phase_config", "agent_role"]) == "executor"
+    assert get_in(event, ["data", "phase_config", "tools"]) == ["read", "edit"]
   end
 
   test "legacy metadata keeps ticket_id scoped path and payload", ctx do

--- a/open-sleigh/test/open_sleigh/runtime_status_writer_test.exs
+++ b/open-sleigh/test/open_sleigh/runtime_status_writer_test.exs
@@ -1,7 +1,7 @@
 defmodule OpenSleigh.RuntimeStatusWriterTest do
   use ExUnit.Case, async: false
 
-  alias OpenSleigh.{ObservationsBus, RuntimeStatusWriter}
+  alias OpenSleigh.{ObservationsBus, PhaseConfig, RuntimeStatusWriter}
 
   defmodule StatusServer do
     use GenServer
@@ -79,6 +79,48 @@ defmodule OpenSleigh.RuntimeStatusWriterTest do
     assert get_in(status, ["failures", Access.at(0), "commission_id"]) == "wc/local-7"
     assert get_in(status, ["failures", Access.at(0), "legacy_ticket_id"]) == "OCT-HG"
     assert get_in(status, ["failures", Access.at(0), "ticket"]) == "OCT-HG"
+  end
+
+  test "snapshot payloads can include non-enumerable structs", ctx do
+    status_root = Path.join(ctx.root, "status")
+
+    phase_config = %PhaseConfig{
+      phase: :execute,
+      agent_role: :executor,
+      tools: [:read, :edit],
+      gates: %{
+        structural: [:design_runtime_split_ok],
+        semantic: [],
+        human: [:commission_approved]
+      },
+      prompt_template_key: :execute,
+      max_turns: 20,
+      default_valid_until_days: 30
+    }
+
+    {:ok, orchestrator} =
+      StatusServer.start_link(%{
+        status: %{claimed: [], running: [phase_config], pending_human: [], retries: %{}},
+        human_gates: []
+      })
+
+    {:ok, _writer} =
+      RuntimeStatusWriter.start_link(
+        orchestrator: orchestrator,
+        path: status_root,
+        metadata: %{commission_id: "wc/struct-2"},
+        interval_ms: 0
+      )
+
+    status_path = Path.join(status_root, "wc_struct-2.json")
+    status = read_status(status_path)
+
+    assert get_in(status, ["orchestrator", "running", Access.at(0), "phase"]) == "execute"
+
+    assert get_in(status, ["orchestrator", "running", Access.at(0), "agent_role"]) ==
+             "executor"
+
+    assert get_in(status, ["orchestrator", "running", Access.at(0), "tools"]) == ["read", "edit"]
   end
 
   test "legacy metadata keeps ticket_id scoped path and snapshot", ctx do


### PR DESCRIPTION
## Summary

Fix Open-Sleigh runtime terminalization failures found in real harness runs:

1. Runtime JSON writers can now serialize ordinary Elixir structs such as `%OpenSleigh.PhaseConfig{}`.
2. Harness apply scope authorization now treats trailing-slash scope entries as directory carriers.
3. Agent-executed shell commands can no longer mutate WorkCommission lifecycle state; lifecycle transitions remain orchestrator-owned.

## Change

- Keep existing special handling for `%DateTime{}` and `%MapSet{}`.
- Add generic struct serialization in runtime/status writers after special cases.
- Interpret allowed scope patterns like `docs/` as allowing descendants under that directory, not only an exact path.
- Reject agent `bash` commands that attempt commission lifecycle mutation (`haft commission complete-external`, `haft_commission`, or lifecycle action payloads such as `complete_or_block`).
- Add regression tests for the struct serialization, directory-carrier scope matching, and lifecycle mutation rejection.

## Verification

Ran locally:

```text
go test ./...
cd open-sleigh && mix test
```

Result:

```text
2 properties, 505 tests, 0 failures (3 excluded)
```

Notes:

- Mix emits the existing `preferred_cli_env` deprecation warning.
- `orchestrator_retry_test` intentionally logs a crashing test agent (`:boom`); the test suite passes.
- Checked the new real-case regression patch for project-specific strings before commit; no downstream repository paths, filenames, commission ids, or domain-specific names are present.
