### PR TITLE
fix(release): embed the guard's short SHA in the release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,16 +154,26 @@ jobs:
             embed-sidecar/target
           key: ${{ runner.os }}-${{ matrix.goarch }}-embed-cargo-${{ hashFiles('embed-sidecar/Cargo.lock') }}
 
+      # Commit comes from the guard, not from a local `git rev-parse --short`.
+      # This job checks out at fetch-depth 1, so its pack holds ~2.5k objects
+      # against ~38k in the guard's full clone, and Git's auto-abbreviation
+      # picks 7 characters here against 8 there. Recomputing locally embeds a
+      # shorter SHA than the one `smoke-archive.sh` is handed, and the
+      # `commit:  <short_sha>` assertion fails.
       - name: Build binary
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '1'
+          CANDIDATE_SHORT_SHA: ${{ needs.guard.outputs.short_sha }}
         run: |
+          test -n "$CANDIDATE_SHORT_SHA"
+          test "$(git rev-parse HEAD)" = "${{ needs.guard.outputs.sha }}"
+
           go build -trimpath \
             -ldflags "-s -w \
               -X github.com/m0n0x41d/haft/internal/cli.Version=${{ needs.guard.outputs.version }} \
-              -X github.com/m0n0x41d/haft/internal/cli.Commit=$(git rev-parse --short HEAD) \
+              -X github.com/m0n0x41d/haft/internal/cli.Commit=$CANDIDATE_SHORT_SHA \
               -X github.com/m0n0x41d/haft/internal/cli.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             -o haft ./cmd/haft/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,10 @@ jobs:
     needs: [guard]
     runs-on: ${{ matrix.runner }}
     strategy:
+      # A packaging or smoke failure is per-platform evidence. Cancelling the
+      # siblings hides whether the same defect reaches them, and every retry
+      # costs a fresh main CI cycle plus a retag, so let all three report.
+      fail-fast: false
       matrix:
         include:
           - { runner: ubuntu-latest,    goos: linux,  goarch: amd64 }


### PR DESCRIPTION
The v9.0.0 tag validation run [31158960101](https://github.com/m0n0x41d/haft/actions/runs/31158960101) passed the guard and failed in `Build CLI linux-arm64` at `Smoke packaged archive`; the other two platforms were cancelled by fail-fast.

## Cause

The build job checks out at `fetch-depth: 1`, so its pack holds ~2.5k objects against ~38k in the guard's `fetch-depth: 0` clone. Git auto-scales abbreviation length with object count, so `git rev-parse --short HEAD` returned 7 characters in the build job and 8 in the guard.

The binary was therefore built with `commit:  fe8ca68` while `smoke-archive.sh` was handed `fe8ca68c`, and its `grep -F "commit:  $short_sha"` found nothing.

This went unnoticed through v8.1.0 because the repository was small enough that both clones abbreviated to 7. Growth past ~16k objects in the full clone moved only the guard to 8.

## Evidence

Reproduced both directions locally against `fe8ca68c`:

| embedded | expected | result |
|---|---|---|
| 8 (`fe8ca68c`) | 8 | full smoke passes, `EXIT=0`, including packaged MCP status and `haft init --codex --local` |
| 7 (`fe8ca68`) | 8 | prints `haft 9.0.0`, `EXIT=1` — byte-identical to the linux-arm64 CI log |

Shallow-clone reproduction: `git clone --depth 1 --branch v9.0.0` yields 2505 in-pack objects and `git rev-parse --short HEAD` = `fe8ca68`; the full clone has 38026 and yields `fe8ca68c`.

## Change

Take the short SHA from the guard's single full clone, and assert the build job sits on the exact candidate commit.

`go test ./internal/streamtruth/` passes — the edit touches none of the pinned workflow anchors.

## After merge

`main` moves, so the existing `race-aggregate-fe8ca68c…` evidence no longer applies and the `v9.0.0` tag has to be recreated on the new `main` HEAD once its push-event CI is green.

https://claude.ai/code/session_018RhHWaFeCNuv9sRgLzSCSG