### PR TITLE
v9.0.1 — one pre-invariant affected_files row no longer fails the fused graph

### DIFF
--- a/.github/release-notes/9.0.1.md
+++ b/.github/release-notes/9.0.1.md
@@ -1,0 +1,67 @@
+# Haft 9.0.1
+
+A patch release for one defect. Its published predecessor is
+[v9.0.0](https://github.com/m0n0x41d/haft/releases/tag/v9.0.0). No contract,
+capability, or authority boundary changes in this release.
+
+## The defect
+
+v9.0.0 introduced the canonical project-relative path invariant for
+`affected_files` and enforced it on both the write and the read path, but
+shipped no migration for rows admitted before that invariant existed.
+
+A project database carrying even one absolute or traversing path — for example
+an agent attachment recorded as an affected file — failed **every**
+concern-seeded `explore` call:
+
+```
+fuse concern reasoning: stored affected file for <artifact-id>:
+affected file: path "<absolute path>" must be a canonical project-relative path
+```
+
+Symbol-seeded `explore` was unaffected, which is why the failure read as
+intermittent rather than as a whole surface being down. The root cause is not a
+wrong path rule and not a corrupt database: it is a strict read-side invariant
+introduced without a paired migration, combined with a read that failed the
+entire projection on the first row it could not express.
+
+Fresh installations were never affected. Both write paths have canonicalized
+since v9.0.0, so only databases that predate the invariant carry such rows.
+
+## What changed
+
+`AllAffectedFiles` and `GetAffectedFiles` now exclude a row the current path
+invariant cannot express instead of failing the read. The projection returns
+the expressible rows together with a named `Skipped` entry per excluded row, so
+the gap stays visible as data rather than disappearing into a silently narrower
+graph. Concern fusion reports the count as `unexpressible_affected_files` in
+its basis.
+
+Kernel migration 58 drops the rows that cannot be expressed. The invariant
+belongs to `internal/projectpath`, so the migration asks that package rather
+than restating the rule in SQL, verifies that no such row survives, and names
+every dropped row and artifact instead of deleting silently.
+
+The two repairs are independent on purpose: the read fix restores `explore`
+even where the migration has not run yet, and the migration makes the stored
+table agree with what every reader can express.
+
+## Upgrade from v9.0.0
+
+Install the new binary, then run `haft init` once in each existing project:
+
+```
+haft init            # applies kernel migration 58
+```
+
+Migration 58 applies during `haft init`. `haft serve` and the read-only
+surfaces require an already-current schema and report `kernel schema is not
+current` until that one command has run. Restart any host session afterwards so
+every MCP process loads the same binary.
+
+A database that never carried a pre-invariant row pays nothing and reports
+nothing. This release adds no schema objects and removes no capability.
+
+This committed note describes the release contract; it does not record a P13 or
+P14 result and is not release authority. Tag validation and public GitHub
+Release publication are separate operator-controlled actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [9.0.0] — 2026-08-06
+## [9.0.1] — 2026-08-07
 
-The last published release is
-[v8.1.0](https://github.com/m0n0x41d/haft/releases/tag/v8.1.0).
-The v8.2.0 candidate was never published; its candidate lineage is incorporated
-into this v9.0.0 release entry.
+A patch release for one defect: a single stored row that the v9 path invariant
+cannot express denied every caller the fused artifact-to-file bridge.
+
+### Fixed
+
+- **One pre-invariant `affected_files` row no longer fails the whole fused
+  graph.** v9 introduced the canonical project-relative path invariant and
+  enforced it on both the write and read paths, but shipped no migration for
+  rows admitted before it existed. A database carrying one absolute or
+  traversing path — for example an agent attachment recorded as an affected
+  file — returned `fuse concern reasoning: stored affected file for <id>: …
+  must be a canonical project-relative path` for **every** concern-seeded
+  `explore` call. Symbol-seeded calls were unaffected, which is why the defect
+  read as intermittent. `AllAffectedFiles` and `GetAffectedFiles` now exclude
+  such a row instead of failing: the projection carries the expressible rows
+  plus a named `Skipped` entry per excluded row, and the concern fusion basis
+  reports the count as `unexpressible_affected_files`. Fresh installations were
+  never affected; both write paths have canonicalized since v9.0.0.
+
+### Changed
+
+- **Kernel migration 58 drops `affected_files` rows that are not
+  project-relative.** The invariant is owned by `internal/projectpath`, so the
+  migration asks that package rather than restating the rule in SQL, and it
+  names every dropped row and artifact rather than deleting silently. Migration
+  58 applies during `haft init`; `haft serve` and the read-only surfaces
+  continue to require an already-current schema. **An existing project must run
+  `haft init` once after upgrading**, otherwise commands report `kernel schema
+  is not current`. A database that never carried such a row pays nothing and
+  reports nothing.
+
+## [9.0.0] — 2026-08-07
+
+[v9.0.0](https://github.com/m0n0x41d/haft/releases/tag/v9.0.0) is the
+published current release. Its published predecessor is
+[v8.1.0](https://github.com/m0n0x41d/haft/releases/tag/v8.1.0). The v8.2.0
+candidate was never published; its candidate lineage is incorporated into this
+v9.0.0 release entry.
 
 ### Changed
 

--- a/MIGRATION-v8.md
+++ b/MIGRATION-v8.md
@@ -5,12 +5,12 @@
 The published predecessor to v9 is
 [v8.1.0](https://github.com/m0n0x41d/haft/releases/tag/v8.1.0).
 There is no published v8.2 release. Work that was previously described as an
-8.2 candidate remains unreleased v9 lineage.
+8.2 candidate was incorporated into the published v9.0.0 lineage.
 
 This document states the supported migration and rollback boundary. It is not
-evidence that a particular project has been upgraded successfully. Release
-publication remains separate from the real v8.1-to-v9 rehearsal on the exact
-candidate binary.
+evidence that a particular project has been upgraded successfully. The
+published release and a real v8.1-to-v9 rehearsal on the exact installed binary
+remain separate results.
 
 ## Upgrading v8.1.0 → v9.0.0
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ without replacing FPF with a second pattern catalog.
 <!-- haft:truth-labels:start -->
 
 - **CURRENT PRODUCT** — the published
-  [v8.1.0 release](https://github.com/m0n0x41d/haft/releases/tag/v8.1.0).
-  No v8.2 release was published.
+  [v9.0.0 release](https://github.com/m0n0x41d/haft/releases/tag/v9.0.0).
+  Its published predecessor is v8.1.0; no v8.2 release was published.
 - **V9 CONTRACT** — source-native FPF Query, fused code-graph orientation,
   project-profile onboarding, task-level EntityOfConcern establishment, typed
   project memory, neighborhood, and recall are included in the v9 contract.
@@ -39,8 +39,9 @@ without replacing FPF with a second pattern catalog.
 <!-- haft:truth-labels:end -->
 
 These distinctions separate contract inclusion, exact-candidate evidence,
-published-product status, and release authority. No source file, local test, or
-matrix result silently promotes a contract to CURRENT PRODUCT, an RC, or a
+published-product status, and release authority. v9.0.0 is CURRENT PRODUCT
+because that exact release was published; no source file, local test, or matrix
+result silently promotes another candidate to CURRENT PRODUCT, an RC, or a
 release.
 
 ---
@@ -287,7 +288,9 @@ Haft is consumed through three surfaces over one `.haft/` artifact graph:
 - **Skills** in your agent. Capability skills may trigger from the current
   operator request; `h-decide` may route a direct unambiguous binding request,
   while `h-commission` still requires manual invocation.
-- **CLI** (`haft problem`, `haft solution`, `haft decision`, ...) — manual access. Those might be used manually, but usually it is just another surface for your agent to use.
+- **CLI** (`haft artifact`, `haft decision`, `haft spec`, `haft memory`,
+  `haft commission`, ...) — direct manual access to the current command
+  families.
 - **MCP server** (`haft serve`) — programmatic access for any LLM agent over the Model Context Protocol
 
 The kernel MCP server is the cross-host enforcement surface: it validates
@@ -433,7 +436,7 @@ restart, and rollback boundaries.
 
 | Tool | What it does |
 |------|-------------|
-| `haft_note` | Micro-decisions — atomic facts with typed anchors, validation, auto-expiry |
+| `haft_note` | Non-binding facts, observations, caveats, and rationale with typed anchors, validation, and optional freshness |
 | `haft_problem` | Frame problems, declare comparison dimensions with indicator roles |
 | `haft_solution` | Explore variants with diversity check, compare under parity |
 | `haft_decision` | Decision contracts: invariants, claims, evidence, baseline lifecycle |

--- a/data/haft/fpf-integration.lock.json
+++ b/data/haft/fpf-integration.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "haft.fpf-integration-lock/v1",
-  "generated_by": "fpf-refresh-inputs/v1:sha256:9c5dd69ba6268fe9f6ca73b6275f3efcd71ddb2237f0a7141c74cd57d19cf20d",
+  "generated_by": "fpf-refresh-inputs/v1:sha256:f6387dc82b7626eb292e4e5846497bc78264b4984a0e3d7a098b085f158294c9",
   "coordinates": {
     "source_revision": "3dbce51436bfd718bf49cb0356eebce70c4fc015",
     "readme_document_digest": "sha256:6c8d87a641f36d34a9d84aa0ab8e7565dcca2a691482a0cee31bd28a743eb3fd",

--- a/db/legacy_affected_path_migration.go
+++ b/db/legacy_affected_path_migration.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/m0n0x41d/haft/internal/projectpath"
+)
+
+const legacyAffectedPathSchemaVersion58 = 58
+
+var legacyAffectedPathMigration58 = Migration{
+	Version: legacyAffectedPathSchemaVersion58,
+	Description: "Drop pre-invariant affected_files rows that are not " +
+		"project-relative",
+	Apply: applyLegacyAffectedPathMigration58,
+}
+
+// unexpressibleAffectedRow58 is one stored artifact<->file row the
+// project-relative path invariant cannot express.
+type unexpressibleAffectedRow58 struct {
+	artifactID string
+	path       string
+}
+
+// applyLegacyAffectedPathMigration58 removes artifact<->file rows that the
+// project-relative path invariant cannot express.
+//
+// Rows were admitted before canonicalAffectedFile existed, so a database that
+// predates that invariant can hold absolute or traversing paths. Readers that
+// enforce the invariant then exclude those rows on every pass; deleting them
+// once makes the stored table agree with what every reader can express.
+//
+// The invariant itself belongs to projectpath. This migration asks that
+// package rather than restating the rule in SQL, so the policy stays in one
+// place and cannot drift away from the read path.
+func applyLegacyAffectedPathMigration58(
+	tx MigrationTransaction,
+	_ []Migration,
+) error {
+	unexpressible, err := readUnexpressibleAffectedRows58(tx)
+	if err != nil {
+		return err
+	}
+	if len(unexpressible) == 0 {
+		return nil
+	}
+	for _, row := range unexpressible {
+		if _, err := tx.Exec(
+			`DELETE FROM affected_files
+			 WHERE artifact_id = ? AND file_path = ?`,
+			row.artifactID,
+			row.path,
+		); err != nil {
+			return fmt.Errorf(
+				"drop non-project-relative affected file for %s: %w",
+				row.artifactID,
+				err,
+			)
+		}
+	}
+	if err := verifyNoUnexpressibleAffectedRows58(tx); err != nil {
+		return err
+	}
+	reportDroppedAffectedRows58(unexpressible)
+	return nil
+}
+
+func readUnexpressibleAffectedRows58(
+	tx MigrationTransaction,
+) ([]unexpressibleAffectedRow58, error) {
+	rows, err := tx.Query(
+		`SELECT artifact_id, file_path FROM affected_files
+		 ORDER BY artifact_id, file_path`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read stored affected files: %w", err)
+	}
+	defer rows.Close()
+	unexpressible := make([]unexpressibleAffectedRow58, 0)
+	for rows.Next() {
+		var row unexpressibleAffectedRow58
+		if err := rows.Scan(&row.artifactID, &row.path); err != nil {
+			return nil, fmt.Errorf("scan stored affected file: %w", err)
+		}
+		if _, err := projectpath.Parse(row.path); err == nil {
+			continue
+		}
+		unexpressible = append(unexpressible, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("enumerate stored affected files: %w", err)
+	}
+	return unexpressible, nil
+}
+
+func verifyNoUnexpressibleAffectedRows58(tx MigrationTransaction) error {
+	remaining, err := readUnexpressibleAffectedRows58(tx)
+	if err != nil {
+		return err
+	}
+	if len(remaining) > 0 {
+		return fmt.Errorf(
+			"%d non-project-relative affected file(s) survived the migration",
+			len(remaining),
+		)
+	}
+	return nil
+}
+
+// reportDroppedAffectedRows58 names what the migration deleted. Deleting stored
+// rows without saying so would leave the operator no way to tell a repaired
+// database from one that never carried the rows.
+func reportDroppedAffectedRows58(dropped []unexpressibleAffectedRow58) {
+	artifactIDs := make([]string, 0, len(dropped))
+	seen := make(map[string]bool, len(dropped))
+	for _, row := range dropped {
+		if seen[row.artifactID] {
+			continue
+		}
+		seen[row.artifactID] = true
+		artifactIDs = append(artifactIDs, row.artifactID)
+	}
+	sort.Strings(artifactIDs)
+	log.Printf(
+		"haft migration %d: dropped %d non-project-relative affected_files "+
+			"row(s) across %d artifact(s): %s",
+		legacyAffectedPathSchemaVersion58,
+		len(dropped),
+		len(artifactIDs),
+		strings.Join(artifactIDs, ", "),
+	)
+}

--- a/db/legacy_affected_path_migration_test.go
+++ b/db/legacy_affected_path_migration_test.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"testing"
+)
+
+// A database predating the project-relative path invariant can hold absolute
+// or traversing affected_files rows. Migration 58 drops exactly those and
+// leaves every expressible row untouched.
+func TestLegacyAffectedPathMigration58DropsOnlyUnexpressibleRows(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(t.TempDir() + "/v58.db")
+	if err != nil {
+		t.Fatalf("open v58 store: %v", err)
+	}
+	defer store.Close()
+
+	const artifactID = "note-20260629-preinvariant"
+	if _, err := store.conn.Exec(
+		`INSERT INTO artifacts (id, kind, title, content, created_at, updated_at)
+		 VALUES (?, 'Note', 'Pre-invariant note', 'fixture',
+		         '2026-06-29T17:30:01Z', '2026-06-29T17:30:01Z')`,
+		artifactID,
+	); err != nil {
+		t.Fatalf("seed artifact: %v", err)
+	}
+
+	expressible := "internal/cli/interface.go"
+	unexpressible := []string{
+		"/Users/someone/.agent/attachments/pasted-text.txt",
+		"../outside-the-project.go",
+	}
+	for _, path := range append([]string{expressible}, unexpressible...) {
+		if _, err := store.conn.Exec(
+			`INSERT INTO affected_files (artifact_id, file_path, file_hash)
+			 VALUES (?, ?, '')`,
+			artifactID,
+			path,
+		); err != nil {
+			t.Fatalf("seed affected file %q: %v", path, err)
+		}
+	}
+
+	tx, err := store.conn.Begin()
+	if err != nil {
+		t.Fatalf("begin migration transaction: %v", err)
+	}
+	if err := applyLegacyAffectedPathMigration58(tx, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("apply migration 58: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit migration 58: %v", err)
+	}
+
+	rows, err := store.conn.Query(
+		`SELECT file_path FROM affected_files WHERE artifact_id = ?
+		 ORDER BY file_path`,
+		artifactID,
+	)
+	if err != nil {
+		t.Fatalf("read surviving affected files: %v", err)
+	}
+	defer rows.Close()
+	surviving := make([]string, 0)
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			t.Fatalf("scan surviving affected file: %v", err)
+		}
+		surviving = append(surviving, path)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("enumerate surviving affected files: %v", err)
+	}
+	if len(surviving) != 1 || surviving[0] != expressible {
+		t.Fatalf("surviving affected files = %v", surviving)
+	}
+}
+
+// The migration is a no-op on a database that never carried a pre-invariant
+// row, so a fresh install pays nothing and reports nothing.
+func TestLegacyAffectedPathMigration58IsANoOpWithoutLegacyRows(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(t.TempDir() + "/v58-clean.db")
+	if err != nil {
+		t.Fatalf("open v58 store: %v", err)
+	}
+	defer store.Close()
+
+	tx, err := store.conn.Begin()
+	if err != nil {
+		t.Fatalf("begin migration transaction: %v", err)
+	}
+	if err := applyLegacyAffectedPathMigration58(tx, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("apply migration 58 on a clean database: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit migration 58: %v", err)
+	}
+}

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -2003,4 +2003,5 @@ var kernelMigrations = []Migration{
 	profileAutomaticBootstrapMigration55,
 	hostRoutedOperatorAuthorityMigration56,
 	projectTypeEnvCompatibleSuccessorMigration57,
+	legacyAffectedPathMigration58,
 }

--- a/internal/artifact/path_boundary_test.go
+++ b/internal/artifact/path_boundary_test.go
@@ -132,13 +132,16 @@ func TestAffectedFileReadersCanonicalizeLegacyRowsWithoutMigration(
 	if len(files) != 1 || files[0].Path != "pkg/a_%/main.go" {
 		t.Fatalf("canonical affected files = %+v", files)
 	}
-	refs, err := store.AllAffectedFiles(ctx)
+	projection, err := store.AllAffectedFiles(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(refs) != 1 ||
-		refs[0].FilePath != "pkg/a_%/main.go" {
-		t.Fatalf("canonical affected-file refs = %+v", refs)
+	if len(projection.Rows) != 1 ||
+		projection.Rows[0].FilePath != "pkg/a_%/main.go" {
+		t.Fatalf("canonical affected-file refs = %+v", projection.Rows)
+	}
+	if !projection.Complete() {
+		t.Fatalf("canonical rows reported as skipped: %+v", projection.Skipped)
 	}
 	linked, err := store.SearchByAffectedFile(
 		ctx,
@@ -405,4 +408,75 @@ func decisionPathContractInput() DecideInput {
 			Reason:     reason,
 		},
 	})
+}
+
+// A row stored before canonicalAffectedFile existed must not deny every reader
+// the rest of the table. The projection excludes it and names it; it never
+// fails the read.
+func TestAffectedFileReadsDegradeOnPreInvariantStoredRow(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	item := &Artifact{
+		Meta: Meta{
+			ID:        "note-pre-invariant-path",
+			Kind:      KindNote,
+			Status:    StatusActive,
+			Title:     "Pre-invariant affected path",
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		Body: "fixture",
+	}
+	if err := store.Create(ctx, item); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetAffectedFiles(
+		ctx,
+		item.Meta.ID,
+		[]AffectedFile{{Path: "internal/cli/main.go"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// SetAffectedFiles rejects this path today, so the fixture reaches the
+	// table directly — exactly how the row was admitted before the invariant.
+	const legacyPath = "/Users/someone/.agent/attachments/pasted-text.txt"
+	if _, err := store.db.ExecContext(
+		ctx,
+		`INSERT INTO affected_files (artifact_id, file_path, file_hash)
+		 VALUES (?, ?, '')`,
+		item.Meta.ID,
+		legacyPath,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	projection, err := store.AllAffectedFiles(ctx)
+	if err != nil {
+		t.Fatalf("one pre-invariant row failed the whole projection: %v", err)
+	}
+	if len(projection.Rows) != 1 ||
+		projection.Rows[0].FilePath != "internal/cli/main.go" {
+		t.Fatalf("expressible rows = %+v", projection.Rows)
+	}
+	if projection.Complete() {
+		t.Fatal("excluded row was not named in the projection")
+	}
+	if len(projection.Skipped) != 1 ||
+		projection.Skipped[0].RawPath != legacyPath ||
+		projection.Skipped[0].ArtifactID != item.Meta.ID {
+		t.Fatalf("skipped rows = %+v", projection.Skipped)
+	}
+	if projection.Skipped[0].Reason == "" {
+		t.Fatal("skipped row carries no reason")
+	}
+
+	files, err := store.GetAffectedFiles(ctx, item.Meta.ID)
+	if err != nil {
+		t.Fatalf("per-artifact read failed on a pre-invariant row: %v", err)
+	}
+	if len(files) != 1 || files[0].Path != "internal/cli/main.go" {
+		t.Fatalf("per-artifact affected files = %+v", files)
+	}
 }

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -783,31 +783,66 @@ type SymbolBindingRef struct {
 	AnchorID   string
 }
 
+// SkippedAffectedFile is one stored affected_files row the current path
+// invariant cannot express. Rows admitted before canonicalAffectedFile existed
+// may hold absolute or traversing paths, so a strict read names them instead of
+// failing every caller of the projection.
+type SkippedAffectedFile struct {
+	ArtifactID string
+	RawPath    string
+	Reason     string
+}
+
+// AffectedFileProjection is one complete read of affected_files under the
+// current path invariant. Skipped carries the rows the invariant excluded, so
+// an empty Skipped is the only evidence that the projection covers the table.
+type AffectedFileProjection struct {
+	Rows    []AffectedFileRef
+	Skipped []SkippedAffectedFile
+}
+
+// Complete reports whether the current path invariant expressed every stored
+// row. A false result is a named coverage limit, not a failure.
+func (p AffectedFileProjection) Complete() bool {
+	return len(p.Skipped) == 0
+}
+
 // AllAffectedFiles enumerates every (artifact, file) pair in one pass, stably
 // ordered — the artifact<->file half of the fused-graph bridge.
-func (s *Store) AllAffectedFiles(ctx context.Context) ([]AffectedFileRef, error) {
+//
+// A row the current path invariant cannot express is excluded and named in
+// Skipped rather than failing the projection: one pre-invariant row must not
+// deny every caller the rest of the bridge.
+func (s *Store) AllAffectedFiles(ctx context.Context) (AffectedFileProjection, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT artifact_id, file_path FROM affected_files ORDER BY artifact_id, file_path`)
 	if err != nil {
-		return nil, err
+		return AffectedFileProjection{}, err
 	}
 	defer rows.Close()
-	out := make([]AffectedFileRef, 0)
+	projection := AffectedFileProjection{
+		Rows:    make([]AffectedFileRef, 0),
+		Skipped: make([]SkippedAffectedFile, 0),
+	}
 	seen := make(map[string]bool)
 	for rows.Next() {
 		var r AffectedFileRef
 		if err := rows.Scan(&r.ArtifactID, &r.FilePath); err != nil {
-			return nil, err
+			return AffectedFileProjection{}, err
 		}
 		canonical, err := canonicalAffectedFile(
 			AffectedFile{Path: r.FilePath},
 		)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"stored affected file for %s: %w",
-				r.ArtifactID,
-				err,
+			projection.Skipped = append(
+				projection.Skipped,
+				SkippedAffectedFile{
+					ArtifactID: r.ArtifactID,
+					RawPath:    r.FilePath,
+					Reason:     err.Error(),
+				},
 			)
+			continue
 		}
 		r.FilePath = canonical.Path
 		key := r.ArtifactID + "\x00" + r.FilePath
@@ -815,9 +850,12 @@ func (s *Store) AllAffectedFiles(ctx context.Context) ([]AffectedFileRef, error)
 			continue
 		}
 		seen[key] = true
-		out = append(out, r)
+		projection.Rows = append(projection.Rows, r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return AffectedFileProjection{}, err
+	}
+	return projection, nil
 }
 
 // AllActiveSymbolBindingRefs enumerates current authority-bearing
@@ -887,7 +925,10 @@ func (s *Store) SetAffectedFiles(ctx context.Context, artifactID string, files [
 	return tx.Commit()
 }
 
-// GetAffectedFiles returns the affected files for an artifact.
+// GetAffectedFiles returns the affected files for an artifact that the current
+// path invariant can express. A row admitted before that invariant existed is
+// excluded rather than failing the read; AllAffectedFiles is the projection
+// that also names what was excluded.
 func (s *Store) GetAffectedFiles(ctx context.Context, artifactID string) ([]AffectedFile, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT file_path, file_hash FROM affected_files WHERE artifact_id = ?`, artifactID)
 	if err != nil {
@@ -904,11 +945,7 @@ func (s *Store) GetAffectedFiles(ctx context.Context, artifactID string) ([]Affe
 		}
 		canonical, err := canonicalAffectedFile(f)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"stored affected file for %s: %w",
-				artifactID,
-				err,
-			)
+			continue
 		}
 		hash, exists := seen[canonical.Path]
 		if exists && hash != canonical.Hash {

--- a/internal/codeintel/concern_fusion.go
+++ b/internal/codeintel/concern_fusion.go
@@ -536,26 +536,30 @@ func (b ConcernCandidateBatch) Budget() codebase.DiscoveryBudget {
 }
 
 type ConcernFusionBasis struct {
-	Schema                 string           `json:"schema"`
-	CodeEpoch              int64            `json:"code_epoch"`
-	GraphDigest            string           `json:"graph_digest"`
-	QueryDigest            string           `json:"query_digest"`
-	ReplayRef              string           `json:"replay_ref"`
-	FullGraphNodes         int              `json:"full_graph_nodes"`
-	GraphNodes             int              `json:"induced_graph_nodes"`
-	GraphInductionMaxHops  int              `json:"graph_induction_max_hops"`
-	GraphInductionMaxNodes int              `json:"graph_induction_max_nodes"`
-	GraphNodeCapReached    bool             `json:"graph_node_cap_reached"`
-	CodeEdges              int              `json:"code_edges"`
-	ReasoningLinks         int              `json:"reasoning_links"`
-	AffectedFileBridges    int              `json:"affected_file_bridges"`
-	ExactSymbolBridges     int              `json:"exact_symbol_bridges"`
-	ModuleContextBridges   int              `json:"module_context_bridges"`
-	StaleSymbolBindings    int              `json:"stale_symbol_bindings"`
-	ArtifactSeedLimit      int              `json:"artifact_seed_limit"`
-	AppliedCandidateBudget int              `json:"applied_candidate_budget"`
-	PPR                    graphrank.Params `json:"ppr"`
-	Seeds                  []ConcernSeed    `json:"seeds"`
+	Schema                 string `json:"schema"`
+	CodeEpoch              int64  `json:"code_epoch"`
+	GraphDigest            string `json:"graph_digest"`
+	QueryDigest            string `json:"query_digest"`
+	ReplayRef              string `json:"replay_ref"`
+	FullGraphNodes         int    `json:"full_graph_nodes"`
+	GraphNodes             int    `json:"induced_graph_nodes"`
+	GraphInductionMaxHops  int    `json:"graph_induction_max_hops"`
+	GraphInductionMaxNodes int    `json:"graph_induction_max_nodes"`
+	GraphNodeCapReached    bool   `json:"graph_node_cap_reached"`
+	CodeEdges              int    `json:"code_edges"`
+	ReasoningLinks         int    `json:"reasoning_links"`
+	AffectedFileBridges    int    `json:"affected_file_bridges"`
+	// UnexpressibleAffectedFiles counts stored artifact<->file rows the current
+	// path invariant cannot express. They are absent from the bridge, so a
+	// non-zero count is a named coverage limit on this fused graph.
+	UnexpressibleAffectedFiles int              `json:"unexpressible_affected_files"`
+	ExactSymbolBridges         int              `json:"exact_symbol_bridges"`
+	ModuleContextBridges       int              `json:"module_context_bridges"`
+	StaleSymbolBindings        int              `json:"stale_symbol_bindings"`
+	ArtifactSeedLimit          int              `json:"artifact_seed_limit"`
+	AppliedCandidateBudget     int              `json:"applied_candidate_budget"`
+	PPR                        graphrank.Params `json:"ppr"`
+	Seeds                      []ConcernSeed    `json:"seeds"`
 }
 
 type concernFusionInputs struct {
@@ -563,11 +567,15 @@ type concernFusionInputs struct {
 	edges     []codebase.CodeEdge
 	links     []artifact.LinkEdge
 	affected  []artifact.AffectedFileRef
-	bindings  []artifact.SymbolBindingRef
-	symbols   []codebase.CodeSymbol
-	refs      []codebase.SymbolRef
-	modules   moduleFusionInputs
-	external  []ConcernExternalSeed
+	// skippedAffected carries artifact<->file rows the current path invariant
+	// cannot express. They are excluded from the bridge, so the concern result
+	// must report the gap instead of presenting a silently narrower graph.
+	skippedAffected []artifact.SkippedAffectedFile
+	bindings        []artifact.SymbolBindingRef
+	symbols         []codebase.CodeSymbol
+	refs            []codebase.SymbolRef
+	modules         moduleFusionInputs
+	external        []ConcernExternalSeed
 }
 
 type concernGraphScores struct {
@@ -764,15 +772,16 @@ func (s *Service) loadConcernFusionInputs(
 		)
 	}
 	return concernFusionInputs{
-		artifacts: artifacts,
-		edges:     edges,
-		links:     links,
-		affected:  affected,
-		bindings:  bindings,
-		symbols:   symbols,
-		refs:      refs,
-		modules:   moduleFusion,
-		external:  external.Items(),
+		artifacts:       artifacts,
+		edges:           edges,
+		links:           links,
+		affected:        affected.Rows,
+		skippedAffected: affected.Skipped,
+		bindings:        bindings,
+		symbols:         symbols,
+		refs:            refs,
+		modules:         moduleFusion,
+		external:        external.Items(),
 	}, nil
 }
 
@@ -1597,6 +1606,9 @@ func concernFusionBasis(
 		CodeEdges:              len(inputs.edges),
 		ReasoningLinks:         len(inputs.links),
 		AffectedFileBridges:    len(inputs.affected),
+
+		UnexpressibleAffectedFiles: len(inputs.skippedAffected),
+
 		ExactSymbolBridges:     currentBindings,
 		ModuleContextBridges:   len(inputs.modules.Contexts),
 		StaleSymbolBindings:    staleBindings,

--- a/internal/codeintel/related.go
+++ b/internal/codeintel/related.go
@@ -423,7 +423,7 @@ func (s *Service) relatedViewOnce(
 	g, kind := buildFusedGraph(
 		edges,
 		links,
-		affected,
+		affected.Rows,
 		bindings,
 		syms,
 		moduleFusion,

--- a/packages/haft-pi/README.md
+++ b/packages/haft-pi/README.md
@@ -26,8 +26,8 @@ authority. Dense/hybrid retrieval and any superiority claim remain
   `haft_solution`, `haft_decision`, `haft_note`, `haft_refresh`,
   `haft_method`, `haft_commission`, and `haft_spec_section`
 - Prompt templates and Agent Skills expose the same twelve public entries:
-  `h-reason`, `h-frame`, `h-diagnose`, `h-explore`, `h-compare`, manual
-  `h-decide`, manual `h-commission`, `h-verify`, `h-status`, `h-spec`,
+  `h-reason`, `h-frame`, `h-diagnose`, `h-explore`, `h-compare`, auto-routed
+  `h-decide`, manual-only `h-commission`, `h-verify`, `h-status`, `h-spec`,
   `h-onboard`, and `h-note`. They are independent capabilities, not phases.
   MethodPack orchestration and semiotic/abductive routines remain internal to
   the relevant public entry rather than adding public skills.


### PR DESCRIPTION
## What broke

v9.0.0 introduced the canonical project-relative path invariant for `affected_files` and enforced it on both the write and the read path, but shipped **no migration** for rows admitted before it existed.

`Store.AllAffectedFiles` returned an error on the first such row, so a single absolute path — in the dogfood database, an agent attachment recorded as an affected file — failed **every** concern-seeded `explore` call:

```
fuse concern reasoning: stored affected file for note-...:
affected file: path "/Users/.../attachments/pasted-text.txt"
must be a canonical project-relative path
```

Symbol-seeded `explore` was unaffected, which is why a dead surface read as intermittent. One row of 1165 took down the whole projection.

Fresh installations were never affected: both write paths have canonicalized since v9.0.0.

## What changed

**Read path degrades instead of failing.** `AllAffectedFiles` returns `AffectedFileProjection` — expressible rows plus a named `Skipped` entry per excluded row — and `GetAffectedFiles` excludes rather than fails. The gap stays visible as data: concern fusion reports it as `unexpressible_affected_files`. Callers updated in `concern_fusion.go` and `related.go`.

**Kernel migration 58** drops the rows that cannot be expressed. The invariant belongs to `internal/projectpath`, so the migration asks that package rather than restating the rule in SQL, verifies none survives, and names every dropped row instead of deleting silently.

The two repairs are independent on purpose: the read fix restores `explore` even where the migration has not run.

**Integration lock resettled.** `cmd/indexer` closes over `internal/artifact`, so the read-path change moved the generator input closure and `fpf-refresh verify` failed with `snapshot_pin_stale`. Re-applied the same source revision `3dbce51` with `--no-fetch`; only `generated_by` moved.

## Upgrade note

Migration 58 applies during `haft init`, while `haft serve` and the read-only surfaces require an already-current schema. An existing project reports `kernel schema is not current` until `haft init` has run once. This is stated in the release notes.

## Evidence

Runtime, on a copy of the real pre-invariant database:

- with migration 58 **deliberately unregistered**, the query that used to fail returned `candidate_set` while the offending row was still stored — the read fix stands on its own;
- `haft init` moved the schema `57 → 58` and removed exactly **1 row of 1165**; `explore` then returned `candidate_set`, 5 candidates, coverage `complete`.

Local gates: `go mod tidy` clean · `golangci-lint run` (v2.11.4, same as CI) 0 issues · `go test ./internal/artifact/... ./internal/codeintel/... ./db/...` pass · `fpf-refresh verify` OK · `fpf_query_token_gate.sh` pass.

Regression tests cover both layers, seeding the legacy row directly into the table because `SetAffectedFiles` rejects it today.

https://claude.ai/code/session_01XDUdQxi1yWjgfoWXcgm5HX