### PR TITLE
fix(p13): keep freshness contour reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,8 @@ jobs:
       - name: Verify fresh P13 evidence against the unchanged candidate
         run: |
           HOME="$P13_REMOTE_HOME" \
+          GOMAXPROCS=1 \
+          GOFLAGS=-p=1 \
           HAFT_P13_VERIFY_ACCEPTANCE_EVIDENCE="$P13_ACCEPTANCE_CARRIER" \
           HAFT_P13_VERIFY_ACCEPTANCE_DIGEST="$P13_ACCEPTANCE_DIGEST" \
             go test -count=1 -timeout=5m -v ./internal/p13acceptance \

--- a/internal/p13acceptance/README.md
+++ b/internal/p13acceptance/README.md
@@ -133,6 +133,8 @@ After automatic activation exists, those exact accepted coordinates have been
 frozen, and the manifest status is `frozen_for_execution`, run exactly:
 
 ```bash
+GOMAXPROCS=1 \
+GOFLAGS=-p=1 \
 HAFT_P13_RUN_CONSOLIDATED=1 \
   go test -count=1 -timeout=12h -v ./internal/p13acceptance \
   -run '^TestP13ConsolidatedAcceptance$'
@@ -151,6 +153,8 @@ passing v3 carrier whose exact dependency digest still matches:
 ```bash
 HAFT_P13_REUSE_ACCEPTANCE_EVIDENCE=.context/p13/<PRIOR_P13_EVIDENCE>.json \
 HAFT_P13_REUSE_ACCEPTANCE_DIGEST=sha256:<PRIOR_CARRIER_DIGEST> \
+GOMAXPROCS=1 \
+GOFLAGS=-p=1 \
 HAFT_P13_RUN_CONSOLIDATED=1 \
   go test -count=1 -timeout=12h -v ./internal/p13acceptance \
   -run '^TestP13ConsolidatedAcceptance$'
@@ -171,6 +175,8 @@ manifest, full acceptance identity, frozen selection, suites, gates, and
 anchors are still current:
 
 ```bash
+GOMAXPROCS=1 \
+GOFLAGS=-p=1 \
 HAFT_P13_VERIFY_ACCEPTANCE_EVIDENCE=.context/p13/<P13_EVIDENCE>.json \
 HAFT_P13_VERIFY_ACCEPTANCE_DIGEST=sha256:<P13_CARRIER_DIGEST> \
   go test -count=1 -v ./internal/p13acceptance \


### PR DESCRIPTION
## What changed

- the manual P13 workflow now restores `GOMAXPROCS=1` and `GOFLAGS=-p=1` for the immediate freshness check
- the local consolidated, reuse, and freshness commands document that same frozen contour

## Root cause

P13 binds both variables into the acceptance identity. The producer used the canonical values, but the workflow's consumer omitted them, so a passing carrier could be rejected as stale. The local README examples also left the required contour implicit.

## Impact

This completes the P13/P14 release-harness fix from #108. Product runtime behavior is unchanged.

## Validation

- `actionlint .github/workflows/ci.yml`
- `go test -count=1 ./internal/p14acceptance`
- `git diff --check`