### PR TITLE
8.1.0: embed-sidecar hang fix + task install fix (release prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,22 @@ plugged into Claude Code / Codex / OpenCode / Cursor over their native skill
   tensor and the sidecar ballooned past 6 GB and stalled. The batch is bounded
   small (peak activation back in the low hundreds of MB), with negligible
   throughput cost.
+- **Incompatible/old `haft-embed` degrades to FTS instead of hanging.** When the
+  resolved sidecar binary could not serve the shared daemon (e.g. an older
+  `haft-embed` that rejects `--serve-socket`), the stdio fallback then blocked
+  forever on a handshake the old protocol never sends. The shared path now flags
+  an unusable binary (`errSharedSidecarUnusable`) and recall degrades straight to
+  FTS5+PPR; the stdio handshake is additionally bounded by
+  `HAFT_EMBED_STARTUP_TIMEOUT_SECS` (generous default for a cold model download,
+  `0` = unbounded) so no resolved binary can hang the caller. Honors the
+  "recall never hard-fails on the optional layer" invariant. (`internal/embedding`.)
+- **`task install` / `task build` use the committed FPF index, never rebake.**
+  They depended on `fpf-refresh`, which re-pulled the FPF submodule and rebaked
+  `internal/cli/fpf.db` through a live `haft-embed` — failing (or, before the
+  hang fix, stalling) whenever the local sidecar was missing or stale. The
+  committed `fpf.db` (go:embed'd into the binary, the same artifact CI verifies)
+  is now built as-is; rebaking is the explicit `task fpf-refresh` maintainer step
+  after an FPF spec bump.
 - **Terminal-status artifacts no longer resurface as expiry debt** — the
   `haft_refresh` stale-collection path now excludes `deprecated` / `superseded`
   artifacts, matching the active-decision scan's status filter. An archived-but-

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -48,9 +48,12 @@ tasks:
     cmds:
       - task fpf-index
 
+  # build/install/dev use the COMMITTED internal/cli/fpf.db (go:embed'd into the
+  # binary), the same source of truth CI verifies but never rebakes. Rebaking
+  # needs a live haft-embed and is the explicit maintainer step `task fpf-refresh`
+  # — run it after an FPF spec bump, then commit the regenerated fpf.db.
   build:
-    desc: Build Go binary
-    deps: [fpf-refresh]
+    desc: Build Go binary (uses the committed FPF index; run `task fpf-refresh` to rebake)
     cmds:
       - go build -o {{.BIN_NAME}} -trimpath ./cmd/haft/
     generates:
@@ -58,7 +61,7 @@ tasks:
 
   install:
     desc: Build and install haft (CLI + Open-Sleigh runtime) locally
-    deps: [fpf-refresh, open-sleigh:install-runtime]
+    deps: [open-sleigh:install-runtime]
     cmds:
       # Remove any stale `haft` in GOBIN so PATH picks up BIN_DIR/haft,
       # not a leftover `go install`'d binary from an older build.
@@ -72,8 +75,7 @@ tasks:
       - echo "Installed {{.OPEN_SLEIGH_INSTALL_DIR}}"
 
   dev:
-    desc: Build Go binary only (no Open-Sleigh runtime release)
-    deps: [fpf-index]
+    desc: Build Go binary only (no Open-Sleigh runtime release; uses the committed FPF index)
     cmds:
       - go build -o {{.BIN_NAME}} -trimpath ./cmd/haft/
 

--- a/internal/embedding/sidecar.go
+++ b/internal/embedding/sidecar.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/m0n0x41d/haft/logger"
 )
@@ -21,6 +22,15 @@ import (
 // MUST degrade to FTS5+PPR recall on this error (decision invariant) — it is
 // the expected state on a default install without the optional sidecar.
 var ErrSidecarUnavailable = errors.New("embedding sidecar (haft-embed) not found")
+
+// errSharedSidecarUnusable signals the shared-daemon attempt resolved a binary
+// that ran but could not serve (rejected the daemon flags / never opened its
+// socket / startup timed out) — i.e. an old or incompatible haft-embed. The
+// same binary will not behave in stdio mode either, so callers degrade straight
+// to FTS5+PPR instead of risking a stdio handshake hang. The shared (unix) path
+// wraps its failures with this sentinel; the non-unix stub does not, so Windows
+// still falls back to stdio.
+var errSharedSidecarUnusable = errors.New("shared embedding sidecar could not serve")
 
 const (
 	sidecarBinaryName = "haft-embed"
@@ -90,6 +100,13 @@ func newSidecarAdapter(cfg Config) (Embedder, error) {
 		if err == nil {
 			return adapter, nil
 		}
+		if errors.Is(err, errSharedSidecarUnusable) {
+			// The binary ran but could not serve (old/incompatible haft-embed).
+			// Retrying it over stdio would risk a handshake hang, so degrade to
+			// FTS5+PPR now — recall never hard-fails on the optional layer.
+			logger.Info().Err(err).Msg("embedding sidecar incompatible — recall falls back to FTS5+PPR")
+			return nil, ErrSidecarUnavailable
+		}
 		logger.Info().Err(err).Msg("shared embedding sidecar unavailable — falling back to stdio child")
 	}
 	return newStdioSidecarAdapter(binary, spec)
@@ -138,10 +155,10 @@ func (a *sidecarAdapter) spawn() error {
 	}
 
 	reader := bufio.NewReader(stdout)
-	handshake, err := readHandshake(reader)
+	handshake, err := readHandshakeWithin(reader, stdioHandshakeTimeout())
 	if err != nil {
 		_ = stdin.Close()
-		_ = cmd.Process.Kill()
+		_ = cmd.Process.Kill() // closing stdout unblocks a leaked reader goroutine
 		_ = cmd.Wait()
 		return err
 	}
@@ -169,6 +186,56 @@ func readHandshake(reader *bufio.Reader) (sidecarHandshake, error) {
 		return sidecarHandshake{}, fmt.Errorf("sidecar failed to start: %s", handshake.Error)
 	}
 	return handshake, nil
+}
+
+// stdioHandshakeTimeoutEnv bounds how long the stdio handshake waits. A cold
+// start that downloads the model is legitimately slow, so the default is
+// generous; 0 opts out (unbounded, the original behavior). Shares the env name
+// with the shared-daemon startup budget.
+const stdioHandshakeTimeoutEnv = "HAFT_EMBED_STARTUP_TIMEOUT_SECS"
+
+// defaultStdioHandshakeTimeout is generous enough for a first-use model download
+// yet finite, so an incompatible binary that never speaks the protocol degrades
+// to FTS5+PPR instead of hanging the caller forever.
+const defaultStdioHandshakeTimeout = 10 * time.Minute
+
+func stdioHandshakeTimeout() time.Duration {
+	value := strings.TrimSpace(os.Getenv(stdioHandshakeTimeoutEnv))
+	if value == "" {
+		return defaultStdioHandshakeTimeout
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds < 0 {
+		return defaultStdioHandshakeTimeout
+	}
+	return time.Duration(seconds) * time.Second // 0 = unbounded (opt-out)
+}
+
+type handshakeResult struct {
+	handshake sidecarHandshake
+	err       error
+}
+
+// readHandshakeWithin bounds readHandshake so a binary that never emits the
+// handshake line (an old protocol, an incompatible build) cannot block the
+// caller forever. timeout<=0 preserves the unbounded cold-start read. On
+// timeout the caller kills the process; closing its stdout unblocks the leaked
+// reader goroutine, which then exits via the buffered channel.
+func readHandshakeWithin(reader *bufio.Reader, timeout time.Duration) (sidecarHandshake, error) {
+	if timeout <= 0 {
+		return readHandshake(reader)
+	}
+	ch := make(chan handshakeResult, 1)
+	go func() {
+		handshake, err := readHandshake(reader)
+		ch <- handshakeResult{handshake: handshake, err: err}
+	}()
+	select {
+	case result := <-ch:
+		return result.handshake, result.err
+	case <-time.After(timeout):
+		return sidecarHandshake{}, fmt.Errorf("sidecar handshake timed out after %s", timeout)
+	}
 }
 
 func (a *sidecarAdapter) Descriptor() Descriptor {

--- a/internal/embedding/sidecar_fastfail_test.go
+++ b/internal/embedding/sidecar_fastfail_test.go
@@ -1,0 +1,88 @@
+package embedding
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// writeFakeSidecar drops an executable bash script and returns its path.
+func writeFakeSidecar(t *testing.T, script string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake sidecar script needs a POSIX shell")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available for the fake sidecar")
+	}
+	path := filepath.Join(t.TempDir(), "fake-haft-embed")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake sidecar: %v", err)
+	}
+	return path
+}
+
+// withinDeadline runs fn and fails the test if it does not return in time —
+// the regression guard for the hang this fix removes.
+func withinDeadline(t *testing.T, d time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { fn(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("call did not return within %s — sidecar resolution hung", d)
+	}
+}
+
+// TestNewSidecar_IncompatibleBinaryDegradesFast pins fix (1): when the shared
+// daemon attempt resolves an OLD binary that rejects --serve-socket, New must
+// degrade to ErrSidecarUnavailable (FTS5+PPR) quickly — it must NOT fall back to
+// driving the same binary over stdio (which would hang on a missing handshake).
+func TestNewSidecar_IncompatibleBinaryDegradesFast(t *testing.T) {
+	// Rejects the daemon flag like an old clap binary; in stdio mode it would
+	// hang without ever sending a handshake. If New wrongly falls back to stdio,
+	// the deadline guard trips.
+	script := "#!/usr/bin/env bash\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$a\" = \"--serve-socket\" ]; then echo 'unexpected argument --serve-socket' >&2; exit 2; fi\n" +
+		"done\n" +
+		"sleep 30\n"
+	path := writeFakeSidecar(t, script)
+
+	t.Setenv(sidecarBinaryEnv, path)
+	t.Setenv(sharedSidecarEnv, "1")           // exercise the shared path
+	t.Setenv(sharedSocketDirEnv, t.TempDir()) // isolate socket/lock from any real daemon
+
+	var gotErr error
+	withinDeadline(t, 15*time.Second, func() {
+		_, gotErr = New(Config{Provider: ProviderLocal})
+	})
+	if !errors.Is(gotErr, ErrSidecarUnavailable) {
+		t.Fatalf("New err = %v, want ErrSidecarUnavailable (degrade to FTS)", gotErr)
+	}
+}
+
+// TestNewSidecar_StdioHandshakeTimesOut pins fix (2): on the stdio path
+// (shared disabled), a binary that never emits a handshake must time out and
+// return an error rather than block forever.
+func TestNewSidecar_StdioHandshakeTimesOut(t *testing.T) {
+	script := "#!/usr/bin/env bash\nsleep 30\n" // starts, never handshakes
+	path := writeFakeSidecar(t, script)
+
+	t.Setenv(sidecarBinaryEnv, path)
+	t.Setenv(sharedSidecarEnv, "0")         // force the stdio path
+	t.Setenv(stdioHandshakeTimeoutEnv, "1") // 1s handshake budget
+
+	var gotErr error
+	withinDeadline(t, 15*time.Second, func() {
+		_, gotErr = New(Config{Provider: ProviderLocal})
+	})
+	if gotErr == nil {
+		t.Fatal("New err = nil, want a handshake-timeout error")
+	}
+}

--- a/internal/embedding/sidecar_shared_unix.go
+++ b/internal/embedding/sidecar_shared_unix.go
@@ -203,15 +203,15 @@ func waitForSharedSidecar(
 		select {
 		case err := <-started.done:
 			if err == nil {
-				return nil, errors.New("shared sidecar exited before opening socket")
+				return nil, fmt.Errorf("%w: exited before opening socket", errSharedSidecarUnusable)
 			}
-			return nil, fmt.Errorf("shared sidecar exited before opening socket: %w", err)
+			return nil, fmt.Errorf("%w: exited before opening socket: %v", errSharedSidecarUnusable, err)
 		default:
 		}
 
 		if timeout > 0 && time.Now().After(deadline) {
 			_ = started.cmd.Process.Kill()
-			return nil, errors.New("shared sidecar startup timed out")
+			return nil, fmt.Errorf("%w: startup timed out", errSharedSidecarUnusable)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
Final fixes before tagging v8.1.0.

- **embedding:** old/incompatible `haft-embed` (e.g. an installed sidecar predating `--serve-socket`) now degrades to FTS5+PPR instead of hanging. Shared path flags an unusable binary (`errSharedSidecarUnusable`) → straight to FTS, no stdio retry on the same binary; stdio handshake bounded by `HAFT_EMBED_STARTUP_TIMEOUT_SECS` (generous default, 0=unbounded). Tests cover both paths + old-binary repro.
- **Taskfile:** `install`/`build`/`dev` use the committed go:embed'd `internal/cli/fpf.db` instead of rebaking it through a live `haft-embed` (which failed/stalled with a missing/stale sidecar). Rebaking stays the explicit `task fpf-refresh` step.
- CHANGELOG: both under [8.1.0] Fixed.

Full `go test -race ./...` green; FPF index verify OK (5696 vectors @ eaafd3a4).