### PR TITLE
feat: add MiniMax provider registry support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- MiniMax model registry entries and configurable OpenAI-compatible and
+  Anthropic-compatible regional endpoints.
 - **Native TypeScript/JavaScript/Vue code graph with durable symbol anchors.**
   Added a dependency-free tree-sitter index for project-aware symbols, calls,
   references, type relations, re-exports, aliases, callbacks, receiver flows,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,15 @@ import (
 //	    api_key: sk-ant-...
 //	  deepseek:
 //	    api_key: sk-...
+//	  minimax:
+//	    api_key: ...
+//	    api_type: openai
+//	    openai_base_url: https://api.minimax.io/v1
+//	    anthropic_base_url: https://api.minimax.io/anthropic
+//
+// MiniMax's China endpoints are https://api.minimaxi.com/v1 and
+// https://api.minimaxi.com/anthropic. Anthropic-compatible base URLs end at
+// /anthropic; the SDK appends /v1/messages.
 type Config struct {
 	Model     string                  `yaml:"model" json:"model"`         // default model ID
 	Providers map[string]ProviderAuth `yaml:"providers" json:"providers"` // provider ID → auth
@@ -55,12 +64,15 @@ type EmbeddingConfig struct {
 
 // ProviderAuth stores credentials for one provider.
 type ProviderAuth struct {
-	AuthType     string `yaml:"auth_type,omitempty" json:"auth_type,omitempty"` // "api_key", "codex_oauth"
-	APIKey       string `yaml:"api_key,omitempty" json:"api_key,omitempty"`
-	AccessToken  string `yaml:"access_token,omitempty" json:"access_token,omitempty"`
-	RefreshToken string `yaml:"refresh_token,omitempty" json:"refresh_token,omitempty"`
-	ExpiresAt    int64  `yaml:"expires_at,omitempty" json:"expires_at,omitempty"`
-	AccountID    string `yaml:"account_id,omitempty" json:"account_id,omitempty"`
+	AuthType         string `yaml:"auth_type,omitempty" json:"auth_type,omitempty"` // "api_key", "codex_oauth"
+	APIType          string `yaml:"api_type,omitempty" json:"api_type,omitempty"`   // "openai", "anthropic"
+	APIKey           string `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	OpenAIBaseURL    string `yaml:"openai_base_url,omitempty" json:"openai_base_url,omitempty"`
+	AnthropicBaseURL string `yaml:"anthropic_base_url,omitempty" json:"anthropic_base_url,omitempty"`
+	AccessToken      string `yaml:"access_token,omitempty" json:"access_token,omitempty"`
+	RefreshToken     string `yaml:"refresh_token,omitempty" json:"refresh_token,omitempty"`
+	ExpiresAt        int64  `yaml:"expires_at,omitempty" json:"expires_at,omitempty"`
+	AccountID        string `yaml:"account_id,omitempty" json:"account_id,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -26,6 +26,16 @@ var _ LLMProvider = (*AnthropicProvider)(nil)
 // NewAnthropic creates an Anthropic provider.
 // Resolves API key from: explicit param → ANTHROPIC_API_KEY env.
 func NewAnthropic(model, apiKey string) (*AnthropicProvider, error) {
+	return NewAnthropicWithBaseURL(model, apiKey, "")
+}
+
+// NewAnthropicWithBaseURL creates an Anthropic-compatible provider with an
+// optional base URL. The SDK appends /v1/messages to the configured base URL.
+func NewAnthropicWithBaseURL(model, apiKey, baseURL string) (*AnthropicProvider, error) {
+	return newAnthropicProvider(model, apiKey, baseURL)
+}
+
+func newAnthropicProvider(model, apiKey, baseURL string, extra ...option.RequestOption) (*AnthropicProvider, error) {
 	if apiKey == "" {
 		apiKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
@@ -33,9 +43,12 @@ func NewAnthropic(model, apiKey string) (*AnthropicProvider, error) {
 		return nil, fmt.Errorf("no Anthropic API key: set ANTHROPIC_API_KEY or run 'haft setup'")
 	}
 
-	client := anthropic.NewClient(
-		option.WithAPIKey(apiKey),
-	)
+	opts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if baseURL != "" {
+		opts = append(opts, option.WithBaseURL(baseURL))
+	}
+	opts = append(opts, extra...)
+	client := anthropic.NewClient(opts...)
 
 	return &AnthropicProvider{
 		client: client,

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -2,24 +2,56 @@ package provider
 
 import "fmt"
 
+// ProviderOptions configures a provider adapter without changing the legacy
+// NewProvider call shape.
+type ProviderOptions struct {
+	APIType          string
+	Region           string
+	OpenAIBaseURL    string
+	AnthropicBaseURL string
+}
+
 // NewProvider creates an LLM provider based on provider ID.
 // Routes to the appropriate implementation:
 //   - "openai": OpenAI Responses API (also handles Codex/ChatGPT auth)
 //   - "anthropic": Anthropic Messages API
-//   - Others: treated as OpenAI-compatible (DeepSeek, Groq, Mistral, etc.)
+//   - "minimax": OpenAI-compatible by default, or Anthropic-compatible with options
 //
 // For OpenAI, apiKey can be empty — it resolves from env/config/codex.
 // For Anthropic, apiKey is required (from env or config).
 func NewProvider(providerID, model, apiKey string) (LLMProvider, error) {
+	return NewProviderWithOptions(providerID, model, apiKey, ProviderOptions{})
+}
+
+// NewProviderWithOptions creates a provider with protocol and endpoint
+// selection for compatible providers.
+func NewProviderWithOptions(providerID, model, apiKey string, options ProviderOptions) (LLMProvider, error) {
 	switch providerID {
 	case "openai":
 		return NewOpenAI(model)
 	case "anthropic":
 		return NewAnthropic(model, apiKey)
+	case "minimax":
+		endpoint, ok := MiniMaxEndpoint(options.Region)
+		if !ok {
+			return nil, fmt.Errorf("unknown MiniMax region %q", options.Region)
+		}
+		if options.APIType == "anthropic" {
+			baseURL := options.AnthropicBaseURL
+			if baseURL == "" {
+				baseURL = endpoint.AnthropicBaseURL
+			}
+			return NewAnthropicWithBaseURL(model, apiKey, baseURL)
+		}
+		if options.APIType != "" && options.APIType != "openai" {
+			return nil, fmt.Errorf("unsupported MiniMax API type %q", options.APIType)
+		}
+		baseURL := options.OpenAIBaseURL
+		if baseURL == "" {
+			baseURL = endpoint.OpenAIBaseURL
+		}
+		return NewOpenAICompatible(model, apiKey, baseURL)
 	default:
-		// OpenAI-compatible providers (DeepSeek, Groq, etc.)
-		// For now, route through OpenAI — they use the same API format.
-		// TODO: support custom base URLs for non-OpenAI providers.
 		return nil, fmt.Errorf("provider %q not yet supported — use openai or anthropic", providerID)
 	}
 }
@@ -54,6 +86,7 @@ func guessProviderFromPrefix(model string) string {
 		"gemini-":   "google",
 		"deepseek-": "deepseek",
 		"llama-":    "groq",
+		"MiniMax-":  "minimax",
 	}
 	for prefix, provider := range prefixes {
 		if len(model) >= len(prefix) && model[:len(prefix)] == prefix {

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -1,0 +1,99 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	openaioption "github.com/openai/openai-go/v3/option"
+)
+
+func TestMiniMaxProviderFactory(t *testing.T) {
+	openAIProvider, err := NewProviderWithOptions(
+		"minimax",
+		"MiniMax-M3",
+		"test-key",
+		ProviderOptions{Region: "global_en"},
+	)
+	if err != nil {
+		t.Fatalf("create MiniMax OpenAI-compatible provider: %v", err)
+	}
+	if _, ok := openAIProvider.(*OpenAIProvider); !ok {
+		t.Fatalf("MiniMax default provider type: got %T, want *OpenAIProvider", openAIProvider)
+	}
+	if openAIProvider.ModelID() != "MiniMax-M3" {
+		t.Fatalf("MiniMax OpenAI-compatible model: got %q", openAIProvider.ModelID())
+	}
+
+	anthropicProvider, err := NewProviderWithOptions(
+		"minimax",
+		"MiniMax-M2.7",
+		"test-key",
+		ProviderOptions{APIType: "anthropic", Region: "cn_zh"},
+	)
+	if err != nil {
+		t.Fatalf("create MiniMax Anthropic-compatible provider: %v", err)
+	}
+	if _, ok := anthropicProvider.(*AnthropicProvider); !ok {
+		t.Fatalf("MiniMax Anthropic-compatible provider type: got %T, want *AnthropicProvider", anthropicProvider)
+	}
+	if anthropicProvider.ModelID() != "MiniMax-M2.7" {
+		t.Fatalf("MiniMax Anthropic-compatible model: got %q", anthropicProvider.ModelID())
+	}
+}
+
+func TestMiniMaxOpenAIEndpointPath(t *testing.T) {
+	var path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"MiniMax-M3","output":[]}`))
+	}))
+	defer server.Close()
+
+	provider, err := newOpenAIProvider(
+		"MiniMax-M3",
+		"test-key",
+		"api_key",
+		"",
+		server.URL+"/v1",
+		openaioption.WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("create OpenAI-compatible provider: %v", err)
+	}
+	_, _ = provider.client.Responses.New(context.Background(), buildResponseParams("MiniMax-M3", "", "api_key", nil, nil))
+	if path != "/v1/responses" {
+		t.Fatalf("OpenAI-compatible request path: got %q, want /v1/responses", path)
+	}
+}
+
+func TestMiniMaxAnthropicEndpointPath(t *testing.T) {
+	var path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	provider, err := newAnthropicProvider(
+		"MiniMax-M2.7",
+		"test-key",
+		server.URL+"/anthropic",
+		option.WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("create Anthropic-compatible provider: %v", err)
+	}
+	_, _ = provider.client.Messages.New(context.Background(), anthropic.MessageNewParams{
+		Model:     "MiniMax-M2.7",
+		MaxTokens: 1,
+	})
+	if path != "/anthropic/v1/messages" {
+		t.Fatalf("Anthropic-compatible request path: got %q, want /anthropic/v1/messages", path)
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -43,27 +43,46 @@ func NewOpenAI(model string) (*OpenAIProvider, error) {
 	if resolved.key == "" {
 		return nil, fmt.Errorf("no OpenAI auth found: run 'haft login' or set OPENAI_API_KEY")
 	}
+	return newOpenAIProvider(model, resolved.key, resolved.authType, resolved.accountID, "")
+}
 
-	opts := []option.RequestOption{option.WithAPIKey(resolved.key)}
+// NewOpenAICompatible creates an OpenAI-compatible provider with an explicit
+// API key and base URL.
+func NewOpenAICompatible(model, apiKey, baseURL string) (*OpenAIProvider, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("no API key configured for OpenAI-compatible provider")
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("no base URL configured for OpenAI-compatible provider")
+	}
+	return newOpenAIProvider(model, apiKey, "api_key", "", baseURL)
+}
+
+func newOpenAIProvider(model, apiKey, authType, accountID, baseURL string, extra ...option.RequestOption) (*OpenAIProvider, error) {
+	opts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if baseURL != "" {
+		opts = append(opts, option.WithBaseURL(baseURL))
+	}
 
 	// ChatGPT/Codex auth uses the ChatGPT backend and requires workspace scoping.
-	if resolved.authType == "codex" || resolved.authType == "codex_cli" {
+	if authType == "codex" || authType == "codex_cli" {
 		opts = append(opts,
 			option.WithBaseURL(codexAPIEndpoint),
 			option.WithHeader("originator", codexOriginator),
 		)
-		if resolved.accountID != "" {
-			opts = append(opts, option.WithHeader("chatgpt-account-id", resolved.accountID))
+		if accountID != "" {
+			opts = append(opts, option.WithHeader("chatgpt-account-id", accountID))
 		}
 	}
+	opts = append(opts, extra...)
 
 	client := openai.NewClient(opts...)
 
 	return &OpenAIProvider{
 		client:    client,
 		model:     model,
-		accountID: resolved.accountID,
-		authType:  resolved.authType,
+		accountID: accountID,
+		authType:  authType,
 	}, nil
 }
 

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -35,22 +35,36 @@ import (
 
 // ModelInfo describes a single LLM model's capabilities and constraints.
 type ModelInfo struct {
-	ID             string  `json:"id"`
-	Name           string  `json:"name,omitempty"`
-	ContextWindow  int     `json:"context_window"`
-	DefaultMaxOut  int     `json:"default_max_tokens"`
-	CanReason      bool    `json:"can_reason,omitempty"`
-	SupportsImages bool    `json:"supports_images,omitempty"`
-	CostPer1MIn    float64 `json:"cost_per_1m_in,omitempty"`
-	CostPer1MOut   float64 `json:"cost_per_1m_out,omitempty"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name,omitempty"`
+	ContextWindow       int      `json:"context_window"`
+	DefaultMaxOut       int      `json:"default_max_tokens"`
+	CanReason           bool     `json:"can_reason,omitempty"`
+	SupportsImages      bool     `json:"supports_images,omitempty"`
+	SupportsVideo       bool     `json:"supports_video,omitempty"`
+	ThinkingModes       []string `json:"thinking_modes,omitempty"`
+	CostPer1MIn         float64  `json:"cost_per_1m_in,omitempty"`
+	CostPer1MOut        float64  `json:"cost_per_1m_out,omitempty"`
+	CostPer1MCacheRead  float64  `json:"cost_per_1m_cache_read,omitempty"`
+	CostPer1MCacheWrite float64  `json:"cost_per_1m_cache_write,omitempty"`
+}
+
+// ProviderEndpoint describes protocol endpoints for one provider region.
+type ProviderEndpoint struct {
+	Region           string `json:"region"`
+	OpenAIBaseURL    string `json:"openai_base_url,omitempty"`
+	AnthropicBaseURL string `json:"anthropic_base_url,omitempty"`
+	DocsURL          string `json:"docs_url,omitempty"`
 }
 
 // ProviderInfo describes an LLM provider and its available models.
 type ProviderInfo struct {
-	ID      string      `json:"id"`
-	Name    string      `json:"name"`
-	APIType string      `json:"type,omitempty"` // "openai", "anthropic", "google"
-	Models  []ModelInfo `json:"models"`
+	ID        string             `json:"id"`
+	Name      string             `json:"name"`
+	APIType   string             `json:"type,omitempty"` // default protocol: "openai", "anthropic", "google"
+	Protocols []string           `json:"protocols,omitempty"`
+	Endpoints []ProviderEndpoint `json:"endpoints,omitempty"`
+	Models    []ModelInfo        `json:"models"`
 }
 
 // ---------------------------------------------------------------------------
@@ -125,22 +139,37 @@ func (r *Registry) Providers() []ProviderInfo {
 func MergeProviders(remote, embedded []ProviderInfo) []ProviderInfo {
 	// Build embedded index: provider → model ID → ModelInfo
 	embeddedModels := make(map[string]map[string]ModelInfo)
+	embeddedProviders := make(map[string]ProviderInfo, len(embedded))
 	for _, p := range embedded {
 		m := make(map[string]ModelInfo, len(p.Models))
 		for _, model := range p.Models {
 			m[model.ID] = model
 		}
 		embeddedModels[p.ID] = m
+		embeddedProviders[p.ID] = p
 	}
 
 	// Start with remote, merge embedded corrections
 	byID := make(map[string]ProviderInfo, len(remote)+len(embedded))
 	for _, p := range remote {
 		if emb, ok := embeddedModels[p.ID]; ok {
-			// Merge models: keep higher context window
+			p = mergeProviderMetadata(p, embeddedProviders[p.ID])
+			// Merge models: keep higher context window and retain embedded-only models.
 			for i, rm := range p.Models {
 				if em, exists := emb[rm.ID]; exists && em.ContextWindow > rm.ContextWindow {
 					p.Models[i].ContextWindow = em.ContextWindow
+				}
+			}
+			for modelID, em := range emb {
+				found := false
+				for _, rm := range p.Models {
+					if rm.ID == modelID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					p.Models = append(p.Models, em)
 				}
 			}
 		}
@@ -158,6 +187,49 @@ func MergeProviders(remote, embedded []ProviderInfo) []ProviderInfo {
 		result = append(result, p)
 	}
 	return result
+}
+
+func mergeProviderMetadata(remote, embedded ProviderInfo) ProviderInfo {
+	if remote.APIType == "" {
+		remote.APIType = embedded.APIType
+	}
+	for _, protocol := range embedded.Protocols {
+		if !containsString(remote.Protocols, protocol) {
+			remote.Protocols = append(remote.Protocols, protocol)
+		}
+	}
+	for _, embeddedEndpoint := range embedded.Endpoints {
+		found := false
+		for i, remoteEndpoint := range remote.Endpoints {
+			if remoteEndpoint.Region != embeddedEndpoint.Region {
+				continue
+			}
+			found = true
+			if remoteEndpoint.OpenAIBaseURL == "" {
+				remote.Endpoints[i].OpenAIBaseURL = embeddedEndpoint.OpenAIBaseURL
+			}
+			if remoteEndpoint.AnthropicBaseURL == "" {
+				remote.Endpoints[i].AnthropicBaseURL = embeddedEndpoint.AnthropicBaseURL
+			}
+			if remoteEndpoint.DocsURL == "" {
+				remote.Endpoints[i].DocsURL = embeddedEndpoint.DocsURL
+			}
+			break
+		}
+		if !found {
+			remote.Endpoints = append(remote.Endpoints, embeddedEndpoint)
+		}
+	}
+	return remote
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------
@@ -232,14 +304,18 @@ type catwalkProvider struct {
 }
 
 type catwalkModel struct {
-	ID               string  `json:"id"`
-	Name             string  `json:"name"`
-	ContextWindow    int     `json:"context_window"`
-	DefaultMaxTokens int     `json:"default_max_tokens"`
-	CanReason        bool    `json:"can_reason"`
-	SupportsImages   bool    `json:"supports_images"`
-	CostPer1MIn      float64 `json:"cost_per_1m_in"`
-	CostPer1MOut     float64 `json:"cost_per_1m_out"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	ContextWindow       int      `json:"context_window"`
+	DefaultMaxTokens    int      `json:"default_max_tokens"`
+	CanReason           bool     `json:"can_reason"`
+	SupportsImages      bool     `json:"supports_images"`
+	SupportsVideo       bool     `json:"supports_video"`
+	ThinkingModes       []string `json:"thinking_modes"`
+	CostPer1MIn         float64  `json:"cost_per_1m_in"`
+	CostPer1MOut        float64  `json:"cost_per_1m_out"`
+	CostPer1MCacheRead  float64  `json:"cost_per_1m_cache_read"`
+	CostPer1MCacheWrite float64  `json:"cost_per_1m_cache_write"`
 }
 
 func convertCatwalkResponse(raw []catwalkProvider) []ProviderInfo {
@@ -252,14 +328,18 @@ func convertCatwalkResponse(raw []catwalkProvider) []ProviderInfo {
 		}
 		for _, rm := range rp.Models {
 			p.Models = append(p.Models, ModelInfo{
-				ID:             rm.ID,
-				Name:           rm.Name,
-				ContextWindow:  rm.ContextWindow,
-				DefaultMaxOut:  rm.DefaultMaxTokens,
-				CanReason:      rm.CanReason,
-				SupportsImages: rm.SupportsImages,
-				CostPer1MIn:    rm.CostPer1MIn,
-				CostPer1MOut:   rm.CostPer1MOut,
+				ID:                  rm.ID,
+				Name:                rm.Name,
+				ContextWindow:       rm.ContextWindow,
+				DefaultMaxOut:       rm.DefaultMaxTokens,
+				CanReason:           rm.CanReason,
+				SupportsImages:      rm.SupportsImages,
+				SupportsVideo:       rm.SupportsVideo,
+				ThinkingModes:       rm.ThinkingModes,
+				CostPer1MIn:         rm.CostPer1MIn,
+				CostPer1MOut:        rm.CostPer1MOut,
+				CostPer1MCacheRead:  rm.CostPer1MCacheRead,
+				CostPer1MCacheWrite: rm.CostPer1MCacheWrite,
 			})
 		}
 		providers = append(providers, p)
@@ -392,6 +472,49 @@ func EmbeddedProviders() []ProviderInfo {
 			},
 		},
 		{
+			ID: "minimax", Name: "MiniMax", APIType: "openai",
+			Protocols: []string{"openai", "anthropic"},
+			Endpoints: []ProviderEndpoint{
+				{
+					Region:           "global_en",
+					OpenAIBaseURL:    "https://api.minimax.io/v1",
+					AnthropicBaseURL: "https://api.minimax.io/anthropic",
+					DocsURL:          "https://platform.minimax.io/docs/api-reference/api-overview",
+				},
+				{
+					Region:           "cn_zh",
+					OpenAIBaseURL:    "https://api.minimaxi.com/v1",
+					AnthropicBaseURL: "https://api.minimaxi.com/anthropic",
+					DocsURL:          "https://platform.minimaxi.com/docs/api-reference/api-overview",
+				},
+			},
+			Models: []ModelInfo{
+				{
+					ID:                 "MiniMax-M3",
+					Name:               "MiniMax M3",
+					ContextWindow:      1_000_000,
+					CanReason:          true,
+					SupportsImages:     true,
+					SupportsVideo:      true,
+					ThinkingModes:      []string{"adaptive", "disabled"},
+					CostPer1MIn:        0.3,
+					CostPer1MOut:       1.2,
+					CostPer1MCacheRead: 0.06,
+				},
+				{
+					ID:                  "MiniMax-M2.7",
+					Name:                "MiniMax M2.7",
+					ContextWindow:       204_800,
+					CanReason:           true,
+					ThinkingModes:       []string{"always_on"},
+					CostPer1MIn:         0.3,
+					CostPer1MOut:        1.2,
+					CostPer1MCacheRead:  0.06,
+					CostPer1MCacheWrite: 0.375,
+				},
+			},
+		},
+		{
 			ID: "google", Name: "Google", APIType: "google",
 			Models: []ModelInfo{
 				{ID: "gemini-2.5-pro", Name: "Gemini 2.5 Pro", ContextWindow: 1_000_000, DefaultMaxOut: 65_536, CanReason: true, SupportsImages: true, CostPer1MIn: 1.25, CostPer1MOut: 10.0},
@@ -413,6 +536,25 @@ func EmbeddedProviders() []ProviderInfo {
 			},
 		},
 	}
+}
+
+// MiniMaxEndpoint returns the configured endpoint pair for a MiniMax region.
+// The empty region selects the global English endpoint.
+func MiniMaxEndpoint(region string) (ProviderEndpoint, bool) {
+	if region == "" {
+		region = "global_en"
+	}
+	for _, provider := range EmbeddedProviders() {
+		if provider.ID != "minimax" {
+			continue
+		}
+		for _, endpoint := range provider.Endpoints {
+			if endpoint.Region == region {
+				return endpoint, true
+			}
+		}
+	}
+	return ProviderEndpoint{}, false
 }
 
 // FormatModelList renders the registry as a human-readable model list.

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -497,9 +497,9 @@ func EmbeddedProviders() []ProviderInfo {
 					SupportsImages:     true,
 					SupportsVideo:      true,
 					ThinkingModes:      []string{"adaptive", "disabled"},
-					CostPer1MIn:        0.3,
-					CostPer1MOut:       1.2,
-					CostPer1MCacheRead: 0.06,
+					CostPer1MIn:        0.6,
+					CostPer1MOut:       2.4,
+					CostPer1MCacheRead: 0.12,
 				},
 				{
 					ID:                  "MiniMax-M2.7",

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -99,3 +99,73 @@ func TestFormatModelList(t *testing.T) {
 		t.Error("FormatModelList should return non-empty for gpt-5.4 filter")
 	}
 }
+
+func TestMiniMaxRegistry(t *testing.T) {
+	r := NewRegistry(EmbeddedProviders())
+
+	cases := []struct {
+		id      string
+		context int
+		cacheW  float64
+		video   bool
+	}{
+		{id: "MiniMax-M3", context: 1_000_000, video: true},
+		{id: "MiniMax-M2.7", context: 204_800, cacheW: 0.375},
+	}
+	for _, tc := range cases {
+		m, ok := r.Lookup(tc.id)
+		if !ok {
+			t.Fatalf("%s not found in registry", tc.id)
+		}
+		if m.ContextWindow != tc.context {
+			t.Errorf("%s context window: got %d, want %d", tc.id, m.ContextWindow, tc.context)
+		}
+		if m.CostPer1MCacheWrite != tc.cacheW {
+			t.Errorf("%s cache-write price: got %v, want %v", tc.id, m.CostPer1MCacheWrite, tc.cacheW)
+		}
+		if m.CanReason == false {
+			t.Errorf("%s should support reasoning", tc.id)
+		}
+		if m.SupportsVideo != tc.video {
+			t.Errorf("%s video support: got %t, want %t", tc.id, m.SupportsVideo, tc.video)
+		}
+	}
+
+	provider, ok := findProvider(EmbeddedProviders(), "minimax")
+	if !ok {
+		t.Fatal("MiniMax provider not found")
+	}
+	if provider.APIType != "openai" {
+		t.Errorf("MiniMax default API type: got %q, want openai", provider.APIType)
+	}
+	if len(provider.Protocols) != 2 || provider.Protocols[0] != "openai" || provider.Protocols[1] != "anthropic" {
+		t.Errorf("MiniMax protocols: got %#v", provider.Protocols)
+	}
+	if len(provider.Endpoints) != 2 {
+		t.Fatalf("MiniMax endpoints: got %d, want 2", len(provider.Endpoints))
+	}
+	if endpoint, ok := MiniMaxEndpoint("cn_zh"); !ok || endpoint.OpenAIBaseURL != "https://api.minimaxi.com/v1" || endpoint.AnthropicBaseURL != "https://api.minimaxi.com/anthropic" {
+		t.Errorf("China endpoint: got %#v, ok=%t", endpoint, ok)
+	}
+
+	merged := MergeProviders(
+		[]ProviderInfo{{ID: "minimax", Models: []ModelInfo{{ID: "MiniMax-M3"}}}},
+		EmbeddedProviders(),
+	)
+	mergedProvider, ok := findProvider(merged, "minimax")
+	if !ok || len(mergedProvider.Endpoints) != 2 {
+		t.Fatalf("merged MiniMax metadata: provider=%#v, ok=%t", mergedProvider, ok)
+	}
+	if _, ok := NewRegistry(merged).Lookup("MiniMax-M2.7"); !ok {
+		t.Fatal("embedded MiniMax model should survive remote registry merge")
+	}
+}
+
+func findProvider(providers []ProviderInfo, id string) (ProviderInfo, bool) {
+	for _, provider := range providers {
+		if provider.ID == id {
+			return provider, true
+		}
+	}
+	return ProviderInfo{}, false
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -106,11 +106,14 @@ func TestMiniMaxRegistry(t *testing.T) {
 	cases := []struct {
 		id      string
 		context int
+		in      float64
+		out     float64
+		cacheR  float64
 		cacheW  float64
 		video   bool
 	}{
-		{id: "MiniMax-M3", context: 1_000_000, video: true},
-		{id: "MiniMax-M2.7", context: 204_800, cacheW: 0.375},
+		{id: "MiniMax-M3", context: 1_000_000, in: 0.6, out: 2.4, cacheR: 0.12, video: true},
+		{id: "MiniMax-M2.7", context: 204_800, in: 0.3, out: 1.2, cacheR: 0.06, cacheW: 0.375},
 	}
 	for _, tc := range cases {
 		m, ok := r.Lookup(tc.id)
@@ -119,6 +122,15 @@ func TestMiniMaxRegistry(t *testing.T) {
 		}
 		if m.ContextWindow != tc.context {
 			t.Errorf("%s context window: got %d, want %d", tc.id, m.ContextWindow, tc.context)
+		}
+		if m.CostPer1MIn != tc.in {
+			t.Errorf("%s input price: got %v, want %v", tc.id, m.CostPer1MIn, tc.in)
+		}
+		if m.CostPer1MOut != tc.out {
+			t.Errorf("%s output price: got %v, want %v", tc.id, m.CostPer1MOut, tc.out)
+		}
+		if m.CostPer1MCacheRead != tc.cacheR {
+			t.Errorf("%s cache-read price: got %v, want %v", tc.id, m.CostPer1MCacheRead, tc.cacheR)
 		}
 		if m.CostPer1MCacheWrite != tc.cacheW {
 			t.Errorf("%s cache-write price: got %v, want %v", tc.id, m.CostPer1MCacheWrite, tc.cacheW)


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

Adds MiniMax M3 and MiniMax M2.7 to the embedded registry with model metadata, global and China endpoints, and completions-compatible and messages-compatible adapters. Keeps the messages-compatible base URL unchanged so the SDK appends /v1/messages.

Checks:
- go test -race ./internal/provider ./internal/config
- go vet ./internal/provider ./internal/config
- golangci-lint run --timeout=5m ./internal/provider/... ./internal/config/...