### PR TITLE
fix(p14): preserve frozen P13 execution contour

### DIFF
--- a/internal/p14acceptance/prepared_carrier_test.go
+++ b/internal/p14acceptance/prepared_carrier_test.go
@@ -490,8 +490,11 @@ func restoreP14AcceptedP13Environment(
 	if err != nil {
 		return nil, err
 	}
-	restored = replaceP14EnvironmentValue(restored, "GOFLAGS", "")
-	restored = replaceP14EnvironmentValue(restored, "GOMAXPROCS", "")
+	// P13 binds these exact values into its acceptance identity. Recreate that
+	// frozen execution contour for the nested freshness check instead of
+	// stripping it and making every canonical P13 carrier appear stale.
+	restored = replaceP14EnvironmentValue(restored, "GOFLAGS", "-p=1")
+	restored = replaceP14EnvironmentValue(restored, "GOMAXPROCS", "1")
 	return restored, nil
 }
 
@@ -607,12 +610,12 @@ func TestRestoreP14AcceptedP13EnvironmentRecoversAcceptedExecutionBasis(
 		)
 	}
 	goFlags, found := p14EnvironmentValue(restored, "GOFLAGS")
-	if !found || goFlags != "" {
-		t.Fatal("restored nested P13 environment retained outer GOFLAGS")
+	if !found || goFlags != "-p=1" {
+		t.Fatal("restored nested P13 environment omitted canonical GOFLAGS")
 	}
 	goMaxProcs, found := p14EnvironmentValue(restored, "GOMAXPROCS")
-	if !found || goMaxProcs != "" {
-		t.Fatal("restored nested P13 environment retained outer GOMAXPROCS")
+	if !found || goMaxProcs != "1" {
+		t.Fatal("restored nested P13 environment omitted canonical GOMAXPROCS")
 	}
 }
 


### PR DESCRIPTION
## What changed

The nested P13 freshness verifier used by P14 now restores the canonical `GOFLAGS=-p=1` and `GOMAXPROCS=1` execution contour instead of clearing both values.

## Root cause

P13 binds those variables into its acceptance identity. P14 cleared them before launching the nested verifier, so a valid exact-candidate P13 carrier was deterministically rejected as stale before runtime fixtures could be materialized.

## Impact

This changes only the release-acceptance harness. It lets P14 verify the same frozen single-worker contour that produced P13 evidence; product runtime behavior is unchanged.

## Validation

- reproduced the pre-fix failure through `TestP14MaterializeRuntimeFixtureCarriers`
- `go test -count=1 ./internal/p14acceptance -run '^(TestRestoreP14AcceptedP13EnvironmentRecoversAcceptedExecutionBasis|TestP14RequestOracleContract)$'`
- `go test -count=1 ./internal/p14acceptance`
- `git diff --check`