### PR TITLE
fix(open-sleigh): harden commission scope and runtime serialization

### DIFF
--- a/internal/cli/serve_commission.go
+++ b/internal/cli/serve_commission.go
@@ -2715,7 +2715,7 @@ func ensureWorkCommissionLifecycleTransition(commission map[string]any, args map
 	state := stringField(commission, "state")
 	allowedStates := workCommissionLifecycleAllowedStatesByAction[action]
 
-	if workCommissionStateAllowed(allowedStates, state) {
+	if workCommissionLifecycleStateAllowed(action, state, stringArg(args, "verdict"), allowedStates) {
 		return nil
 	}
 
@@ -2725,6 +2725,23 @@ func ensureWorkCommissionLifecycleTransition(commission map[string]any, args map
 		state,
 		strings.Join(allowedStates, ","),
 	)
+}
+
+func workCommissionLifecycleStateAllowed(action string, state string, verdict string, allowedStates []string) bool {
+	if workCommissionStateAllowed(allowedStates, state) {
+		return true
+	}
+
+	// Preflight pass markers are intentionally idempotent once a commission has
+	// advanced to running. Open-Sleigh may replay a local preflight ticket after a
+	// runtime restart or worker stall while Haft already records the
+	// WorkCommission as running. Rejecting that replay traps the harness in a
+	// preflight retry loop: record_run_event is accepted in running, then
+	// record_preflight/start_after_preflight is rejected, then the orchestrator
+	// retries preflight again. Only pass verdicts get this replay tolerance; a
+	// stale preflight must not be able to retroactively block a running commission.
+	return state == "running" && verdict == "pass" &&
+		(action == "record_preflight" || action == "start_after_preflight")
 }
 
 func workCommissionFreshnessReport(

--- a/internal/cli/serve_commission_test.go
+++ b/internal/cli/serve_commission_test.go
@@ -878,6 +878,114 @@ func TestHandleHaftCommission_RecordRunEventPersistsRuntimeRunRefDuringPreflight
 	}
 }
 
