### PR TITLE
feat(drift): auto-baseline disposition floor (safety classifier) + em…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] — governance substrate pivot
+## [8.1.0] — 2026-06-06 — shared embedding runtime
 
 Architectural pivot recorded in
 `.haft/decisions/dec-20260525-v8-architecture-pivot-from-standalone-agent-to-g-bbe45cb7.md`.
@@ -44,6 +44,15 @@ plugged into Claude Code / Codex / OpenCode / Cursor over their native skill
 
 ### Added
 
+- **Shared Rust embedding sidecar daemon.** Local embeddings now use one
+  per-user/per-model `haft-embed` process instead of one model process per
+  `haft serve` instance. The Go embedding adapter first connects to a
+  user-owned Unix socket daemon keyed by binary/model/cache/dim; the first
+  client starts it under a lockfile, later Claude Code / Codex / MCP sessions
+  reuse the same loaded ONNX model. The socket directory is private to the
+  current user, sockets are `0600`, startup races are serialized, and the daemon
+  exits after an idle timeout so memory is released when agents stop using it.
+  The old stdio child-process adapter remains the fallback path.
 - **Code-graph retrieval — codegraph-parity lexical heuristics.** `haft_query`
   symbol seeds and the `search` action now tolerate typos (bounded edit
   distance), split compound identifiers (`getUserName` → get/user/name), stem
@@ -143,6 +152,19 @@ plugged into Claude Code / Codex / OpenCode / Cursor over their native skill
 - **Code drift surfaced in `/h-status` (H1)** — `haft_query(action="status")`
   reports decisions whose affected files changed since baseline, so drift is
   visible without a manual `/h-verify`.
+- **Auto-baseline disposition floor — safety classifier** (`dec-20260606-9b4a4c52`).
+  Pure deterministic classifier (`internal/artifact/autobaseline.go`) that maps
+  each drift report to one disposition by keying off the existing symbol-level
+  `SymbolVerdict`: provably-additive drift → auto-resolve-silent; a
+  modified/removed governed symbol (or deleted file) → stage-for-confirm;
+  anything unprovable (no baseline / unanalyzable) → surface-for-review.
+  Conservative by construction — a governed-symbol change can **never** be
+  silently auto-baselined, regression-pinned against the seeded harness-drain
+  removed-func case. This release ships the tested safety core only; acting on
+  the silent bucket (re-baseline + snapshot history for reversibility), the
+  staged confirm-digest surface, and the callee-closure monitoring extension are
+  deferred slices — the closure step waits on cross-package code-graph edges
+  (`note-20260606-90688835`).
 - **Context graph — code intelligence fused with the reasoning graph**
   (`dec-20260603-5825abc6`, plan `note-20260603-7d6632f1`). A code-graph
   (symbols + call/dispatch edges) built on the existing tree-sitter substrate,
@@ -335,6 +357,13 @@ plugged into Claude Code / Codex / OpenCode / Cursor over their native skill
 
 ### Changed
 
+- **Embedding startup is lazy and shared.** `haft serve` no longer prewarms the
+  FPF, per-project, or cross-project embedding layers just because an MCP client
+  connected. The model is loaded only when a semantic query actually needs it,
+  and multiple live `haft serve` processes share that one Rust sidecar when the
+  shared socket path is available. On any shared-daemon setup fault, recall
+  still degrades through the existing optional-embedding contract rather than
+  hard-failing.
 - **Embedding sidecar defaults to int8-quantized EmbeddingGemma.** The local
   `haft-embed` sidecar now defaults to `embeddinggemma-300m-q`: measured
   retrieval parity with the fp32 model (FPF card R@10 0.88, MRR ~0.73) at a

--- a/embed-sidecar/src/main.rs
+++ b/embed-sidecar/src/main.rs
@@ -1,10 +1,11 @@
 //! haft-embed — local embedding sidecar.
 //!
-//! Speaks newline-delimited JSON over stdio so haft can spawn it as a child
-//! process and stream embedding requests without a vector DB or a network hop.
+//! Speaks newline-delimited JSON over stdio or a Unix socket so haft can stream
+//! embedding requests without a vector DB or a network hop.
 //! Protocol:
-//!   - on startup, emits one handshake line: {"ready":true,"model":..,"dim":N}
-//!     (or {"ready":false,"error":..} + exit 1 if the model fails to load)
+//!   - on stdio startup, or on each socket connection, emits one handshake line:
+//!     {"ready":true,"model":..,"dim":N}
+//!     (or {"ready":false,"error":..} + exit 1 on stdio if the model fails)
 //!   - then, per input line: request  {"id":N,"task":"query|document|raw","texts":[..]}
 //!                           response {"id":N,"vectors":[[f32..]..]}  | {"id":N,"error":..}
 //!   - EOF on stdin -> exit 0.
@@ -13,8 +14,17 @@
 //! It exists only to AUGMENT that recall with semantic similarity — the
 //! decision graph stays primary (dec-20260605-fe77b358).
 
-use std::io::{self, BufRead, Write};
-use std::path::PathBuf;
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
@@ -40,6 +50,14 @@ struct Args {
     /// Show model-download progress on stderr (kept off so stdout stays a clean JSON stream).
     #[arg(long)]
     show_progress: bool,
+
+    /// Serve the same JSON protocol over this Unix socket instead of stdio.
+    #[arg(long)]
+    serve_socket: Option<PathBuf>,
+
+    /// Exit socket server mode after this many idle seconds. 0 = never exit.
+    #[arg(long, default_value_t = 1200)]
+    idle_timeout_secs: u64,
 }
 
 #[derive(Deserialize)]
