### PR TITLE
test(ci): cover supported target build gate

### DIFF
--- a/internal/streamtruth/public_release_carriers_test.go
+++ b/internal/streamtruth/public_release_carriers_test.go
@@ -224,11 +224,19 @@ func TestRaceTasksKeepCriticalLocalAndFullCIContoursDistinct(t *testing.T) {
 func TestManualP13DoesNotAlsoStartTheFullCIMatrix(t *testing.T) {
 	workflow := readTruthRepoFile(t, ".github/workflows/ci.yml")
 	const exclusion = "github.event_name != 'workflow_dispatch' || !inputs.run_p13"
-	if count := strings.Count(workflow, exclusion); count != 4 {
+	if count := strings.Count(workflow, exclusion); count != 5 {
 		t.Fatalf(
-			"full CI jobs excluding manual P13 = %d, want 4 exact guards",
+			"full CI jobs excluding manual P13 = %d, want 5 exact guards",
 			count,
 		)
+	}
+	for _, required := range []string{
+		"supported-target-build:",
+		"needs: [supported-target-build]",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("race matrix omits supported-target build gate %q", required)
+		}
 	}
 }
 


### PR DESCRIPTION
Updates the CI truth-carrier test for the fifth ordinary job introduced by PR #110 and asserts that the race matrix depends on the supported-target build gate.

This repairs the exact-main Test & Build failure in run 31462580930. Local streamtruth tests, FPF integration verification, workflow YAML parsing, and diff checks pass.