### PR TITLE
Haft v9.0.2: fix conventional monorepo profile onboarding

### DIFF
--- a/.github/release-notes/9.0.2.md
+++ b/.github/release-notes/9.0.2.md
@@ -1,0 +1,65 @@
+# Haft 9.0.2
+
+A patch release for the project-profile onboarding defect in conventional
+monorepos. Its published predecessor is
+[v9.0.1](https://github.com/m0n0x41d/haft/releases/tag/v9.0.1).
+
+## The defect
+
+The file-metadata detector recognized `apps/web/package.json` as a software
+manifest but accepted production source only when the first path segment was
+`app`, `cmd`, `internal`, `lib`, `pkg`, or `src`. A normal path such as
+`apps/web/src/main.tsx` therefore supplied no production-source signal.
+
+In a repository with product and design Markdown, that left an inconsistent
+onboarding state:
+
+- `haft profile inspect` reported mixed, conflicting evidence with no complete
+  `suggested_scopes`;
+- `haft_onboard(action="profile_prepare")` could still materialize the partial
+  document suggestion as an exact review;
+- an explicit software scope was rejected because the detector had retained a
+  partial candidate.
+
+Applying that review would make software specifications inapplicable to the
+real product, while the normal recovery path was unavailable.
+
+## What changed
+
+`apps/<component>/src/**` now carries a production-source signal. A conventional
+manifest and source tree therefore produces one supported `software` scope.
+Ordinary Markdown beside that implementation remains product material rather
+than a separate realization; an explicit document-system manifest can still
+establish its own scope.
+
+Profile preparation now uses an explicit scope-identity posture:
+
+- stable identity may produce an automatic review;
+- a complete mixed or otherwise underdetermined observation produces
+  `needs_scope_review` with no partial projected scopes and may accept explicit
+  reviewed scopes;
+- a truncated observation cannot use manual fallback;
+- stable detection cannot be replaced through fallback.
+
+An unchanged Haft-generated review from an older detector can be atomically
+refreshed. Manual, enriched, and foreign reviews keep the existing no-clobber
+protection.
+
+## Upgrade from v9.0.1
+
+Install 9.0.2 and reconnect or restart the host so every MCP process loads the
+new binary. In an affected project, inspect the profile again:
+
+```bash
+haft profile inspect --json --full-evidence
+```
+
+Then prepare the non-binding review again through
+`haft_onboard(action="profile_prepare")`.
+
+`profile_prepare` does not apply the profile, change specification lifecycle,
+or grant authority. This release adds no database migration.
+
+This committed note describes the release contract; it does not record P13 or
+P14 evidence and is not release authority. Tag validation and public GitHub
+Release publication remain separate actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [9.0.2] — 2026-08-08
+
+A patch release for one profile-onboarding defect: a conventional monorepo
+could expose a real software manifest and source tree while Haft prepared only
+a partial document review and rejected the explicit recovery scope.
+
+### Fixed
+
+- **Conventional monorepo source now establishes a software scope.** Files
+  under `apps/<component>/src/**` carry the same production-source signal as
+  the existing top-level source roots. A manifest such as
+  `apps/web/package.json` plus that source produces one supported `software`
+  scope; ordinary product and design Markdown remains material about that
+  realization instead of becoming a separate document scope. Existing helper,
+  test-root, generated-root, dependency, and build-output exclusions remain in
+  force.
+- **Automatic onboarding no longer turns partial detector output into an exact
+  review.** Detector results now state whether scope identity is stable, needs
+  review, or comes from an incomplete observation. `profile_prepare` writes an
+  automatic carrier only for stable scope identity. A complete mixed or
+  otherwise underdetermined observation returns `needs_scope_review` without
+  projected partial scopes and accepts explicit reviewed scopes; a truncated
+  observation cannot use that fallback, and stable detection cannot be
+  overridden through it.
+- **Stale generated reviews can recover without weakening no-clobber.** When a
+  detector upgrade changes the exact suggestion, `profile_prepare` atomically
+  replaces an unchanged Haft-generated review. A manual, enriched, or foreign
+  review still blocks replacement and remains untouched.
+
 ## [9.0.1] — 2026-08-07
 
 A patch release for one defect: a single stored row that the v9 path invariant

--- a/internal/cli/onboard_command_test.go
+++ b/internal/cli/onboard_command_test.go
@@ -182,15 +182,35 @@ func TestOnboardProfileMatrixRunsReviewThroughPublicApplyCommand(
 			},
 		},
 		{
-			name: "mixed software and model",
+			name:   "mixed software and model manual review",
+			manual: true,
 			files: []string{
 				"package.json",
 				"src/index.ts",
 				"models/current.onnx",
 			},
+			manualScopes: []onboardScopeWire{
+				{
+					ScopeID:         "application",
+					Label:           "Application",
+					RealizationKind: "software",
+					EvidencePaths: []string{
+						"package.json",
+						"src/index.ts",
+					},
+				},
+				{
+					ScopeID:         "current-model",
+					Label:           "Current model",
+					RealizationKind: "non_software",
+					EvidencePaths: []string{
+						"models/current.onnx",
+					},
+				},
+			},
 			wantScopeKind: []string{
-				"non_software",
 				"software",
+				"non_software",
 			},
 		},
 		{

--- a/internal/cli/onboard_server.go
+++ b/internal/cli/onboard_server.go
@@ -572,8 +572,8 @@ func (runtime *projectOnboardingRuntime) observePendingProfile(
 		onboarding.ObservationInput{
 			Initialized:        true,
 			ProfileReviewReady: reviewReady,
-			DetectionNeedsHelp: suggestion.Classification() ==
-				profiledetector.InsufficientDetectorBasis,
+			DetectionNeedsHelp: suggestion.ScopeIdentityPosture() !=
+				profiledetector.StableScopeIdentity,
 			AutoBootstrapEligible: autoBootstrapEligible,
 			Scopes:                scopes,
 			Detail:                detail,
@@ -641,13 +641,13 @@ func (runtime *projectOnboardingRuntime) PrepareProfile(
 			request,
 		)
 	}
-	if suggestion.Classification() ==
-		profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.StableScopeIdentity {
 		return onboarding.NewPreparation(
 			onboarding.PreparationNeedsScopeReview,
 			"",
 			detected,
-			"Repository detection cannot establish a reliable project scope; no review carrier was written.",
+			"Repository detection cannot establish stable project scope identity; no review carrier was written.",
 		)
 	}
 	review, err := prepareProfileReviewCandidate(
@@ -847,13 +847,13 @@ func (runtime *projectOnboardingRuntime) prepareManualProfileReview(
 	suggestion profiledetector.Suggestion,
 	request onboarding.Request,
 ) (onboarding.Preparation, error) {
-	if suggestion.Classification() !=
-		profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.ScopeIdentityNeedsReview {
 		return onboarding.NewPreparation(
 			onboarding.PreparationBlocked,
 			"",
 			request.Scopes(),
-			"Explicit fallback scopes are available only when repository detection is insufficient; the current detected scopes were retained.",
+			"Explicit fallback scopes are available only when a complete repository observation leaves scope identity underdetermined; the current detected scopes were retained.",
 		)
 	}
 	proposalScopes := make(
@@ -1095,6 +1095,10 @@ func profileRealizationKind(
 func onboardScopesFromSuggestion(
 	suggestion profiledetector.Suggestion,
 ) ([]onboarding.Scope, error) {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.StableScopeIdentity {
+		return []onboarding.Scope{}, nil
+	}
 	values := suggestion.SuggestedScopes()
 	result := make([]onboarding.Scope, len(values))
 	for index, value := range values {

--- a/internal/cli/onboard_server_test.go
+++ b/internal/cli/onboard_server_test.go
@@ -591,14 +591,15 @@ func TestOnboardMCPManualFallbackCoversUnsupportedDocsEmptyAndMultipleScopes(
 	}
 }
 
-func TestOnboardMCPDetectedMixedProjectPreparesNormalMultiScopeReview(
+func TestOnboardMCPMixedPartialSuggestionRequiresExplicitScopeReview(
 	t *testing.T,
 ) {
 	project := newCLIProfileOnboardLedgerFixture(t)
 	for _, relative := range []string{
-		"go.mod",
-		"internal/kernel.go",
-		"models/current.onnx",
+		"apps/web/package.json",
+		"DESIGN.md",
+		"PRODUCT.md",
+		"photojan_prd_fpf.md",
 	} {
 		writeProfileInspectionFixture(
 			t,
@@ -611,10 +612,13 @@ func TestOnboardMCPDetectedMixedProjectPreparesNormalMultiScopeReview(
 		t.Fatal(err)
 	}
 	if suggestion.Classification() !=
-		profiledetector.MixedSignals {
+		profiledetector.MixedSignals ||
+		suggestion.ScopeIdentityPosture() !=
+			profiledetector.ScopeIdentityNeedsReview {
 		t.Fatalf(
-			"fixture classification = %q",
+			"fixture posture = %q/%q",
 			suggestion.Classification(),
+			suggestion.ScopeIdentityPosture(),
 		)
 	}
 	surface, err := openSealedProjectOnboardSurface(
@@ -625,42 +629,75 @@ func TestOnboardMCPDetectedMixedProjectPreparesNormalMultiScopeReview(
 		t.Fatal(err)
 	}
 	defer surface.Close()
-	output := callOnboardHandler(
+	statusOutput := callOnboardHandler(
+		t,
+		surface.Handler(),
+		`{"action":"status"}`,
+	)
+	status := decodeOnboardResponse(t, statusOutput)
+	if status.Result != "needs_profile" ||
+		status.Status != "needs_profile" ||
+		len(status.Scopes) != 0 ||
+		!strings.Contains(status.NextAction, "explicit scopes") {
+		t.Fatalf("mixed status = %#v", status)
+	}
+	autoOutput := callOnboardHandler(
 		t,
 		surface.Handler(),
 		`{"action":"profile_prepare"}`,
 	)
-	response := decodeOnboardResponse(t, output)
-	if response.Result != "profile_review_prepared" ||
-		response.Status != "profile_review_ready" ||
-		len(response.Scopes) != 2 {
+	auto := decodeOnboardResponse(t, autoOutput)
+	if auto.Result != "needs_scope_review" ||
+		auto.Status != "needs_profile" ||
+		len(auto.Scopes) != 0 {
 		t.Fatalf(
-			"mixed prepare = %#v",
-			response,
+			"automatic mixed prepare = %#v",
+			auto,
 		)
 	}
-	kinds := []string{
-		response.Scopes[0].RealizationKind,
-		response.Scopes[1].RealizationKind,
+	if _, err := os.Lstat(
+		profileDeclarationReviewPath(project.root),
+	); !os.IsNotExist(err) {
+		t.Fatalf("mixed automatic prepare wrote review: %v", err)
 	}
-	if !reflect.DeepEqual(
-		kinds,
-		[]string{"non_software", "software"},
-	) && !reflect.DeepEqual(
-		kinds,
-		[]string{"software", "non_software"},
-	) {
-		t.Fatalf(
-			"mixed scope kinds = %#v",
-			kinds,
-		)
+	scopes := []onboardScopeWire{{
+		ScopeID:         "photojan",
+		Label:           "PhotoJan",
+		RealizationKind: "software",
+		EvidencePaths:   []string{"apps/web/package.json"},
+	}}
+	request := onboardRequestWire{
+		Action: "profile_prepare",
+		Basis: stringPointer(
+			"The complete observation is mixed; apps/web is the PhotoJan product implementation.",
+		),
+		Scopes: &scopes,
+	}
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manualOutput := callOnboardHandler(
+		t,
+		surface.Handler(),
+		string(requestBytes),
+	)
+	manual := decodeOnboardResponse(t, manualOutput)
+	if manual.Result != "profile_review_prepared" ||
+		manual.Status != "profile_review_ready" ||
+		len(manual.Scopes) != 1 ||
+		manual.Scopes[0].ScopeID != "photojan" ||
+		manual.Scopes[0].Label != "PhotoJan" ||
+		manual.Scopes[0].RealizationKind != "software" {
+		t.Fatalf("manual mixed prepare = %#v", manual)
 	}
 	assertCLIProfileOnboardMutationCounts(
 		t,
 		project.root,
 		0,
 	)
-	assertOnboardOutputHasNoInternalJargon(t, output)
+	assertOnboardOutputHasNoInternalJargon(t, autoOutput)
+	assertOnboardOutputHasNoInternalJargon(t, manualOutput)
 }
 
 func TestOnboardLegacyMemoryPreparationRemainsNonBindingButStatusRequiresInitRepair(

--- a/internal/cli/profile_inspect.go
+++ b/internal/cli/profile_inspect.go
@@ -512,13 +512,15 @@ func profileSuggestionOutcome(
 	fullEvidence bool,
 ) (string, []profileSuggestedScopeView, []profileSuggestedScopeView, []string) {
 	views := profileSuggestedScopeViews(suggestion.SuggestedScopes(), fullEvidence)
-	if suggestion.Classification() == profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() ==
+		profiledetector.StableScopeIdentity {
+		return "suggested_scopes", views, []profileSuggestedScopeView{}, []string{}
+	}
+	if suggestion.Classification() ==
+		profiledetector.InsufficientDetectorBasis {
 		return "underdetermined", []profileSuggestedScopeView{}, views, []string{"classification_basis"}
 	}
-	if suggestion.Classification() == profiledetector.MixedSignals {
-		return "underdetermined", []profileSuggestedScopeView{}, views, []string{"stable_scope_identity"}
-	}
-	return "suggested_scopes", views, []profileSuggestedScopeView{}, []string{}
+	return "underdetermined", []profileSuggestedScopeView{}, views, []string{"stable_scope_identity"}
 }
 
 func profileSuggestedScopeViews(

--- a/internal/cli/profile_inspect_test.go
+++ b/internal/cli/profile_inspect_test.go
@@ -331,6 +331,87 @@ func TestPrepareProfileReviewCandidateCreatesReadableNoClobberCarrier(t *testing
 	}
 }
 
+func TestPrepareProfileReviewCandidateRefreshesOnlyUneditedGeneratedCarrier(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := mustCLIProfileOnboardPhysicalPath(t, t.TempDir())
+	if err := os.MkdirAll(filepath.Join(root, ".haft"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, relative := range []string{
+		"DESIGN.md",
+		"PRODUCT.md",
+		"photojan_prd_fpf.md",
+	} {
+		writeProfileInspectionFixture(t, root, relative)
+	}
+	documents, err := profiledetector.Inspect(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if documents.Classification() != profiledetector.NonSoftwareSignals {
+		t.Fatalf("initial classification = %q", documents.Classification())
+	}
+	if _, err := prepareProfileReviewCandidate(root, documents); err != nil {
+		t.Fatal(err)
+	}
+	path := profileDeclarationReviewPath(root)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := bytes.ReplaceAll(
+		before,
+		[]byte(profiledetector.Version),
+		[]byte("haft.project-profile-detector/file-metadata-v3"),
+	)
+	legacy = bytes.ReplaceAll(
+		legacy,
+		[]byte(profiledetector.PolicyVersion),
+		[]byte("haft.project-profile-detector-policy/supported-singleton-v3"),
+	)
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before = legacy
+	writeProfileInspectionFixture(t, root, "apps/web/package.json")
+	writeProfileInspectionFixture(t, root, "apps/web/src/main.tsx")
+	software, err := profiledetector.Inspect(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if software.Classification() != profiledetector.SoftwareSignals {
+		t.Fatalf("updated classification = %q", software.Classification())
+	}
+	refreshed, err := prepareProfileReviewCandidate(root, software)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.State != "created" {
+		t.Fatalf("refreshed review candidate = %#v", refreshed)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(before, after) {
+		t.Fatal("generated review did not change with the detector observation")
+	}
+	input, err := profileonboarding.DecodeProfileOnboardingWorkInput(
+		after,
+		software,
+	)
+	if err != nil {
+		t.Fatalf("decode refreshed review: %v", err)
+	}
+	values := input.Payload().Scopes().Values()
+	if len(values) != 1 || values[0].ScopeID().String() != "software" {
+		t.Fatalf("refreshed review scopes = %#v", values)
+	}
+}
+
 func writeProfileInspectionFixture(t *testing.T, root string, relative string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(relative))

--- a/internal/cli/profile_review_carrier.go
+++ b/internal/cli/profile_review_carrier.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/m0n0x41d/haft/internal/profiledeclarationpreparation"
 	"github.com/m0n0x41d/haft/internal/profiledetector"
 	"github.com/m0n0x41d/haft/internal/profileonboarding"
 )
@@ -70,10 +71,34 @@ func installProfileReviewCandidate(
 	projectRoot string,
 	content []byte,
 ) (string, error) {
-	return installProfileReviewCandidateAt(
-		profileDeclarationReviewPath(projectRoot),
-		profileDeclarationReviewRelativePath(),
-		".profile-declaration-review-stage-",
+	target := profileDeclarationReviewPath(projectRoot)
+	displayPath := profileDeclarationReviewRelativePath()
+	stagePrefix := ".profile-declaration-review-stage-"
+	current, present, err := readOptionalRegularProfileReview(target)
+	if err != nil {
+		return "", err
+	}
+	if !present || bytes.Equal(current, content) {
+		return installProfileReviewCandidateAt(
+			target,
+			displayPath,
+			stagePrefix,
+			content,
+		)
+	}
+	_, generated := profiledeclarationpreparation.
+		InspectGeneratedProfileReview(current)
+	if !generated {
+		return "", fmt.Errorf(
+			"%s already contains a different review candidate; declare or deliberately remove that readable file before preparing another one",
+			displayPath,
+		)
+	}
+	return replaceGeneratedProfileReviewCandidateAt(
+		target,
+		displayPath,
+		stagePrefix,
+		current,
 		content,
 	)
 }
@@ -196,6 +221,69 @@ func installProfileReviewCandidateAt(
 	if !installedPresent || !bytes.Equal(installed, content) {
 		return "", fmt.Errorf(
 			"project-profile review candidate installation could not be verified",
+		)
+	}
+	return "created", nil
+}
+
+func replaceGeneratedProfileReviewCandidateAt(
+	target string,
+	displayPath string,
+	stagePrefix string,
+	expected []byte,
+	content []byte,
+) (string, error) {
+	directory := filepath.Dir(target)
+	stage, err := os.CreateTemp(directory, stagePrefix)
+	if err != nil {
+		return "", fmt.Errorf("create project-profile review replacement stage: %w", err)
+	}
+	stagePath := stage.Name()
+	stageOpen := true
+	defer func() {
+		if stageOpen {
+			_ = stage.Close()
+		}
+		_ = os.Remove(stagePath)
+	}()
+	if err := writeAndSyncProfileReviewStage(stage, content); err != nil {
+		return "", err
+	}
+	stageOpen = false
+	current, present, err := readOptionalRegularProfileReview(target)
+	if err != nil {
+		return "", err
+	}
+	if !present || !bytes.Equal(current, expected) {
+		return "", fmt.Errorf(
+			"%s changed while its generated candidate was being refreshed; the current readable file was retained",
+			displayPath,
+		)
+	}
+	_, generated := profiledeclarationpreparation.
+		InspectGeneratedProfileReview(current)
+	if !generated {
+		return "", fmt.Errorf(
+			"%s is no longer an unchanged Haft-generated review; the current readable file was retained",
+			displayPath,
+		)
+	}
+	if err := os.Rename(stagePath, target); err != nil {
+		return "", fmt.Errorf("atomically refresh generated project-profile review candidate: %w", err)
+	}
+	if err := syncProfileReviewDirectory(directory); err != nil {
+		return "", fmt.Errorf(
+			"generated project-profile review may already be refreshed, but directory synchronization failed: %w",
+			err,
+		)
+	}
+	installed, installedPresent, err := readOptionalRegularProfileReview(target)
+	if err != nil {
+		return "", err
+	}
+	if !installedPresent || !bytes.Equal(installed, content) {
+		return "", fmt.Errorf(
+			"generated project-profile review refresh could not be verified",
 		)
 	}
 	return "created", nil

--- a/internal/profileadmission/sqlite/preparation_fixture_test.go
+++ b/internal/profileadmission/sqlite/preparation_fixture_test.go
@@ -18,23 +18,29 @@ import (
 const testProfileWorkInputSchema = "haft.profile-onboarding.work-input/v1"
 
 type testProfileWorkInputJSON struct {
-	Schema            string                      `json:"schema"`
-	ProjectRoot       string                      `json:"project_root"`
-	SuggestionRef     string                      `json:"suggestion_ref"`
-	DetectorVersion   string                      `json:"detector_version"`
-	PolicyVersion     string                      `json:"policy_version"`
-	ObservationDigest string                      `json:"observation_digest"`
-	Scopes            []testProfileScopeInputJSON `json:"scopes"`
+	Schema                     string                      `json:"schema"`
+	ProjectRoot                string                      `json:"project_root"`
+	SuggestionRef              string                      `json:"suggestion_ref"`
+	DetectorVersion            string                      `json:"detector_version"`
+	PolicyVersion              string                      `json:"policy_version"`
+	ObservationDetectorVersion string                      `json:"observation_detector_version,omitempty"`
+	ObservationPolicyVersion   string                      `json:"observation_policy_version,omitempty"`
+	ObservationDigest          string                      `json:"observation_digest"`
+	ProposalSource             string                      `json:"proposal_source,omitempty"`
+	ManualBasis                string                      `json:"manual_basis,omitempty"`
+	Scopes                     []testProfileScopeInputJSON `json:"scopes"`
 }
 
 type testProfileScopeInputJSON struct {
 	ComponentCandidateRef string   `json:"component_candidate_ref"`
 	ScopeID               string   `json:"scope_id"`
 	RealizationKind       string   `json:"realization_kind"`
+	Label                 string   `json:"label,omitempty"`
 	EntityRef             string   `json:"entity_ref,omitempty"`
 	AdmittedKindRef       string   `json:"admitted_kind_ref,omitempty"`
 	GoverningPatternRefs  []string `json:"governing_pattern_refs,omitempty"`
 	ContractRefs          []string `json:"contract_refs,omitempty"`
+	EvidencePaths         []string `json:"evidence_paths,omitempty"`
 }
 
 func prepareV3AdmissionRequest(
@@ -116,17 +122,13 @@ func newV3TestWorkInput(
 		t.Fatalf("NewSnapshot: %v", err)
 	}
 	suggestion := profiledetector.Detect(snapshot)
-	declarations := testScopeDeclarations(t, scopes, suggestion.SuggestedScopes())
-	document := testProfileWorkInputJSON{
-		Schema:            testProfileWorkInputSchema,
-		ProjectRoot:       root.String(),
-		SuggestionRef:     suggestion.SuggestionRef(),
-		DetectorVersion:   suggestion.DetectorVersion(),
-		PolicyVersion:     profiledetector.PolicyVersion,
-		ObservationDigest: snapshot.ObservationDigest(),
-		Scopes:            declarations,
-	}
-	data, err := json.Marshal(document)
+	data, err := testProfileWorkInputBytes(
+		t,
+		root,
+		scopes,
+		files,
+		suggestion,
+	)
 	if err != nil {
 		t.Fatalf("marshal profile Work input: %v", err)
 	}
@@ -138,6 +140,90 @@ func newV3TestWorkInput(
 		t.Fatalf("DecodeProfileOnboardingWorkInput: %v", err)
 	}
 	return input
+}
+
+func testProfileWorkInputBytes(
+	t testing.TB,
+	root projectprofile.ProjectRootV1,
+	scopes []projectprofile.RealizationScope,
+	files []string,
+	suggestion profiledetector.Suggestion,
+) ([]byte, error) {
+	t.Helper()
+	if suggestion.ScopeIdentityPosture() ==
+		profiledetector.StableScopeIdentity {
+		declarations := testScopeDeclarations(
+			t,
+			scopes,
+			suggestion.SuggestedScopes(),
+		)
+		document := testProfileWorkInputJSON{
+			Schema:            testProfileWorkInputSchema,
+			ProjectRoot:       root.String(),
+			SuggestionRef:     suggestion.SuggestionRef(),
+			DetectorVersion:   suggestion.DetectorVersion(),
+			PolicyVersion:     profiledetector.PolicyVersion,
+			ObservationDigest: suggestion.Snapshot().ObservationDigest(),
+			Scopes:            declarations,
+		}
+		return json.Marshal(document)
+	}
+	manualScopes := make(
+		[]profiledeclarationpreparation.ManualProfileScopeInput,
+		len(scopes),
+	)
+	for index, scope := range scopes {
+		scopeID := scope.ScopeID().String()
+		manualScopes[index] =
+			profiledeclarationpreparation.ManualProfileScopeInput{
+				ScopeID:         scopeID,
+				Label:           scopeID,
+				RealizationKind: testRealizationKind(t, scope),
+				EvidencePaths:   append([]string{}, files...),
+			}
+	}
+	data, err := profiledeclarationpreparation.
+		ProposeManualProfileOnboardingWorkInput(
+			suggestion,
+			profiledeclarationpreparation.ManualProfileProposalInput{
+				Basis:  "Mixed profile fixture with explicitly reviewed scopes.",
+				Scopes: manualScopes,
+			},
+		)
+	if err != nil {
+		return nil, err
+	}
+	document := testProfileWorkInputJSON{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, err
+	}
+	for index, declaration := range document.Scopes {
+		scope := testScopeByID(t, scopes, declaration.ScopeID)
+		enriched := testScopeDeclaration(
+			t,
+			declaration.ComponentCandidateRef,
+			scope,
+		)
+		enriched.Label = declaration.Label
+		enriched.EvidencePaths = declaration.EvidencePaths
+		document.Scopes[index] = enriched
+	}
+	return json.Marshal(document)
+}
+
+func testScopeByID(
+	t testing.TB,
+	scopes []projectprofile.RealizationScope,
+	scopeID string,
+) projectprofile.RealizationScope {
+	t.Helper()
+	for _, scope := range scopes {
+		if scope.ScopeID().String() == scopeID {
+			return scope
+		}
+	}
+	t.Fatalf("fixture scope %q is absent", scopeID)
+	return scopes[0]
 }
 
 func testDetectorFilesForScopes(

--- a/internal/profiledeclarationpreparation/generated_review.go
+++ b/internal/profiledeclarationpreparation/generated_review.go
@@ -11,12 +11,14 @@ var generatedReviewDetectorVersions = []string{
 	"haft.project-profile-detector/file-paths-v1",
 	"haft.project-profile-detector/file-metadata-v2",
 	"haft.project-profile-detector/file-metadata-v3",
+	"haft.project-profile-detector/file-metadata-v4",
 }
 
 var generatedReviewPolicyVersions = []string{
 	"haft.project-profile-detector-policy/file-paths-v1",
 	"haft.project-profile-detector-policy/supported-singleton-v2",
 	"haft.project-profile-detector-policy/supported-singleton-v3",
+	"haft.project-profile-detector-policy/supported-singleton-v4",
 }
 
 // GeneratedProfileReview identifies an exact, unedited review carrier emitted

--- a/internal/profiledeclarationpreparation/generated_review_test.go
+++ b/internal/profiledeclarationpreparation/generated_review_test.go
@@ -39,3 +39,28 @@ func TestInspectGeneratedProfileReviewDistinguishesUneditedAndEnriched(t *testin
 		t.Fatal("semantically enriched review was recognized as generated and unedited")
 	}
 }
+
+func TestInspectGeneratedProfileReviewRecognizesLegacyPartialSuggestion(t *testing.T) {
+	t.Parallel()
+
+	content := []byte(`{
+  "schema": "haft.profile-onboarding.work-input/v1",
+  "project_root": "/tmp/project",
+  "suggestion_ref": "profile-suggestion:sha256:7708e5ba64e30def62ebd6fa62b3a1681331b003bcdd4cc8ef8e674f41f1ce76",
+  "detector_version": "haft.project-profile-detector/file-metadata-v3",
+  "policy_version": "haft.project-profile-detector-policy/supported-singleton-v3",
+  "observation_digest": "sha256:3e02d0df4a830f8c15046813b04f476bc247fdfae78946ec882a179a0b09993d",
+  "scopes": [
+    {
+      "component_candidate_ref": "profile-component-suggestion:sha256:2b528f6915d3e93e2b726e0742c384325e8dd131b9ca2e39c096a916b174aff5",
+      "scope_id": "documents",
+      "realization_kind": "non_software"
+    }
+  ]
+}
+`)
+
+	if _, recognized := InspectGeneratedProfileReview(content); !recognized {
+		t.Fatal("legacy generated partial review was not recognized")
+	}
+}

--- a/internal/profiledeclarationpreparation/sqlite/prepare_test.go
+++ b/internal/profiledeclarationpreparation/sqlite/prepare_test.go
@@ -97,7 +97,7 @@ func TestPrepareBeforeAdmissionRecoversAfterPostAuthorityRevalidationFailure(t *
 	input := newPreparationInput(
 		t,
 		root,
-		[]string{"go.mod", "internal/kernel.go", "models/current.onnx"},
+		[]string{"go.mod", "internal/kernel.go"},
 	)
 	policy := newPreparationPolicy(t, input, "recovery")
 	checkedAt := time.Date(2026, 7, 19, 10, 0, 0, 0, time.UTC)

--- a/internal/profiledeclarationpreparation/work_input.go
+++ b/internal/profiledeclarationpreparation/work_input.go
@@ -182,8 +182,8 @@ type profileScopeDeclarationJSON struct {
 }
 
 // ManualProfileScopeInput is an operator-reviewable fallback scope used only
-// when the path detector cannot classify a complete repository snapshot. The
-// paths are observation references, not evidence-truth claims.
+// when a complete detector observation cannot establish stable scope identity.
+// The paths are observation references, not evidence-truth claims.
 type ManualProfileScopeInput struct {
 	ScopeID         string
 	Label           string
@@ -237,10 +237,10 @@ func ProposeProfileOnboardingWorkInput(
 	suggestion profiledetector.Suggestion,
 ) ([]byte, error) {
 	snapshot := suggestion.Snapshot()
-	if snapshot.Truncated() ||
-		suggestion.Classification() == profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.StableScopeIdentity {
 		return nil, fmt.Errorf(
-			"profile detector basis is insufficient; no declaration proposal can be prepared",
+			"profile detector basis is insufficient for stable scopes; no declaration proposal can be prepared",
 		)
 	}
 	suggested := suggestion.SuggestedScopes()
@@ -279,9 +279,10 @@ func ProposeProfileOnboardingWorkInput(
 }
 
 // ProposeManualProfileOnboardingWorkInput produces a non-binding review
-// carrier for a complete detector snapshot whose language or repository shape
-// is unsupported, too small, documentation-only, or empty. It never guesses a
-// scope: the caller supplies the readable basis and exact realization kinds.
+// carrier for a complete detector snapshot whose language, repository shape,
+// or conflicting signals leave scope identity underdetermined. It never
+// guesses a scope: the caller supplies the readable basis and exact
+// realization kinds.
 func ProposeManualProfileOnboardingWorkInput(
 	suggestion profiledetector.Suggestion,
 	proposal ManualProfileProposalInput,
@@ -292,10 +293,10 @@ func ProposeManualProfileOnboardingWorkInput(
 			"manual profile fallback requires a complete repository observation",
 		)
 	}
-	if suggestion.Classification() !=
-		profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.ScopeIdentityNeedsReview {
 		return nil, fmt.Errorf(
-			"manual profile fallback is available only when detector classification is insufficient",
+			"manual profile fallback is available only when detector scope identity needs review",
 		)
 	}
 	basis, err := validateManualProfileBasis(proposal.Basis)
@@ -881,10 +882,10 @@ func validateProfileSuggestionBinding(
 		)
 	}
 	if dto.ProposalSource == profileProposalSourceManual {
-		if suggestion.Classification() !=
-			profiledetector.InsufficientDetectorBasis {
+		if suggestion.ScopeIdentityPosture() !=
+			profiledetector.ScopeIdentityNeedsReview {
 			return fmt.Errorf(
-				"manual profile fallback requires an insufficient detector classification",
+				"manual profile fallback requires detector scope identity that needs review",
 			)
 		}
 		return nil
@@ -892,10 +893,10 @@ func validateProfileSuggestionBinding(
 	if dto.ProposalSource == profileProposalSourceRelation {
 		return nil
 	}
-	if suggestion.Classification() ==
-		profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.StableScopeIdentity {
 		return fmt.Errorf(
-			"profile detector basis is insufficient; declaration requires an explicit reviewed manual scope",
+			"profile detector basis is insufficient for stable scopes; declaration requires an explicit reviewed manual scope",
 		)
 	}
 	return nil
@@ -1313,10 +1314,10 @@ func validateManualProfileScopeCoverage(
 	dto profileOnboardingWorkInputJSON,
 	suggestion profiledetector.Suggestion,
 ) error {
-	if suggestion.Classification() !=
-		profiledetector.InsufficientDetectorBasis {
+	if suggestion.ScopeIdentityPosture() !=
+		profiledetector.ScopeIdentityNeedsReview {
 		return fmt.Errorf(
-			"manual profile fallback cannot replace a supported detector classification",
+			"manual profile fallback cannot replace a stable detector scope identity",
 		)
 	}
 	snapshot := suggestion.Snapshot()

--- a/internal/profiledeclarationpreparation/work_input_test.go
+++ b/internal/profiledeclarationpreparation/work_input_test.go
@@ -3,6 +3,7 @@ package profiledeclarationpreparation
 import (
 	"encoding/json"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -144,7 +145,9 @@ func TestProfileEntityRelationChangeReviewPinsPredecessorAndOneDelta(
 	}
 }
 
-func TestProfileOnboardingWorkInputMapsEveryMixedCandidateExactlyOnce(t *testing.T) {
+func TestProfileOnboardingWorkInputRejectsDetectedMixedCandidatesAsStableScopes(
+	t *testing.T,
+) {
 	root := canonicalWorkInputTestRoot(t)
 	suggestion := workInputTestSuggestion(t, root, []string{
 		"go.mod",
@@ -170,24 +173,12 @@ func TestProfileOnboardingWorkInputMapsEveryMixedCandidateExactlyOnce(t *testing
 		declarations = append(declarations, declaration)
 	}
 	dto := profileWorkInputTestDTO(root, suggestion, declarations)
-	input, err := DecodeProfileOnboardingWorkInput(
+	_, err := DecodeProfileOnboardingWorkInput(
 		marshalProfileWorkInputTest(t, dto),
 		suggestion,
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if input.Payload().Scopes().Len() != 2 {
-		t.Fatalf("payload scopes = %d", input.Payload().Scopes().Len())
-	}
-
-	dto.Scopes = dto.Scopes[:1]
-	_, err = DecodeProfileOnboardingWorkInput(
-		marshalProfileWorkInputTest(t, dto),
-		suggestion,
-	)
-	if err == nil || !strings.Contains(err.Error(), "maps 1 scope") {
-		t.Fatalf("partial mixed declaration error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "explicit reviewed manual scope") {
+		t.Fatalf("mixed detector declaration error = %v", err)
 	}
 }
 
@@ -243,7 +234,6 @@ func TestProposeProfileOnboardingWorkInputProducesReadableRoundTrip(t *testing.T
 	suggestion := workInputTestSuggestion(t, root, []string{
 		"go.mod",
 		"internal/kernel.go",
-		"models/current.onnx",
 	})
 	data, err := ProposeProfileOnboardingWorkInput(suggestion)
 	if err != nil {
@@ -256,16 +246,61 @@ func TestProposeProfileOnboardingWorkInputProducesReadableRoundTrip(t *testing.T
 	if err != nil {
 		t.Fatalf("decode proposed Work input: %v", err)
 	}
-	if input.Payload().Scopes().Len() != 2 {
+	if input.Payload().Scopes().Len() != 1 {
 		t.Fatalf("proposed scope count = %d", input.Payload().Scopes().Len())
 	}
 	got := []string{}
 	for _, scope := range input.Payload().Scopes().Values() {
 		got = append(got, scope.ScopeID().String())
 	}
-	if !strings.Contains(strings.Join(got, ","), "software") ||
-		!strings.Contains(strings.Join(got, ","), "models") {
+	if !reflect.DeepEqual(got, []string{"software"}) {
 		t.Fatalf("proposed scope IDs = %#v", got)
+	}
+}
+
+func TestMixedProfileSuggestionRequiresReviewedManualScopes(t *testing.T) {
+	root := canonicalWorkInputTestRoot(t)
+	suggestion := workInputTestSuggestion(t, root, []string{
+		"apps/web/package.json",
+		"DESIGN.md",
+		"PRODUCT.md",
+		"photojan_prd_fpf.md",
+	})
+	if suggestion.Classification() != profiledetector.MixedSignals ||
+		suggestion.ScopeIdentityPosture() !=
+			profiledetector.ScopeIdentityNeedsReview {
+		t.Fatalf(
+			"mixed fixture posture = %q/%q",
+			suggestion.Classification(),
+			suggestion.ScopeIdentityPosture(),
+		)
+	}
+	_, err := ProposeProfileOnboardingWorkInput(suggestion)
+	if err == nil || !strings.Contains(err.Error(), "stable scopes") {
+		t.Fatalf("automatic mixed proposal error = %v", err)
+	}
+	proposal, err := ProposeManualProfileOnboardingWorkInput(
+		suggestion,
+		ManualProfileProposalInput{
+			Basis: "The complete observation is mixed; the product implementation is the PhotoJan web application.",
+			Scopes: []ManualProfileScopeInput{{
+				ScopeID:         "photojan",
+				Label:           "PhotoJan",
+				RealizationKind: profiledetector.SoftwareRealization,
+				EvidencePaths:   []string{"apps/web/package.json"},
+			}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("manual mixed proposal: %v", err)
+	}
+	input, err := DecodeProfileOnboardingWorkInput(proposal, suggestion)
+	if err != nil {
+		t.Fatalf("decode manual mixed proposal: %v", err)
+	}
+	values := input.Payload().Scopes().Values()
+	if len(values) != 1 || values[0].ScopeID().String() != "photojan" {
+		t.Fatalf("manual mixed scopes = %#v", values)
 	}
 }
 
@@ -459,7 +494,7 @@ func TestManualProfileFallbackRejectsUnobservedEvidenceAndSupportedOverride(
 	)
 	if err == nil || !strings.Contains(
 		err.Error(),
-		"only when detector classification is insufficient",
+		"only when detector scope identity needs review",
 	) {
 		t.Fatalf("supported override error = %v", err)
 	}

--- a/internal/profiledetector/detector.go
+++ b/internal/profiledetector/detector.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	Version       = "haft.project-profile-detector/file-metadata-v3"
-	PolicyVersion = "haft.project-profile-detector-policy/supported-singleton-v3"
+	Version       = "haft.project-profile-detector/file-metadata-v4"
+	PolicyVersion = "haft.project-profile-detector-policy/supported-singleton-v4"
 )
 
 type Classification string
@@ -34,6 +34,14 @@ const (
 	SupportedConfidence    ConfidencePosture = "supported"
 	ConflictingConfidence  ConfidencePosture = "conflicting"
 	InsufficientConfidence ConfidencePosture = "insufficient"
+)
+
+type ScopeIdentityPosture string
+
+const (
+	StableScopeIdentity        ScopeIdentityPosture = "stable"
+	ScopeIdentityNeedsReview   ScopeIdentityPosture = "needs_review"
+	ScopeObservationIncomplete ScopeIdentityPosture = "observation_incomplete"
 )
 
 type RealizationKind string
@@ -112,7 +120,7 @@ func (scope SuggestedScope) NegativeSignals() []Signal {
 	return append([]Signal{}, scope.negativeSignals...)
 }
 
-// Snapshot is the complete input to the file-metadata detector v2. It contains no
+// Snapshot is the complete input to the file-metadata detector v4. It contains no
 // declaration, performed Work, or evidence-truth claim.
 type Snapshot struct {
 	projectRoot       string
@@ -202,6 +210,16 @@ func (suggestion Suggestion) Classification() Classification {
 }
 func (suggestion Suggestion) ConfidencePosture() ConfidencePosture {
 	return suggestion.confidence
+}
+func (suggestion Suggestion) ScopeIdentityPosture() ScopeIdentityPosture {
+	if suggestion.snapshot.truncated {
+		return ScopeObservationIncomplete
+	}
+	if suggestion.confidence != SupportedConfidence ||
+		len(suggestion.scopes) == 0 {
+		return ScopeIdentityNeedsReview
+	}
+	return StableScopeIdentity
 }
 func (suggestion Suggestion) SuggestedScopes() []SuggestedScope {
 	return append([]SuggestedScope{}, suggestion.scopes...)
@@ -617,7 +635,21 @@ func matchesProductionSource(file ObservedFile) bool {
 	if len(segments) == 1 {
 		return true
 	}
-	return slices.Contains([]string{"app", "cmd", "internal", "lib", "pkg", "src"}, segments[0])
+	directSourceRoot := slices.Contains(
+		[]string{"app", "cmd", "internal", "lib", "pkg", "src"},
+		segments[0],
+	)
+	if directSourceRoot {
+		return true
+	}
+	return matchesConventionalMonorepoSource(segments)
+}
+
+func matchesConventionalMonorepoSource(segments []string) bool {
+	if len(segments) < 4 {
+		return false
+	}
+	return segments[0] == "apps" && segments[2] == "src"
 }
 
 func matchesDocumentPrimaryManifest(file ObservedFile) bool {

--- a/internal/profiledetector/detector_test.go
+++ b/internal/profiledetector/detector_test.go
@@ -23,6 +23,19 @@ func TestDetectorClassifiesRequiredRepositoryFixturesWithoutBinding(t *testing.T
 			orientations:   []string{"software"},
 		},
 		{
+			name: "conventional_monorepo_software_with_product_documents",
+			files: []string{
+				"apps/web/package.json",
+				"apps/web/src/main.tsx",
+				"DESIGN.md",
+				"PRODUCT.md",
+				"photojan_prd_fpf.md",
+			},
+			classification: SoftwareSignals,
+			confidence:     SupportedConfidence,
+			orientations:   []string{"software"},
+		},
+		{
 			name: "software_with_embedded_document_artifacts",
 			files: []string{
 				"go.mod",
@@ -99,6 +112,37 @@ func TestDetectorClassifiesRequiredRepositoryFixturesWithoutBinding(t *testing.T
 			gotOrientations := orientations(result.SuggestedScopes())
 			if !reflect.DeepEqual(gotOrientations, test.orientations) {
 				t.Fatalf("orientations = %#v, want %#v", gotOrientations, test.orientations)
+			}
+		})
+	}
+}
+
+func TestProductionSourceMatchesConventionalMonorepoWithoutBroadeningExcludedRoots(
+	t *testing.T,
+) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "apps/web/src/main.tsx", want: true},
+		{path: "apps/admin/src/server/index.ts", want: true},
+		{path: "scripts/src/generate.ts", want: false},
+		{path: "tests/fixtures/src/main.tsx", want: false},
+		{path: "generated/client/src/client.ts", want: false},
+		{path: "apps/web/test/main.tsx", want: false},
+		{path: "apps/web/generated/client.ts", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			file := mustObservedFile(t, test.path, 1)
+			got := matchesProductionSource(file)
+			if got != test.want {
+				t.Fatalf(
+					"matchesProductionSource(%q) = %t, want %t",
+					test.path,
+					got,
+					test.want,
+				)
 			}
 		})
 	}

--- a/internal/testsupport/profileadmissionfixture/v3_input.go
+++ b/internal/testsupport/profileadmissionfixture/v3_input.go
@@ -12,23 +12,29 @@ import (
 const fixtureProfileWorkInputSchema = "haft.profile-onboarding.work-input/v1"
 
 type fixtureProfileWorkInputJSON struct {
-	Schema            string                           `json:"schema"`
-	ProjectRoot       string                           `json:"project_root"`
-	SuggestionRef     string                           `json:"suggestion_ref"`
-	DetectorVersion   string                           `json:"detector_version"`
-	PolicyVersion     string                           `json:"policy_version"`
-	ObservationDigest string                           `json:"observation_digest"`
-	Scopes            []fixtureProfileScopeDeclaration `json:"scopes"`
+	Schema                     string                           `json:"schema"`
+	ProjectRoot                string                           `json:"project_root"`
+	SuggestionRef              string                           `json:"suggestion_ref"`
+	DetectorVersion            string                           `json:"detector_version"`
+	PolicyVersion              string                           `json:"policy_version"`
+	ObservationDetectorVersion string                           `json:"observation_detector_version,omitempty"`
+	ObservationPolicyVersion   string                           `json:"observation_policy_version,omitempty"`
+	ObservationDigest          string                           `json:"observation_digest"`
+	ProposalSource             string                           `json:"proposal_source,omitempty"`
+	ManualBasis                string                           `json:"manual_basis,omitempty"`
+	Scopes                     []fixtureProfileScopeDeclaration `json:"scopes"`
 }
 
 type fixtureProfileScopeDeclaration struct {
 	ComponentCandidateRef string   `json:"component_candidate_ref"`
 	ScopeID               string   `json:"scope_id"`
 	RealizationKind       string   `json:"realization_kind"`
+	Label                 string   `json:"label,omitempty"`
 	EntityRef             string   `json:"entity_ref,omitempty"`
 	AdmittedKindRef       string   `json:"admitted_kind_ref,omitempty"`
 	GoverningPatternRefs  []string `json:"governing_pattern_refs,omitempty"`
 	ContractRefs          []string `json:"contract_refs,omitempty"`
+	EvidencePaths         []string `json:"evidence_paths,omitempty"`
 }
 
 func newFixtureProfileWorkInput(
@@ -39,18 +45,7 @@ func newFixtureProfileWorkInput(
 	t.Helper()
 	scopes := payload.Scopes().Values()
 	suggestion := fixtureProfileSuggestion(t, root, scopes)
-	declarations := fixtureProfileScopeDeclarations(t, suggestion, scopes)
-	snapshot := suggestion.Snapshot()
-	document := fixtureProfileWorkInputJSON{
-		Schema:            fixtureProfileWorkInputSchema,
-		ProjectRoot:       snapshot.ProjectRoot(),
-		SuggestionRef:     suggestion.SuggestionRef(),
-		DetectorVersion:   suggestion.DetectorVersion(),
-		PolicyVersion:     profiledetector.PolicyVersion,
-		ObservationDigest: snapshot.ObservationDigest(),
-		Scopes:            declarations,
-	}
-	encoded, err := json.Marshal(document)
+	encoded, err := fixtureProfileWorkInputBytes(t, suggestion, scopes)
 	if err != nil {
 		t.Fatalf("marshal fixture profile WorkInput: %v", err)
 	}
@@ -62,6 +57,88 @@ func newFixtureProfileWorkInput(
 		t.Fatalf("decode fixture profile WorkInput: %v", err)
 	}
 	return input
+}
+
+func fixtureProfileWorkInputBytes(
+	t testing.TB,
+	suggestion profiledetector.Suggestion,
+	scopes []projectprofile.RealizationScope,
+) ([]byte, error) {
+	t.Helper()
+	snapshot := suggestion.Snapshot()
+	if suggestion.ScopeIdentityPosture() ==
+		profiledetector.StableScopeIdentity {
+		declarations := fixtureProfileScopeDeclarations(
+			t,
+			suggestion,
+			scopes,
+		)
+		document := fixtureProfileWorkInputJSON{
+			Schema:            fixtureProfileWorkInputSchema,
+			ProjectRoot:       snapshot.ProjectRoot(),
+			SuggestionRef:     suggestion.SuggestionRef(),
+			DetectorVersion:   suggestion.DetectorVersion(),
+			PolicyVersion:     profiledetector.PolicyVersion,
+			ObservationDigest: snapshot.ObservationDigest(),
+			Scopes:            declarations,
+		}
+		return json.Marshal(document)
+	}
+	files := snapshot.RelativeFiles()
+	manualScopes := make(
+		[]profileonboarding.ManualProfileScopeInput,
+		len(scopes),
+	)
+	for index, scope := range scopes {
+		scopeID := scope.ScopeID().String()
+		manualScopes[index] = profileonboarding.ManualProfileScopeInput{
+			ScopeID:         scopeID,
+			Label:           scopeID,
+			RealizationKind: fixtureRealizationKind(t, scope),
+			EvidencePaths:   append([]string{}, files...),
+		}
+	}
+	encoded, err := profileonboarding.ProposeManualProfileOnboardingWorkInput(
+		suggestion,
+		profileonboarding.ManualProfileProposalInput{
+			Basis:  "Mixed profile fixture with explicitly reviewed scopes.",
+			Scopes: manualScopes,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	document := fixtureProfileWorkInputJSON{}
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		return nil, err
+	}
+	for index, declaration := range document.Scopes {
+		scope := fixtureScopeByID(t, scopes, declaration.ScopeID)
+		enriched := fixtureScopeDeclaration(
+			t,
+			declaration.ComponentCandidateRef,
+			scope,
+		)
+		enriched.Label = declaration.Label
+		enriched.EvidencePaths = declaration.EvidencePaths
+		document.Scopes[index] = enriched
+	}
+	return json.Marshal(document)
+}
+
+func fixtureScopeByID(
+	t testing.TB,
+	scopes []projectprofile.RealizationScope,
+	scopeID string,
+) projectprofile.RealizationScope {
+	t.Helper()
+	for _, scope := range scopes {
+		if scope.ScopeID().String() == scopeID {
+			return scope
+		}
+	}
+	t.Fatalf("fixture scope %q is absent", scopeID)
+	return scopes[0]
 }
 
 func fixtureProfileSuggestion(


### PR DESCRIPTION
## What changed

- recognize `apps/<component>/src/**` as production source without broadening the existing helper, test-root, generated-root, dependency, or build-output exclusions;
- make stable scope identity an explicit prerequisite for automatic `profile_prepare` output;
- return `needs_scope_review` without partial projected scopes for complete mixed or otherwise underdetermined observations, while keeping truncated and stable observations outside manual fallback;
- atomically refresh only unchanged Haft-generated review carriers and retain no-clobber for manual, enriched, or foreign reviews;
- add the 9.0.2 changelog entry and committed release notes.

## Root cause and impact

The detector accepted `apps/web/package.json` as a software manifest but rejected `apps/web/src/main.tsx` because only the first path segment was examined. Product Markdown could then supply a partial document candidate. `profile inspect` exposed no complete scope, but onboarding promoted that partial candidate to a review and rejected the explicit software recovery scope.

A conventional React/Vite monorepo now produces one supported `software` scope. Ordinary product and design Markdown remains material about that product instead of becoming a separate realization.

## Verification

- `task install`
- focused tests for the detector, profile preparation, profile onboarding, profile admission, and initial bootstrap packages
- exact CLI regressions for profile inspection, mixed recovery, generated-review refresh, and no-clobber
- real conventional React/Vite consumer: `software_signals`, `supported`, one software scope, no partial scope, no conflicts
- fresh MCP `status → profile_prepare → status`: review prepared, canonical profile unchanged
- `gofmt` and `git diff --check`

## Release boundary

This PR prepares v9.0.2. `profile_prepare` remains non-binding: it does not apply a profile, change specification lifecycle, or grant authority. Release tagging and publication remain separate exact-main workflow actions.