@@ -61,7 +79,7 @@ enum Task {
     Raw,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 struct Handshake {
     ready: bool,
     model: String,
@@ -81,7 +99,9 @@ struct Response {
 
 fn resolve_model(name: &str) -> Result<EmbeddingModel> {
     match name.to_ascii_lowercase().replace('_', "-").as_str() {
-        "embeddinggemma-300m" | "embeddinggemma" | "gemma" => Ok(EmbeddingModel::EmbeddingGemma300M),
+        "embeddinggemma-300m" | "embeddinggemma" | "gemma" => {
+            Ok(EmbeddingModel::EmbeddingGemma300M)
+        }
         // Quantized EmbeddingGemma: same 768-native MRL model, int8/4-bit weights —
         // 3-4x faster CPU inference and a far smaller first-use download than fp32,
         // with near-identical retrieval quality. Same asymmetric prefixes apply.
@@ -132,7 +152,11 @@ impl Embedder {
 
         let probe = model.embed(vec!["x"], None).context("probe embedding")?;
         let native = probe.first().map(Vec::len).unwrap_or(0);
-        let dim = if args.dim > 0 && args.dim < native { args.dim } else { native };
+        let dim = if args.dim > 0 && args.dim < native {
+            args.dim
+        } else {
+            native
+        };
         Ok(Self { model, dim })
     }
 
@@ -153,12 +177,24 @@ fn handle_line(embedder: &mut Embedder, line: &str) -> Response {
     let request: Request = match serde_json::from_str(line) {
         Ok(request) => request,
         Err(err) => {
-            return Response { id: 0, vectors: None, error: Some(format!("bad request json: {err}")) }
+            return Response {
+                id: 0,
+                vectors: None,
+                error: Some(format!("bad request json: {err}")),
+            }
         }
     };
     match embedder.embed(request.task, &request.texts) {
-        Ok(vectors) => Response { id: request.id, vectors: Some(vectors), error: None },
-        Err(err) => Response { id: request.id, vectors: None, error: Some(format!("{err:#}")) },
+        Ok(vectors) => Response {
+            id: request.id,
+            vectors: Some(vectors),
+            error: None,
+        },
+        Err(err) => Response {
+            id: request.id,
+            vectors: None,
+            error: Some(format!("{err:#}")),
+        },
     }
 }
 
@@ -166,6 +202,13 @@ fn handle_line(embedder: &mut Embedder, line: &str) -> Response {
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    if let Some(socket) = &args.serve_socket {
+        return run_socket(&args, socket);
+    }
+    run_stdio(&args)
+}
+
+fn run_stdio(args: &Args) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
@@ -179,7 +222,11 @@ fn main() -> Result<()> {
         }
     };
 
-    let handshake = Handshake { ready: true, model: args.model.clone(), dim: embedder.dim };
+    let handshake = Handshake {
+        ready: true,
+        model: args.model.clone(),
+        dim: embedder.dim,
+    };
     writeln!(out, "{}", serde_json::to_string(&handshake)?)?;
     out.flush()?;
 
@@ -194,4 +241,152 @@ fn main() -> Result<()> {
         out.flush()?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn run_socket(args: &Args, socket: &Path) -> Result<()> {
+    let embedder = Embedder::load(args).context("load embedding daemon")?;
+    let handshake = Handshake {
+        ready: true,
+        model: args.model.clone(),
+        dim: embedder.dim,
+    };
+
+    if socket.exists() {
+        std::fs::remove_file(socket)
+            .with_context(|| format!("remove stale socket {}", socket.display()))?;
+    }
+    let listener =
+        UnixListener::bind(socket).with_context(|| format!("bind socket {}", socket.display()))?;
+    std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("secure socket {}", socket.display()))?;
+    listener
+        .set_nonblocking(true)
+        .context("set socket nonblocking")?;
+
+    let embedder = Arc::new(Mutex::new(embedder));
+    let active = Arc::new(AtomicUsize::new(0));
+    let last_activity = Arc::new(Mutex::new(Instant::now()));
+    let idle_timeout = Duration::from_secs(args.idle_timeout_secs);
+
+    loop {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                stream
+                    .set_nonblocking(false)
+                    .context("set client socket blocking")?;
+                mark_activity(&last_activity);
+                spawn_client(
+                    stream,
+                    embedder.clone(),
+                    handshake.clone(),
+                    active.clone(),
+                    last_activity.clone(),
+                );
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                if should_exit_idle(&active, &last_activity, idle_timeout) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => return Err(err).context("accept socket client"),
+        }
+    }
+
+    let _ = std::fs::remove_file(socket);
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn run_socket(_args: &Args, _socket: &Path) -> Result<()> {
+    Err(anyhow!(
+        "socket server mode is only supported on Unix platforms"
+    ))
+}
+
+#[cfg(unix)]
+fn spawn_client(
+    stream: UnixStream,
+    embedder: Arc<Mutex<Embedder>>,
+    handshake: Handshake,
+    active: Arc<AtomicUsize>,
+    last_activity: Arc<Mutex<Instant>>,
+) {
+    active.fetch_add(1, Ordering::SeqCst);
+    thread::spawn(move || {
+        let _guard = ActiveClient { active };
+        if let Err(err) = handle_client(stream, embedder, handshake, last_activity) {
+            eprintln!("haft-embed client error: {err:#}");
+        }
+    });
+}
+
+#[cfg(unix)]
+struct ActiveClient {
+    active: Arc<AtomicUsize>,
+}
+
+#[cfg(unix)]
+impl Drop for ActiveClient {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(unix)]
+fn handle_client(
+    stream: UnixStream,
+    embedder: Arc<Mutex<Embedder>>,
+    handshake: Handshake,
+    last_activity: Arc<Mutex<Instant>>,
+) -> Result<()> {
+    let reader_stream = stream.try_clone().context("clone socket stream")?;
+    let mut reader = BufReader::new(reader_stream);
+    let mut out = stream;
+
+    writeln!(out, "{}", serde_json::to_string(&handshake)?)?;
+    out.flush()?;
+
+    loop {
+        let mut line = String::new();
+        let bytes = reader.read_line(&mut line).context("read socket request")?;
+        if bytes == 0 {
+            return Ok(());
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        mark_activity(&last_activity);
+        let response = {
+            let mut guard = embedder
+                .lock()
+                .map_err(|_| anyhow!("embedding model lock poisoned"))?;
+            handle_line(&mut guard, &line)
+        };
+        writeln!(out, "{}", serde_json::to_string(&response)?)?;
+        out.flush()?;
+    }
+}
+
+#[cfg(unix)]
+fn mark_activity(last_activity: &Arc<Mutex<Instant>>) {
+    if let Ok(mut last) = last_activity.lock() {
+        *last = Instant::now();
+    }
+}
+
+#[cfg(unix)]
+fn should_exit_idle(
+    active: &Arc<AtomicUsize>,
+    last_activity: &Arc<Mutex<Instant>>,
+    idle_timeout: Duration,
+) -> bool {
+    if idle_timeout.is_zero() || active.load(Ordering::SeqCst) > 0 {
+        return false;
+    }
+    last_activity
+        .lock()
+        .map(|last| last.elapsed() >= idle_timeout)
+        .unwrap_or(false)
 }

--- a/internal/artifact/autobaseline.go
+++ b/internal/artifact/autobaseline.go
@@ -1,0 +1,95 @@
+package artifact
+
+// Auto-baseline disposition floor (dec-20260606-9b4a4c52).
+//
+// This is the SAFETY core of the conservative auto-baseline gate: a pure,
+// deterministic mapping from a decision's drift report to one of three
+// dispositions. It keys off the kernel-computed SymbolVerdict (the symbol-level
+// floor from dec-20260605-413e2600) and is conservative by construction —
+// a governed-symbol change can NEVER map to AutoResolveSilent.
+//
+// What this file intentionally does NOT do (separate slices, by design):
+//   - It does not mutate any baseline. Acting on AutoResolveSilent (re-baseline
+//     + prior-snapshot retention for reversibility) is the mutation slice.
+//   - It does not extend monitoring to a governed symbol's callee-closure. The
+//     closure refinement (note-20260606-694247bb) is deferred while the code
+//     graph is intra-package only (cross-package edges = P1b, not yet built),
+//     so over the current graph it is a recall tweak, not a safety guarantee.
+//
+// The disposition floor here is the part that makes the operator's requirement
+// true regardless of those slices: drift touching a governed symbol is never
+// silently blessed.
+
+// AutoBaselineAction is the deterministic disposition of one decision's drift
+// under the conservative floor.
+type AutoBaselineAction string
+
+const (
+	// AutoResolveSilent: every drift is provably additive (new symbols only).
+	// Safe to re-baseline without operator review. By construction this is
+	// never assigned to a governed-symbol modification/removal/file-deletion.
+	AutoResolveSilent AutoBaselineAction = "auto_resolve_silent"
+	// StageForConfirm: a governed symbol body was modified/removed (or a file
+	// deleted). Staged into the confirm-digest — visible and reversible, never
+	// silently baselined.
+	StageForConfirm AutoBaselineAction = "stage_for_confirm"
+	// SurfaceForReview: benignity could not be proven (no baseline, no symbol
+	// evidence, unanalyzable change). Fail-safe to the operator.
+	SurfaceForReview AutoBaselineAction = "surface_for_review"
+)
+
+// DriftDisposition pairs a drift report with its deterministic action + reason.
+type DriftDisposition struct {
+	Report DriftReport
+	Action AutoBaselineAction
+	Reason string
+}
+
+// verdictToAction is the table-driven core: each kernel verdict has exactly one
+// disposition. Keeping it a table (not branching) makes the total mapping
+// auditable at a glance and keeps the safety property obvious — governed_modified
+// maps to StageForConfirm, never AutoResolveSilent.
+var verdictToAction = map[string]struct {
+	action AutoBaselineAction
+	reason string
+}{
+	SymbolVerdictAdditiveOnly:     {AutoResolveSilent, "every drift is provably additive (new symbols only)"},
+	SymbolVerdictGovernedModified: {StageForConfirm, "a governed symbol body was modified/removed or a file was deleted"},
+	SymbolVerdictNeedsReview:      {SurfaceForReview, "benignity could not be proven (no symbol evidence / unanalyzable)"},
+}
+
+// ClassifyAutoBaseline maps each drift report to its deterministic disposition.
+// Pure and side-effect-free: no store, no filesystem, no agent judgment.
+func ClassifyAutoBaseline(reports []DriftReport) []DriftDisposition {
+	out := make([]DriftDisposition, 0, len(reports))
+	for _, r := range reports {
+		out = append(out, classifyOne(r))
+	}
+	return out
+}
+
+// classifyOne applies the fail-safe precondition then the verdict table.
+func classifyOne(r DriftReport) DriftDisposition {
+	// Fail-safe precondition: a report with no baseline cannot be proven benign,
+	// independent of any symbol verdict.
+	if !r.HasBaseline {
+		return DriftDisposition{Report: r, Action: SurfaceForReview, Reason: "no baseline to compare against — fail-safe to review"}
+	}
+	ar := verdictToAction[r.SymbolVerdict()]
+	return DriftDisposition{Report: r, Action: ar.action, Reason: ar.reason}
+}
+
+// PartitionDispositions splits dispositions into the three action buckets in a
+// single pass — the shape the confirm-digest renders from.
+func PartitionDispositions(ds []DriftDisposition) (silent, confirm, review []DriftDisposition) {
+	bucket := map[AutoBaselineAction]*[]DriftDisposition{
+		AutoResolveSilent: &silent,
+		StageForConfirm:   &confirm,
+		SurfaceForReview:  &review,
+	}
+	for _, d := range ds {
+		b := bucket[d.Action]
+		*b = append(*b, d)
+	}
+	return silent, confirm, review
+}

--- a/internal/artifact/autobaseline_test.go
+++ b/internal/artifact/autobaseline_test.go
@@ -1,0 +1,169 @@
+package artifact
+
+import "testing"
+
+// helpers mirroring symbol_drift_test.go style
+func tdAdded(name string) SymbolDriftItem {
+	return SymbolDriftItem{SymbolName: name, SymbolKind: "func", Status: "added"}
+}
+func tdModified(name string) SymbolDriftItem {
+	return SymbolDriftItem{SymbolName: name, SymbolKind: "func", Status: "modified"}
+}
+func tdRemoved(name string) SymbolDriftItem {
+	return SymbolDriftItem{SymbolName: name, SymbolKind: "func", Status: "removed"}
+}
+
+// TestClassifyAutoBaseline_VerdictMapping pins the table: each kernel verdict
+// maps to exactly one disposition, and the safety-critical one (governed_modified)
+// never becomes AutoResolveSilent.
+func TestClassifyAutoBaseline_VerdictMapping(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []DriftItem
+		want  AutoBaselineAction
+	}{
+		{
+			name:  "additive-only resolves silently",
+			files: []DriftItem{{Path: "a.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdAdded("Foo")}}},
+			want:  AutoResolveSilent,
+		},
+		{
+			name:  "added file resolves silently",
+			files: []DriftItem{{Path: "new.go", Status: DriftAdded}},
+			want:  AutoResolveSilent,
+		},
+		{
+			name:  "modified governed symbol stages for confirm",
+			files: []DriftItem{{Path: "a.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdModified("Bar")}}},
+			want:  StageForConfirm,
+		},
+		{
+			name:  "removed governed symbol stages for confirm",
+			files: []DriftItem{{Path: "a.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdRemoved("Bar")}}},
+			want:  StageForConfirm,
+		},
+		{
+			name:  "deleted file stages for confirm",
+			files: []DriftItem{{Path: "gone.go", Status: DriftMissing}},
+			want:  StageForConfirm,
+		},
+		{
+			name:  "unanalyzable change surfaces for review",
+			files: []DriftItem{{Path: "a.bin", Status: DriftModified}},
+			want:  SurfaceForReview,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := DriftReport{HasBaseline: true, Files: tc.files}
+			got := ClassifyAutoBaseline([]DriftReport{r})
+			if len(got) != 1 {
+				t.Fatalf("expected 1 disposition, got %d", len(got))
+			}
+			if got[0].Action != tc.want {
+				t.Fatalf("Action = %q, want %q (reason: %s)", got[0].Action, tc.want, got[0].Reason)
+			}
+		})
+	}
+}
+
+// TestClassifyAutoBaseline_SeededHarnessDrainSurfaces is the regression test
+// named in dec-20260606-9b4a4c52 prediction #2: the harness-drain decision's
+// governed func canApplyHarnessWorkspaceDiff was REMOVED; that drift must stage
+// for confirm and must NEVER be silently auto-baselined.
+func TestClassifyAutoBaseline_SeededHarnessDrainSurfaces(t *testing.T) {
+	harnessDrain := DriftReport{
+		DecisionID:    "dec-20260428-harness-drain-v3-16bf21f3",
+		DecisionTitle: "Per-WorkCommission delivery_policy as the apply-authority gate for batch drain mode",
+		HasBaseline:   true,
+		Files: []DriftItem{
+			{
+				Path:    "internal/cli/harness.go",
+				Status:  DriftModified,
+				Symbols: []SymbolDriftItem{tdRemoved("canApplyHarnessWorkspaceDiff")},
+			},
+		},
+	}
+	got := ClassifyAutoBaseline([]DriftReport{harnessDrain})
+	if got[0].Action == AutoResolveSilent {
+		t.Fatalf("SAFETY VIOLATION: removed governed func was silently auto-baselined")
+	}
+	if got[0].Action != StageForConfirm {
+		t.Fatalf("Action = %q, want %q", got[0].Action, StageForConfirm)
+	}
+}
+
+// TestClassifyAutoBaseline_NeverSilentlyResolvesGoverned is the property behind
+// prediction #3: across any report whose kernel verdict is governed_modified,
+// the disposition is never AutoResolveSilent.
+func TestClassifyAutoBaseline_NeverSilentlyResolvesGoverned(t *testing.T) {
+	governed := []DriftReport{
+		{HasBaseline: true, Files: []DriftItem{{Path: "a.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdModified("X")}}}},
+		{HasBaseline: true, Files: []DriftItem{{Path: "b.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdRemoved("Y")}}}},
+		{HasBaseline: true, Files: []DriftItem{{Path: "c.go", Status: DriftMissing}}},
+		{HasBaseline: true, Files: []DriftItem{
+			{Path: "a.go", Status: DriftAdded},
+			{Path: "b.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdModified("Z")}},
+		}},
+	}
+	for _, d := range ClassifyAutoBaseline(governed) {
+		if d.Action == AutoResolveSilent {
+			t.Fatalf("SAFETY VIOLATION: governed_modified report mapped to AutoResolveSilent: %+v", d.Report)
+		}
+	}
+}
+
+// TestClassifyAutoBaseline_NoBaselineFailsSafe: no baseline => cannot prove
+// benign => surface, regardless of file shape.
+func TestClassifyAutoBaseline_NoBaselineFailsSafe(t *testing.T) {
+	r := DriftReport{HasBaseline: false, Files: []DriftItem{{Path: "a.go", Status: DriftAdded}}}
+	got := ClassifyAutoBaseline([]DriftReport{r})
+	if got[0].Action != SurfaceForReview {
+		t.Fatalf("Action = %q, want %q", got[0].Action, SurfaceForReview)
+	}
+}
+
+// TestClassifyAutoBaseline_CorpusReplay models this session's drift corpus shape
+// (a mix of additive churn, freshly-shipped governed changes, and one seeded
+// breakage) and asserts the safety invariant holds across the whole set: no
+// governed change is ever in the silent bucket.
+func TestClassifyAutoBaseline_CorpusReplay(t *testing.T) {
+	corpus := []DriftReport{}
+	// 11 "additive / shared-file churn" decisions -> silent
+	for range 11 {
+		corpus = append(corpus, DriftReport{
+			HasBaseline: true,
+			Files:       []DriftItem{{Path: "shared.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdAdded("New")}}},
+		})
+	}
+	// 13 "freshly-shipped governed" decisions -> stage for confirm
+	for range 13 {
+		corpus = append(corpus, DriftReport{
+			HasBaseline: true,
+			Files:       []DriftItem{{Path: "impl.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdModified("Impl")}}},
+		})
+	}
+	// 1 seeded true breakage (removed governed func) -> stage for confirm
+	corpus = append(corpus, DriftReport{
+		HasBaseline: true,
+		Files:       []DriftItem{{Path: "harness.go", Status: DriftModified, Symbols: []SymbolDriftItem{tdRemoved("canApplyHarnessWorkspaceDiff")}}},
+	})
+
+	silent, confirm, review := PartitionDispositions(ClassifyAutoBaseline(corpus))
+
+	if len(silent) != 11 {
+		t.Fatalf("silent bucket = %d, want 11", len(silent))
+	}
+	if len(confirm) != 14 {
+		t.Fatalf("confirm bucket = %d, want 14", len(confirm))
+	}
+	if len(review) != 0 {
+		t.Fatalf("review bucket = %d, want 0", len(review))
+	}
+	// Safety invariant: nothing in the silent bucket is a governed change.
+	for _, d := range silent {
+		if d.Report.SymbolVerdict() == SymbolVerdictGovernedModified {
+			t.Fatalf("SAFETY VIOLATION: governed change in silent bucket")
+		}
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -134,10 +134,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 				searcher := buildHybridSearcher(artStore, database.GetRawDB())
 				crossHybrid := buildCrossProjectHybrid(indexStore)
 
-				if hybrid := ensureFPFHybrid(); hybrid != nil {
-					hybrid.Prewarm() // background-load the baked FPF vectors so the first fpf search is fast
-				}
-
 				server.SetV5Handler(makeV5Handler(artStore, searcher, crossHybrid, haftDir, projCfg, indexStore))
 			}
 		}
@@ -158,8 +154,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 // buildHybridSearcher wires the optional embedding layer over the artifact
 // store. The embedder is resolved lazily on first search, so startup never
-// blocks on a first-run model download. A nil result (provider disabled or any
-// setup fault) means search runs FTS5+PPR only — recall never hard-fails on the
+// blocks on a first-run model download or spawns an embedding sidecar just
+// because an MCP client connected. A nil result (provider disabled or any setup
+// fault) means search runs FTS5+PPR only — recall never hard-fails on the
 // optional layer (dec-20260605-fe77b358).
 func buildHybridSearcher(store *artifact.Store, rawDB *sql.DB) recall.Searcher {
 	embCfg := embeddingConfigFromFile()
@@ -188,7 +185,6 @@ func buildHybridSearcher(store *artifact.Store, rawDB *sql.DB) recall.Searcher {
 	}
 
 	hybrid := recall.NewHybrid(store, newEmbedder, rawDB)
-	hybrid.Prewarm() // warm the corpus index in the background so the first search is fast
 	return hybrid
 }
 
@@ -214,6 +210,8 @@ func embeddingConfigFromFile() embedding.Config {
 // buildCrossProjectHybrid wires the optional embedding layer over the
 // cross-project index, mirroring buildHybridSearcher. nil (provider disabled /
 // no index) means cross-project recall runs the FTS path (now AND+OR) only.
+// The embedder is intentionally lazy so a single MCP server does not load an
+// additional ONNX model before the operator asks for cross-project recall.
 func buildCrossProjectHybrid(indexStore *project.IndexStore) *project.CrossHybrid {
 	if indexStore == nil {
 		return nil
@@ -235,7 +233,6 @@ func buildCrossProjectHybrid(indexStore *project.IndexStore) *project.CrossHybri
 		return embedder, nil
 	}
 	hybrid := project.NewCrossHybrid(indexStore, newEmbedder)
-	hybrid.Prewarm() // background-warm the cross-project index so the first frame recall is fast
 	return hybrid
 }
 

--- a/internal/embedding/sidecar.go
+++ b/internal/embedding/sidecar.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/m0n0x41d/haft/logger"
@@ -31,11 +32,12 @@ const (
 	DefaultLocalModel = "embeddinggemma-300m-q"
 )
 
-// sidecarAdapter is the local Embedder adapter: it owns a long-lived haft-embed
-// child process (the model loads once) and serializes request/response lines
-// over its stdio pipe. It is self-healing — if the process faults mid-session it
-// respawns once and retries, so a sidecar crash costs a single failed query, not
-// FTS5+PPR for the rest of the session. Implements the Embedder port.
+// sidecarAdapter is the stdio local Embedder adapter: it owns a long-lived
+// haft-embed child process (the model loads once) and serializes
+// request/response lines over its stdio pipe. It is self-healing — if the
+// process faults mid-session it respawns once and retries, so a sidecar crash
+// costs a single failed query, not FTS5+PPR for the rest of the session.
+// Implements the Embedder port.
 type sidecarAdapter struct {
 	binary string
 	args   []string
@@ -69,22 +71,45 @@ type sidecarHandshake struct {
 	Error string `json:"error"`
 }
 
+type sidecarSpec struct {
+	Model    string
+	CacheDir string
+	Dim      int
+	Args     []string
+}
+
 func newSidecarAdapter(cfg Config) (Embedder, error) {
 	binary, ok := locateSidecar()
 	if !ok {
 		return nil, ErrSidecarUnavailable
 	}
 
+	spec := sidecarSpecFromConfig(cfg)
+	if sharedSidecarEnabled() {
+		adapter, err := newSharedSidecarAdapter(binary, spec)
+		if err == nil {
+			return adapter, nil
+		}
+		logger.Info().Err(err).Msg("shared embedding sidecar unavailable — falling back to stdio child")
+	}
+	return newStdioSidecarAdapter(binary, spec)
+}
+
+func sidecarSpecFromConfig(cfg Config) sidecarSpec {
 	model := cfg.Model
 	if model == "" {
 		model = DefaultLocalModel
 	}
-	args := []string{"--model", model, "--cache-dir", resolveCacheDir(cfg.CacheDir)}
+	cacheDir := resolveCacheDir(cfg.CacheDir)
+	args := []string{"--model", model, "--cache-dir", cacheDir}
 	if cfg.Dim > 0 {
 		args = append(args, "--dim", strconv.Itoa(cfg.Dim))
 	}
+	return sidecarSpec{Model: model, CacheDir: cacheDir, Dim: cfg.Dim, Args: args}
+}
 
-	adapter := &sidecarAdapter{binary: binary, args: args}
+func newStdioSidecarAdapter(binary string, spec sidecarSpec) (Embedder, error) {
+	adapter := &sidecarAdapter{binary: binary, args: spec.Args}
 	adapter.mu.Lock()
 	err := adapter.spawn()
 	adapter.mu.Unlock()
@@ -270,6 +295,19 @@ func resolveCacheDir(configured string) string {
 
 // sidecarBinaryEnv overrides binary discovery with an explicit path.
 const sidecarBinaryEnv = "HAFT_EMBED_BIN"
+
+// sharedSidecarEnv disables per-user daemon sharing when set to 0/false/no.
+const sharedSidecarEnv = "HAFT_EMBED_SHARED"
+
+func sharedSidecarEnabled() bool {
+	value := strings.TrimSpace(os.Getenv(sharedSidecarEnv))
+	switch strings.ToLower(value) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
 
 // locateSidecar resolves the haft-embed binary: an explicit HAFT_EMBED_BIN
 // override, then the installed runtime location (mirroring open-sleigh under

--- a/internal/embedding/sidecar_respawn_test.go
+++ b/internal/embedding/sidecar_respawn_test.go
@@ -34,6 +34,7 @@ func TestSidecarRespawnsAfterFault(t *testing.T) {
 		t.Fatalf("write fake sidecar: %v", err)
 	}
 	t.Setenv(sidecarBinaryEnv, path)
+	t.Setenv(sharedSidecarEnv, "0")
 
 	embedder, err := New(Config{Provider: ProviderLocal})
 	if err != nil {

--- a/internal/embedding/sidecar_shared_other.go
+++ b/internal/embedding/sidecar_shared_other.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package embedding
+
+import "errors"
+
+func newSharedSidecarAdapter(_ string, _ sidecarSpec) (Embedder, error) {
+	return nil, errors.New("shared embedding sidecar is unsupported on this platform")
+}

--- a/internal/embedding/sidecar_shared_unix.go
+++ b/internal/embedding/sidecar_shared_unix.go
@@ -1,0 +1,393 @@
+//go:build !windows
+
+package embedding
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/m0n0x41d/haft/logger"
+)
+
+const (
+	sharedSidecarProtocolVersion = "v1"
+	sharedSocketDirEnv           = "HAFT_EMBED_SOCKET_DIR"
+	sharedIdleTimeoutEnv         = "HAFT_EMBED_IDLE_TIMEOUT_SECS"
+	sharedStartupTimeoutEnv      = "HAFT_EMBED_STARTUP_TIMEOUT_SECS"
+	defaultSharedIdleTimeout     = 20 * time.Minute
+	defaultSharedStartupTimeout  = 10 * time.Minute
+)
+
+type sharedSidecarAdapter struct {
+	binary string
+	spec   sidecarSpec
+	socket string
+
+	mu     sync.Mutex
+	conn   io.ReadWriteCloser
+	reader *bufio.Reader
+	nextID uint64
+	desc   Descriptor
+	closed bool
+}
+
+type sharedDaemonStart struct {
+	cmd  *exec.Cmd
+	done <-chan error
+}
+
+func newSharedSidecarAdapter(binary string, spec sidecarSpec) (Embedder, error) {
+	adapter, err := connectOrStartSharedSidecar(binary, spec)
+	if err != nil {
+		return nil, err
+	}
+	return adapter, nil
+}
+
+func connectOrStartSharedSidecar(binary string, spec sidecarSpec) (*sharedSidecarAdapter, error) {
+	socket, lock, err := sharedSidecarPaths(binary, spec)
+	if err != nil {
+		return nil, err
+	}
+	if adapter, err := dialSharedSidecar(binary, spec, socket); err == nil {
+		return adapter, nil
+	}
+
+	return withSharedSidecarLock(lock, func() (*sharedSidecarAdapter, error) {
+		if adapter, err := dialSharedSidecar(binary, spec, socket); err == nil {
+			return adapter, nil
+		}
+		_ = os.Remove(socket)
+		started, err := startSharedSidecarDaemon(binary, spec, socket)
+		if err != nil {
+			return nil, err
+		}
+		return waitForSharedSidecar(binary, spec, socket, started)
+	})
+}
+
+func withSharedSidecarLock(
+	lockPath string,
+	fn func() (*sharedSidecarAdapter, error),
+) (*sharedSidecarAdapter, error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open shared sidecar lock: %w", err)
+	}
+	defer file.Close()
+	_ = file.Chmod(0o600)
+
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		return nil, fmt.Errorf("lock shared sidecar: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}
+
+func dialSharedSidecar(binary string, spec sidecarSpec, socket string) (*sharedSidecarAdapter, error) {
+	conn, err := net.DialTimeout("unix", socket, 500*time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	_ = conn.SetDeadline(deadline)
+	reader := bufio.NewReader(conn)
+	handshake, err := readHandshake(reader)
+	_ = conn.SetDeadline(time.Time{})
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err := validateSharedHandshake(spec, handshake); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	return &sharedSidecarAdapter{
+		binary: binary,
+		spec:   spec,
+		socket: socket,
+		conn:   conn,
+		reader: reader,
+		desc: Descriptor{
+			Provider:   ProviderLocal,
+			Model:      handshake.Model,
+			Dimensions: handshake.Dim,
+		},
+	}, nil
+}
+
+func validateSharedHandshake(spec sidecarSpec, handshake sidecarHandshake) error {
+	if handshake.Model != spec.Model {
+		return fmt.Errorf("shared sidecar model = %q, want %q", handshake.Model, spec.Model)
+	}
+	if spec.Dim > 0 && handshake.Dim != spec.Dim {
+		return fmt.Errorf("shared sidecar dim = %d, want %d", handshake.Dim, spec.Dim)
+	}
+	return nil
+}
+
+func startSharedSidecarDaemon(
+	binary string,
+	spec sidecarSpec,
+	socket string,
+) (sharedDaemonStart, error) {
+	args := append([]string{}, spec.Args...)
+	args = append(args, "--serve-socket", socket)
+	args = append(args, "--idle-timeout-secs", strconv.Itoa(sharedIdleTimeoutSecs()))
+
+	cmd := exec.Command(binary, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return sharedDaemonStart{}, fmt.Errorf("start shared sidecar: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			logger.Info().Err(err).Msg("shared embedding sidecar exited")
+		}
+		done <- err
+	}()
+
+	return sharedDaemonStart{cmd: cmd, done: done}, nil
+}
+
+func waitForSharedSidecar(
+	binary string,
+	spec sidecarSpec,
+	socket string,
+	started sharedDaemonStart,
+) (*sharedSidecarAdapter, error) {
+	timeout := sharedStartupTimeout()
+	deadline := time.Now().Add(timeout)
+	for {
+		if adapter, err := dialSharedSidecar(binary, spec, socket); err == nil {
+			logger.Info().
+				Int("pid", started.cmd.Process.Pid).
+				Str("model", adapter.desc.Model).
+				Int("dim", adapter.desc.Dimensions).
+				Msg("shared embedding sidecar started")
+			return adapter, nil
+		}
+
+		select {
+		case err := <-started.done:
+			if err == nil {
+				return nil, errors.New("shared sidecar exited before opening socket")
+			}
+			return nil, fmt.Errorf("shared sidecar exited before opening socket: %w", err)
+		default:
+		}
+
+		if timeout > 0 && time.Now().After(deadline) {
+			_ = started.cmd.Process.Kill()
+			return nil, errors.New("shared sidecar startup timed out")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func sharedIdleTimeoutSecs() int {
+	duration := durationFromEnv(sharedIdleTimeoutEnv, defaultSharedIdleTimeout)
+	return int(duration / time.Second)
+}
+
+func sharedStartupTimeout() time.Duration {
+	return durationFromEnv(sharedStartupTimeoutEnv, defaultSharedStartupTimeout)
+}
+
+func durationFromEnv(name string, fallback time.Duration) time.Duration {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds < 0 {
+		return fallback
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func sharedSidecarPaths(binary string, spec sidecarSpec) (socket string, lock string, err error) {
+	dir, err := sharedSidecarDir()
+	if err != nil {
+		return "", "", err
+	}
+	key := sharedSidecarKey(binary, spec)
+	return filepath.Join(dir, key+".sock"), filepath.Join(dir, key+".lock"), nil
+}
+
+func sharedSidecarKey(binary string, spec sidecarSpec) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(sharedSidecarProtocolVersion))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(binary))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(spec.Model))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(spec.CacheDir))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strconv.Itoa(spec.Dim)))
+	sum := hex.EncodeToString(hash.Sum(nil))
+	return "embed-" + sum[:16]
+}
+
+func sharedSidecarDir() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(sharedSocketDirEnv)); override != "" {
+		return ensurePrivateDir(override)
+	}
+	parent := filepath.Join("/tmp", fmt.Sprintf("haft-%d", os.Getuid()))
+	dir, err := ensurePrivateDir(parent)
+	if err != nil {
+		return "", err
+	}
+	return ensurePrivateDir(filepath.Join(dir, "embed"))
+}
+
+func ensurePrivateDir(dir string) (string, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create private dir %s: %w", dir, err)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", fmt.Errorf("stat private dir %s: %w", dir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("private dir %s is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("private dir %s is not a directory", dir)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return "", fmt.Errorf("chmod private dir %s: %w", dir, err)
+	}
+	if err := validatePrivateDir(dir); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func validatePrivateDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat private dir %s: %w", dir, err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("private dir %s is accessible by group/other", dir)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if ok && int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("private dir %s is not owned by current user", dir)
+	}
+	return nil
+}
+
+func (a *sharedSidecarAdapter) Descriptor() Descriptor {
+	return a.desc
+}
+
+func (a *sharedSidecarAdapter) Embed(
+	ctx context.Context,
+	role Role,
+	texts []string,
+) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return nil, errors.New("embedding sidecar closed")
+	}
+
+	vectors, err := a.embedOnce(role, texts)
+	if err == nil {
+		return vectors, nil
+	}
+	logger.Warn().Err(err).Msg("shared embedding sidecar connection faulted — reconnecting")
+	if err := a.reconnectLocked(); err != nil {
+		return nil, fmt.Errorf("shared sidecar reconnect failed: %w", err)
+	}
+	return a.embedOnce(role, texts)
+}
+
+func (a *sharedSidecarAdapter) embedOnce(role Role, texts []string) ([][]float32, error) {
+	a.nextID++
+	request := sidecarRequest{ID: a.nextID, Task: taskFor(role), Texts: texts}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("encode embed request: %w", err)
+	}
+	if _, err := a.conn.Write(append(payload, '\n')); err != nil {
+		return nil, fmt.Errorf("write embed request: %w", err)
+	}
+
+	line, err := a.reader.ReadBytes('\n')
+	if err != nil {
+		return nil, fmt.Errorf("read embed response: %w", err)
+	}
+	var response sidecarResponse
+	if err := json.Unmarshal(line, &response); err != nil {
+		return nil, fmt.Errorf("decode embed response: %w", err)
+	}
+	if response.Error != "" {
+		return nil, fmt.Errorf("sidecar embed: %s", response.Error)
+	}
+	if len(response.Vectors) != len(texts) {
+		return nil, fmt.Errorf("sidecar returned %d vectors for %d texts", len(response.Vectors), len(texts))
+	}
+	return response.Vectors, nil
+}
+
+func (a *sharedSidecarAdapter) reconnectLocked() error {
+	if a.conn != nil {
+		_ = a.conn.Close()
+	}
+	adapter, err := connectOrStartSharedSidecar(a.binary, a.spec)
+	if err != nil {
+		return err
+	}
+	a.conn = adapter.conn
+	a.reader = adapter.reader
+	a.desc = adapter.desc
+	return nil
+}
+
+func (a *sharedSidecarAdapter) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return nil
+	}
+	a.closed = true
+	if a.conn != nil {
+		return a.conn.Close()
+	}
+	return nil
+}

--- a/internal/embedding/sidecar_shared_unix.go
+++ b/internal/embedding/sidecar_shared_unix.go
@@ -92,12 +92,20 @@ func withSharedSidecarLock(
 	defer file.Close()
 	_ = file.Chmod(0o600)
 
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+	if err := flockFile(file, syscall.LOCK_EX); err != nil {
 		return nil, fmt.Errorf("lock shared sidecar: %w", err)
 	}
-	defer func() { _ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) }()
+	defer func() { _ = flockFile(file, syscall.LOCK_UN) }()
 
 	return fn()
+}
+
+func flockFile(file *os.File, how int) error {
+	fd := file.Fd()
+	if fd > (^uintptr(0) >> 1) {
+		return fmt.Errorf("file descriptor %d exceeds int range", fd)
+	}
+	return syscall.Flock(int(fd), how) // #nosec G115 -- fd is range-checked above.
 }
 
 func dialSharedSidecar(binary string, spec sidecarSpec, socket string) (*sharedSidecarAdapter, error) {

--- a/internal/embedding/sidecar_shared_unix_test.go
+++ b/internal/embedding/sidecar_shared_unix_test.go
@@ -1,0 +1,214 @@
+//go:build !windows
+
+package embedding
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSharedSidecarReusesOneDaemon(t *testing.T) {
+	helper := writeSharedSidecarHelper(t)
+	socketDir := filepath.Join("/tmp", fmt.Sprintf("haft-test-%d-%d", os.Getpid(), time.Now().UnixNano()))
+	startLog := filepath.Join(t.TempDir(), "starts.log")
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+
+	t.Setenv(sidecarBinaryEnv, helper)
+	t.Setenv(sharedSocketDirEnv, socketDir)
+	t.Setenv(sharedIdleTimeoutEnv, "1")
+	t.Setenv(sharedStartupTimeoutEnv, "5")
+	t.Setenv("HAFT_TEST_SHARED_SIDECAR_STARTS", startLog)
+
+	first, err := New(Config{Provider: ProviderLocal, Model: "fake", Dim: 2})
+	if err != nil {
+		t.Fatalf("first New(local): %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	second, err := New(Config{Provider: ProviderLocal, Model: "fake", Dim: 2})
+	if err != nil {
+		t.Fatalf("second New(local): %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	firstVectors, err := first.Embed(context.Background(), RoleQuery, []string{"alpha"})
+	if err != nil {
+		t.Fatalf("first embed: %v", err)
+	}
+	secondVectors, err := second.Embed(context.Background(), RoleDocument, []string{"beta"})
+	if err != nil {
+		t.Fatalf("second embed: %v", err)
+	}
+	if len(firstVectors) != 1 || len(firstVectors[0]) != 2 {
+		t.Fatalf("first vector shape = %v, want one 2-dim vector", firstVectors)
+	}
+	if len(secondVectors) != 1 || len(secondVectors[0]) != 2 {
+		t.Fatalf("second vector shape = %v, want one 2-dim vector", secondVectors)
+	}
+
+	starts := readStartLog(t, startLog)
+	if starts != 1 {
+		t.Fatalf("daemon starts = %d, want 1", starts)
+	}
+}
+
+func writeSharedSidecarHelper(t *testing.T) string {
+	t.Helper()
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("test executable: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "fake-haft-embed")
+	script := fmt.Sprintf(
+		"#!/usr/bin/env bash\nHAFT_TEST_SHARED_SIDECAR=1 exec %q -test.run=TestSharedSidecarHelperProcess -- \"$@\"\n",
+		binary,
+	)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+	return path
+}
+
+func readStartLog(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read start log: %v", err)
+	}
+	return len(strings.Fields(string(data)))
+}
+
+func TestSharedSidecarHelperProcess(t *testing.T) {
+	if os.Getenv("HAFT_TEST_SHARED_SIDECAR") != "1" {
+		return
+	}
+	args := sidecarHelperArgs(os.Args)
+	socket := helperArg(args, "--serve-socket")
+	model := helperArg(args, "--model")
+	dim := helperIntArg(args, "--dim", 2)
+	idle := time.Duration(helperIntArg(args, "--idle-timeout-secs", 30)) * time.Second
+	if socket == "" {
+		os.Exit(2)
+	}
+	if model == "" {
+		model = DefaultLocalModel
+	}
+
+	logPath := os.Getenv("HAFT_TEST_SHARED_SIDECAR_STARTS")
+	if logPath != "" {
+		file, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err == nil {
+			_, _ = fmt.Fprintln(file, os.Getpid())
+			_ = file.Close()
+		}
+	}
+
+	_ = os.Remove(socket)
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		os.Exit(3)
+	}
+	defer listener.Close()
+	_ = os.Chmod(socket, 0o600)
+
+	unixListener := listener.(*net.UnixListener)
+	active := atomic.Int32{}
+	lastAccept := time.Now()
+	for {
+		_ = unixListener.SetDeadline(time.Now().Add(100 * time.Millisecond))
+		conn, err := unixListener.Accept()
+		if err != nil {
+			if active.Load() == 0 && time.Since(lastAccept) >= idle {
+				os.Exit(0)
+			}
+			continue
+		}
+		active.Add(1)
+		lastAccept = time.Now()
+		go handleSharedSidecarHelperConn(conn, model, dim, &active)
+	}
+}
+
+func sidecarHelperArgs(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[i+1:]
+		}
+	}
+	return nil
+}
+
+func helperArg(args []string, name string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == name {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func helperIntArg(args []string, name string, fallback int) int {
+	value := helperArg(args, name)
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func handleSharedSidecarHelperConn(conn net.Conn, model string, dim int, active *atomic.Int32) {
+	defer active.Add(-1)
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	handshake := sidecarHandshake{Ready: true, Model: model, Dim: dim}
+	line, err := json.Marshal(handshake)
+	if err != nil {
+		return
+	}
+	_, _ = conn.Write(append(line, '\n'))
+
+	for {
+		requestLine, err := reader.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+		var request sidecarRequest
+		if err := json.Unmarshal(requestLine, &request); err != nil {
+			return
+		}
+		response := sidecarResponse{
+			ID:      request.ID,
+			Vectors: helperVectors(len(request.Texts), dim),
+		}
+		payload, err := json.Marshal(response)
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write(append(payload, '\n'))
+	}
+}
+
+func helperVectors(rows int, dim int) [][]float32 {
+	vectors := make([][]float32, rows)
+	for row := range vectors {
+		vector := make([]float32, dim)
+		if dim > 0 {
+			vector[0] = 1
+		}
+		vectors[row] = vector
+	}
+	return vectors
+}


### PR DESCRIPTION
…bed-sidecar memory fix

drift: pure deterministic classifier (internal/artifact/autobaseline.go) keying off the existing symbol-level SymbolVerdict; a governed-symbol change can never be silently auto-baselined, regression-pinned against the seeded harness-drain removed-func case. Safety core of dec-20260606-9b4a4c52 (slice 1); acting on the silent bucket + snapshot-history reversibility, the staged confirm-digest, and the callee-closure extension are deferred (closure waits on cross-package code-graph edges).

embed-sidecar: drop eager Prewarm on MCP connect + shared per-user Unix-socket sidecar daemon with idle exit so a single MCP client no longer loads an ONNX model eagerly or spawns a model process per serve instance (addresses prob-20260606-bcf759b5: sidecars hang / high memory). Lint: explicit error-discard on deferred Flock unlock.

CHANGELOG: 8.1.0 entries.