### PR TITLE
fix(build): restore linux arm64 release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,43 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
+  supported-target-build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.run_p13 }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    goos: linux,  goarch: amd64 }
+          - { runner: ubuntu-24.04-arm, goos: linux,  goarch: arm64 }
+          - { runner: macos-latest,     goos: darwin, goarch: arm64 }
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache-dependency-path: go.sum
+
+      - name: Prepare desktop embed placeholder
+        run: |
+          mkdir -p desktop/frontend/dist
+          printf 'ci placeholder\n' > desktop/frontend/dist/.ci-placeholder
+
+      - name: Compile supported target
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -trimpath -o "$RUNNER_TEMP/haft-${GOOS}-${GOARCH}" ./cmd/haft/
+
   race-shard:
     name: Race shard ${{ matrix.shard_index }}
     if: ${{ github.event_name != 'workflow_dispatch' || !inputs.run_p13 }}
+    needs: [supported-target-build]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:

--- a/internal/projectledgermigration/lease_supported.go
+++ b/internal/projectledgermigration/lease_supported.go
@@ -142,13 +142,14 @@ func requireRegularAttachedMigrationLease(
 	return nil
 }
 
-// Stat_t uses uint16 for Mode and Nlink on Darwin, but uint32 and uint64 on
-// Linux. These widening helpers keep the shared lease check type-safe on both.
+// Stat_t uses uint16 or uint32 for Mode and uint16, uint32, or uint64 for
+// Nlink across the supported Darwin and Linux architectures. These widening
+// helpers keep the shared lease check type-safe on all of them.
 func migrationStatMode[T ~uint16 | ~uint32](mode T) uint32 {
 	return uint32(mode)
 }
 
-func migrationStatLinkCount[T ~uint16 | ~uint64](linkCount T) uint64 {
+func migrationStatLinkCount[T ~uint16 | ~uint32 | ~uint64](linkCount T) uint64 {
 	return uint64(linkCount)
 }
 

--- a/internal/projectledgermigration/lease_supported_test.go
+++ b/internal/projectledgermigration/lease_supported_test.go
@@ -42,6 +42,18 @@ func TestSafeMigrationLeaseMetadata(t *testing.T) {
 	}
 }
 
+func TestMigrationStatLinkCountSupportsPlatformWidths(t *testing.T) {
+	for name, linkCount := range map[string]uint64{
+		"uint16": migrationStatLinkCount(uint16(1)),
+		"uint32": migrationStatLinkCount(uint32(1)),
+		"uint64": migrationStatLinkCount(uint64(1)),
+	} {
+		if linkCount != 1 {
+			t.Fatalf("%s link count = %d, want 1", name, linkCount)
+		}
+	}
+}
+
 func TestEnsureCurrentForServeRejectsUnsafeLeaseCarrier(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Fixes the v9.0.3 release validation failure on Linux arm64 by accepting the uint32 Stat_t.Nlink width and exercising all supported widths in an architecture-independent regression test.

CI now compiles every supported release target on its native runner before starting the 12 race shards, so target-specific build failures stop the expensive qualification early.

Validation:
- projectledgermigration package tests
- projectledgermigration vet
- native Haft build
- isolated lease source compile for Linux amd64/arm64 and Darwin arm64
- FPF integration verification
- workflow YAML parse and diff check

Failed release validation: https://github.com/m0n0x41d/haft/actions/runs/31462077973/job/93687536966