### PR TITLE
Fix CI on main: schema frontier 58 and the exact README truth boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ without replacing FPF with a second pattern catalog.
 These distinctions separate contract inclusion, exact-candidate evidence,
 published-product status, and release authority. v9.0.0 is CURRENT PRODUCT
 because that exact release was published; no source file, local test, or matrix
-result silently promotes another candidate to CURRENT PRODUCT, an RC, or a
-release.
+result silently promotes a contract to CURRENT PRODUCT, an RC, or a release.
 
 ---
 

--- a/internal/p13acceptance/README.md
+++ b/internal/p13acceptance/README.md
@@ -92,7 +92,7 @@ predecessor rather than relabeling it. The activated target Stage remains schema
 and byte-match the current canonical profile basis, compatible ProfileFit, and
 installed transition-profile closure when final freeze input is captured. The
 same preflight requires the exact selected FPF checkout plus embedded index
-metadata, schema 57 with its exact writer-54 marker (independently verified), and an
+metadata, schema 58 with its exact writer-54 marker (independently verified), and an
 explicitly empty excluded-Go-package set. Any
 changed coordinate, missing anchor, skipped anchor, non-empty waiver set, or
 failed command blocks the run.

--- a/internal/p13acceptance/manifest.json
+++ b/internal/p13acceptance/manifest.json
@@ -11,7 +11,7 @@
   "single_command": "HAFT_P13_RUN_CONSOLIDATED=1 go test -count=1 -timeout=12h -v ./internal/p13acceptance -run '^TestP13ConsolidatedAcceptance$'",
   "waivers": [],
   "identity": {
-    "required_schema_version": 57,
+    "required_schema_version": 58,
     "required_writer_generation": 54,
     "required_fpf": {
       "revision": "3dbce51436bfd718bf49cb0356eebce70c4fc015",

--- a/internal/p13acceptance/manifest_test.go
+++ b/internal/p13acceptance/manifest_test.go
@@ -1215,9 +1215,9 @@ func requireOneP13Anchor(
 }
 
 func validateIdentitySpec(spec identitySpec) error {
-	if spec.RequiredSchemaVersion != 57 {
+	if spec.RequiredSchemaVersion != 58 {
 		return fmt.Errorf(
-			"P13 schema version = %d, want exactly 57",
+			"P13 schema version = %d, want exactly 58",
 			spec.RequiredSchemaVersion,
 		)
 	}

--- a/internal/typedmemorystore/frozen_legacy_v1_fixture_test.go
+++ b/internal/typedmemorystore/frozen_legacy_v1_fixture_test.go
@@ -159,9 +159,9 @@ func assertFrozenLegacyV1StorageBoundary(
 	); err != nil {
 		t.Fatalf("inspect frozen legacy-v1 schema frontier: %v", err)
 	}
-	if maximumVersion != 57 {
+	if maximumVersion != 58 {
 		t.Fatalf(
-			"frozen legacy-v1 schema frontier = %d; want 57",
+			"frozen legacy-v1 schema frontier = %d; want 58",
 			maximumVersion,
 		)
 	}


### PR DESCRIPTION
Repairs the two failures that turned CI red on `c0edcb82` after #103 merged. Both come from that PR; neither is a flake.

## 1. `frozen legacy-v1 schema frontier = 58; want 57`

Migration 58 raised the kernel schema frontier, but three carriers pin it by hand:

- `internal/typedmemorystore/frozen_legacy_v1_fixture_test.go` — restores a historical dump, opens it through `db.NewStore`, then asserts the post-migration frontier;
- `internal/p13acceptance/manifest.json` + its validator in `manifest_test.go`;
- `internal/p13acceptance/README.md`, which the manifest currentness check reads.

Only the first reached CI (`Test & Build`, `Race shard 4`). The P13 job runs solely under `workflow_dispatch` with `run_p13`, so the manifest would have failed on the next P13 run instead of now. All four move to 58 together.

## 2. `README truth boundary missing "silently promotes a contract to CURRENT PRODUCT"`

The v9.0.0 label refresh in `88184016` rewrote that sentence to "another candidate", and `internal/streamtruth` requires the phrase verbatim. The guarded claim is specific — contract inclusion alone never becomes published-product status, which is the whole V9 CONTRACT / CURRENT PRODUCT distinction. Restored the exact wording while keeping the added statement that v9.0.0 is CURRENT PRODUCT because that exact release was published.

## Evidence

`go test ./...` — 134 packages ok. The two previously failing packages now pass: `internal/streamtruth` and `internal/typedmemorystore`, plus `internal/p13acceptance` which was not yet firing. `internal/cli` needs the CI `-timeout=90m`; under the default 10m it times out locally, and it was green in the failing CI run, so it is unaffected by these changes.

`fpf-refresh verify` OK — test-only edits do not move the generator input closure, so the integration lock stays settled.

Once this is green, `v9.0.1` can be tagged: the release guard needs a successful `event=push` CI run on the exact `origin/main` SHA plus its `race-aggregate` artifact.

https://claude.ai/code/session_01XDUdQxi1yWjgfoWXcgm5HX