+func TestHandleHaftCommission_PreflightLifecycleIsIdempotentOnceRunning(t *testing.T) {
+	store := setupCLIArtifactStore(t)
+	ctx := context.Background()
+	haftDir := t.TempDir()
+
+	decision := createCommissionDecisionFixture(t, ctx, store, haftDir, "Replay preflight", "internal/cli/serve_commission.go")
+
+	result, err := handleHaftCommission(ctx, store, map[string]any{
+		"action":        "create_from_decision",
+		"decision_ref":  decision.Meta.ID,
+		"repo_ref":      "local:haft",
+		"base_sha":      "base-r1",
+		"target_branch": "dev",
+		"valid_until":   "2099-01-01T00:00:00Z",
+		"spec_readiness_override": map[string]any{
+			"kind":              "tactical",
+			"out_of_spec":       true,
+			"project_readiness": "needs_onboard",
+			"reason":            "unit test fixture without project spec carriers",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created := map[string]map[string]any{}
+	if err := json.Unmarshal([]byte(result), &created); err != nil {
+		t.Fatal(err)
+	}
+	commissionID := created["commission"]["id"].(string)
+
+	_, err = handleHaftCommission(ctx, store, map[string]any{
+		"action":        "claim_for_preflight",
+		"commission_id": commissionID,
+		"runner_id":     "open-sleigh:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = handleHaftCommission(ctx, store, map[string]any{
+		"action":        "start_after_preflight",
+		"commission_id": commissionID,
+		"runner_id":     "open-sleigh:test",
+		"event":         "preflight_passed",
+		"verdict":       "pass",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = handleHaftCommission(ctx, store, map[string]any{
+		"action":        "record_preflight",
+		"commission_id": commissionID,
+		"runner_id":     "open-sleigh:test",
+		"event":         "preflight_checked",
+		"verdict":       "pass",
+	})
+	if err != nil {
+		t.Fatalf("record_preflight replay on running commission failed: %v", err)
+	}
+
+	result, err = handleHaftCommission(ctx, store, map[string]any{
+		"action":        "start_after_preflight",
+		"commission_id": commissionID,
+		"runner_id":     "open-sleigh:test",
+		"event":         "preflight_passed",
+		"verdict":       "pass",
+	})
+	if err != nil {
+		t.Fatalf("start_after_preflight replay on running commission failed: %v", err)
+	}
+
+	shown := map[string]map[string]any{}
+	if err := json.Unmarshal([]byte(result), &shown); err != nil {
+		t.Fatal(err)
+	}
+	commission := shown["commission"]
+	if commission["state"] != "running" {
+		t.Fatalf("state = %#v, want running", commission["state"])
+	}
+
+	events, ok := commission["events"].([]any)
+	if !ok || len(events) != 3 {
+		t.Fatalf("events = %#v, want three lifecycle events", commission["events"])
+	}
+
+	last, ok := events[len(events)-1].(map[string]any)
+	if !ok {
+		t.Fatalf("last event = %#v, want object", events[len(events)-1])
+	}
+	if last["action"] != "start_after_preflight" || last["verdict"] != "pass" {
+		t.Fatalf("last event = %#v, want replayed start_after_preflight/pass", last)
+	}
+
+	_, err = handleHaftCommission(ctx, store, map[string]any{
+		"action":        "record_preflight",
+		"commission_id": commissionID,
+		"runner_id":     "open-sleigh:test",
+		"event":         "preflight_checked",
+		"verdict":       "blocked",
+		"reason":        "late stale replay",
+	})
+	if err == nil || !strings.Contains(err.Error(), "commission_lifecycle_forbidden") {
+		t.Fatalf("blocked preflight replay error = %v, want commission_lifecycle_forbidden", err)
+	}
+}
+
 func TestHandleHaftCommission_CommissionLifecycleRejectsOutOfOrderEvents(t *testing.T) {
 	store := setupCLIArtifactStore(t)
 	ctx := context.Background()

--- a/internal/scopeauth/scope_authorization.go
+++ b/internal/scopeauth/scope_authorization.go
@@ -269,11 +269,18 @@ func pathMatches(pattern string, changedPath string) bool {
 	case strings.HasSuffix(normalizedPattern, "/**"):
 		prefix := strings.TrimSuffix(normalizedPattern, "/**")
 		return changedPath == prefix || strings.HasPrefix(changedPath, prefix+"/")
+	case scopePatternIsDirectory(pattern):
+		return changedPath == normalizedPattern || strings.HasPrefix(changedPath, normalizedPattern+"/")
 	case strings.Contains(normalizedPattern, "*"):
 		return globRegex(normalizedPattern).MatchString(changedPath)
 	default:
 		return changedPath == normalizedPattern
 	}
+}
+
+func scopePatternIsDirectory(pattern string) bool {
+	trimmedPattern := strings.TrimSpace(filepath.ToSlash(pattern))
+	return strings.HasSuffix(trimmedPattern, "/")
 }
 
 func globRegex(pattern string) *regexp.Regexp {

--- a/internal/scopeauth/scope_authorization_test.go
+++ b/internal/scopeauth/scope_authorization_test.go
@@ -28,6 +28,26 @@ func TestAuthorizeWorkspaceDiffAllowsAllowedPath(t *testing.T) {
 	}
 }
 
+func TestAuthorizeWorkspaceDiffAllowsDirectoryCarrierWithTrailingSlash(t *testing.T) {
+	facts := testPathFacts()
+	scope := CommissionScope{
+		AllowedPaths: []string{"docs/", "test/"},
+	}
+
+	summary := AuthorizeWorkspaceDiff(
+		scope,
+		[]string{"docs/readiness.md", "test/smoke_test.go"},
+		facts,
+	)
+
+	if summary.Verdict != Allowed {
+		t.Fatalf("verdict = %s, want %s; out_of_scope=%#v", summary.Verdict, Allowed, summary.OutOfScope)
+	}
+	if !slices.Equal(summary.Allowed, []string{"docs/readiness.md", "test/smoke_test.go"}) {
+		t.Fatalf("allowed = %#v", summary.Allowed)
+	}
+}
+
 func TestAuthorizeWorkspaceDiffForbiddenOverridesBroadAllowedPath(t *testing.T) {
 	facts := testPathFacts()
 	scope := CommissionScope{

--- a/open-sleigh/lib/open_sleigh/agent/adapter.ex
+++ b/open-sleigh/lib/open_sleigh/agent/adapter.ex
@@ -409,6 +409,10 @@ defmodule OpenSleigh.Agent.Adapter do
         prefix = String.trim_trailing(pattern, "/**")
         path == prefix or String.starts_with?(path, prefix <> "/")
 
+      String.ends_with?(pattern, "/") ->
+        prefix = String.trim_trailing(pattern, "/")
+        path == prefix or String.starts_with?(path, prefix <> "/")
+
       String.contains?(pattern, "*") ->
         pattern
         |> glob_regex()

--- a/open-sleigh/lib/open_sleigh/agent/tool_runtime.ex
+++ b/open-sleigh/lib/open_sleigh/agent/tool_runtime.ex
@@ -488,15 +488,42 @@ defmodule OpenSleigh.Agent.ToolRuntime do
   @spec run_bash(String.t(), Path.t(), pos_integer()) ::
           {:ok, String.t()} | {:error, EffectError.t()}
   defp run_bash(command, workspace_path, timeout_ms) do
-    task =
-      Task.async(fn ->
-        System.cmd("bash", ["-lc", command], cd: workspace_path, stderr_to_stdout: true)
-      end)
+    with :ok <- reject_commission_lifecycle_mutation(command) do
+      task =
+        Task.async(fn ->
+          System.cmd("bash", ["-lc", command], cd: workspace_path, stderr_to_stdout: true)
+        end)
 
-    task
-    |> bash_task_result(timeout_ms)
+      task
+      |> bash_task_result(timeout_ms)
+    end
   rescue
     _ -> {:error, :tool_execution_failed}
+  end
+
+  @spec reject_commission_lifecycle_mutation(String.t()) :: :ok | {:error, EffectError.t()}
+  defp reject_commission_lifecycle_mutation(command) do
+    if commission_lifecycle_mutation_command?(command) do
+      {:error, :no_commission_mutation}
+    else
+      :ok
+    end
+  end
+
+  @spec commission_lifecycle_mutation_command?(String.t()) :: boolean()
+  defp commission_lifecycle_mutation_command?(command) do
+    normalized = String.downcase(command)
+
+    Enum.any?(commission_lifecycle_mutation_patterns(), &Regex.match?(&1, normalized))
+  end
+
+  @spec commission_lifecycle_mutation_patterns() :: [Regex.t()]
+  defp commission_lifecycle_mutation_patterns do
+    [
+      ~r/\bhaft\s+commission\s+(cancel|claim|complete-external|create|create-batch|create-from-decision|create-from-plan|requeue)\b/,
+      ~r/\bhaft_commission\b/,
+      ~r/["']action["']\s*:\s*["'](claim_for_preflight|complete_or_block|record_preflight|record_run_event|requeue|start_after_preflight)["']/
+    ]
   end
 
   @spec bash_task_result(Task.t(), pos_integer()) :: {:ok, String.t()} | {:error, EffectError.t()}

--- a/open-sleigh/lib/open_sleigh/runtime_log_writer.ex
+++ b/open-sleigh/lib/open_sleigh/runtime_log_writer.ex
@@ -208,6 +208,7 @@ defmodule OpenSleigh.RuntimeLogWriter do
   defp serialise(boolean) when is_boolean(boolean), do: boolean
   defp serialise(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp serialise(%MapSet{} = set), do: set |> MapSet.to_list() |> serialise()
+  defp serialise(%_{} = struct), do: struct |> Map.from_struct() |> serialise()
 
   defp serialise(%{} = map) do
     map

--- a/open-sleigh/lib/open_sleigh/runtime_status_writer.ex
+++ b/open-sleigh/lib/open_sleigh/runtime_status_writer.ex
@@ -277,6 +277,7 @@ defmodule OpenSleigh.RuntimeStatusWriter do
   defp serialise(boolean) when is_boolean(boolean), do: boolean
   defp serialise(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp serialise(%MapSet{} = set), do: set |> MapSet.to_list() |> serialise()
+  defp serialise(%_{} = struct), do: struct |> Map.from_struct() |> serialise()
 
   defp serialise(%{} = map) do
     map

--- a/open-sleigh/test/open_sleigh/agent/adapter_scope_test.exs
+++ b/open-sleigh/test/open_sleigh/agent/adapter_scope_test.exs
@@ -89,6 +89,25 @@ defmodule OpenSleigh.Agent.AdapterScopeTest do
              Adapter.validate_terminal_diff(session, ["lib/a.ex", "lib/b.ex"])
   end
 
+  test "terminal diff validation treats trailing slash scope entries as recursive directories", ctx do
+    commission =
+      ["gui/"]
+      |> scope!([])
+      |> commission!()
+
+    session =
+      ctx.workspace
+      |> adapter_session!(commission, MapSet.new([:write]))
+
+    changed_paths = [
+      "gui/foo.cpp",
+      "gui/nested/bar.cpp"
+    ]
+
+    assert :ok = Adapter.validate_terminal_diff(session, changed_paths)
+    assert [] = Adapter.terminal_diff_out_of_scope_paths(session, changed_paths)
+  end
+
   test "terminal diff observability reports exact out-of-scope paths", ctx do
     commission =
       ["lib/a.ex"]

--- a/open-sleigh/test/open_sleigh/agent/tool_runtime_test.exs
+++ b/open-sleigh/test/open_sleigh/agent/tool_runtime_test.exs
@@ -151,6 +151,30 @@ defmodule OpenSleigh.Agent.ToolRuntimeTest do
     refute File.exists?(target)
   end
 
+  test "bash rejects commission lifecycle mutation before command execution", ctx do
+    commission =
+      ["**/*"]
+      |> scoped_commission!([], MapSet.new([:run_tests]))
+
+    session =
+      ctx.workspace
+      |> adapter_session(commission, MapSet.new([:bash]))
+
+    target = Path.join(ctx.workspace, "should-not-exist.txt")
+
+    assert {:error, :no_commission_mutation} =
+             ToolRuntime.execute(
+               "bash",
+               %{
+                 "command" =>
+                   "haft commission complete-external wc-tool-runtime --runner codex; touch should-not-exist.txt"
+               },
+               session
+             )
+
+    refute File.exists?(target)
+  end
+
   test "bash path mutation is terminal-diff checked because shell text is opaque", ctx do
     commission =
       ["allowed.txt"]

--- a/open-sleigh/test/open_sleigh/runtime_log_writer_test.exs
+++ b/open-sleigh/test/open_sleigh/runtime_log_writer_test.exs
@@ -1,7 +1,7 @@
 defmodule OpenSleigh.RuntimeLogWriterTest do
   use ExUnit.Case, async: true
 
-  alias OpenSleigh.RuntimeLogWriter
+  alias OpenSleigh.{PhaseConfig, RuntimeLogWriter}
 
   setup do
     root =
@@ -37,6 +37,43 @@ defmodule OpenSleigh.RuntimeLogWriterTest do
     assert Enum.all?(events, &(&1["commission_id"] == "wc/local-1"))
     assert Enum.all?(events, &(&1["legacy_ticket_id"] == "OCT-1"))
     assert Enum.any?(events, &(&1["event"] == "phase_completed"))
+  end
+
+  test "event payloads can include non-enumerable structs", ctx do
+    log_root = Path.join(ctx.root, "wal")
+
+    phase_config = %PhaseConfig{
+      phase: :execute,
+      agent_role: :executor,
+      tools: [:read, :edit],
+      gates: %{
+        structural: [:design_runtime_split_ok],
+        semantic: [],
+        human: [:commission_approved]
+      },
+      prompt_template_key: :execute,
+      max_turns: 20,
+      default_valid_until_days: 30
+    }
+
+    {:ok, writer} =
+      RuntimeLogWriter.start_link(
+        path: log_root,
+        metadata: %{commission_id: "wc/struct-1"}
+      )
+
+    :ok =
+      RuntimeLogWriter.event(writer, :session_waiting_human, %{phase_config: phase_config})
+
+    :ok = RuntimeLogWriter.stop(writer)
+
+    log_path = Path.join(log_root, "wc_struct-1.jsonl")
+    events = log_events(log_path)
+    event = Enum.find(events, &(&1["event"] == "session_waiting_human"))
+
+    assert get_in(event, ["data", "phase_config", "phase"]) == "execute"
+    assert get_in(event, ["data", "phase_config", "agent_role"]) == "executor"
+    assert get_in(event, ["data", "phase_config", "tools"]) == ["read", "edit"]
   end
 
   test "legacy metadata keeps ticket_id scoped path and payload", ctx do

--- a/open-sleigh/test/open_sleigh/runtime_status_writer_test.exs
+++ b/open-sleigh/test/open_sleigh/runtime_status_writer_test.exs
@@ -1,7 +1,7 @@
 defmodule OpenSleigh.RuntimeStatusWriterTest do
   use ExUnit.Case, async: false
 
-  alias OpenSleigh.{ObservationsBus, RuntimeStatusWriter}
+  alias OpenSleigh.{ObservationsBus, PhaseConfig, RuntimeStatusWriter}
 
   defmodule StatusServer do
     use GenServer
@@ -79,6 +79,48 @@ defmodule OpenSleigh.RuntimeStatusWriterTest do
     assert get_in(status, ["failures", Access.at(0), "commission_id"]) == "wc/local-7"
     assert get_in(status, ["failures", Access.at(0), "legacy_ticket_id"]) == "OCT-HG"
     assert get_in(status, ["failures", Access.at(0), "ticket"]) == "OCT-HG"
+  end
+
+  test "snapshot payloads can include non-enumerable structs", ctx do
+    status_root = Path.join(ctx.root, "status")
+
+    phase_config = %PhaseConfig{
+      phase: :execute,
+      agent_role: :executor,
+      tools: [:read, :edit],
+      gates: %{
+        structural: [:design_runtime_split_ok],
+        semantic: [],
+        human: [:commission_approved]
+      },
+      prompt_template_key: :execute,
+      max_turns: 20,
+      default_valid_until_days: 30
+    }
+
+    {:ok, orchestrator} =
+      StatusServer.start_link(%{
+        status: %{claimed: [], running: [phase_config], pending_human: [], retries: %{}},
+        human_gates: []
+      })
+
+    {:ok, _writer} =
+      RuntimeStatusWriter.start_link(
+        orchestrator: orchestrator,
+        path: status_root,
+        metadata: %{commission_id: "wc/struct-2"},
+        interval_ms: 0
+      )
+
+    status_path = Path.join(status_root, "wc_struct-2.json")
+    status = read_status(status_path)
+
+    assert get_in(status, ["orchestrator", "running", Access.at(0), "phase"]) == "execute"
+
+    assert get_in(status, ["orchestrator", "running", Access.at(0), "agent_role"]) ==
+             "executor"
+
+    assert get_in(status, ["orchestrator", "running", Access.at(0), "tools"]) == ["read", "edit"]
   end
 
   test "legacy metadata keeps ticket_id scoped path and snapshot", ctx do


### PR DESCRIPTION
## Summary

- fix Open-Sleigh runtime log/status writers so struct payloads serialize cleanly
- tighten commission scope authorization for runtime tool mutations
- treat `allowed_paths` entries ending in `/` as recursive directory scopes for terminal diff validation

## Verification

- `go test ./internal/scopeauth`
- `cd open-sleigh && mix test test/open_sleigh/agent/adapter_scope_test.exs test/open_sleigh/agent/tool_runtime_test.exs test/open_sleigh/runtime_log_writer_test.exs test/open_sleigh/runtime_status_writer_test.exs`
